### PR TITLE
(feat): Add closeOnOutsideClick input to dropdowns

### DIFF
--- a/demo/app/app.template.html
+++ b/demo/app/app.template.html
@@ -347,7 +347,7 @@
           <td>
             <input type="text" class="form-input" placeholder="Inputbox Placeholder"/>
           </td>
-          <td>   
+          <td>
             <select placeholder="Select Box Placeholder">
               <option>Breach</option>
               <option>DDOS</option>
@@ -2406,7 +2406,7 @@
 </div>
         ]]>
       </ngx-codemirror>
-      
+
       <h3 class="style-header">Loader - Determinate</h3>
       <div class="ngx-progress"><svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="160" width="160" viewBox="0 0 160 160"><circle cx="80" cy="80" r="60" stroke-width="8"/></svg></div>
       <ngx-codemirror mode="javascript" readOnly="true">
@@ -3766,6 +3766,47 @@
           </ngx-codemirror>
 
         </ngx-section>
+
+        <ngx-section class="shadow" [sectionTitle]="'Prevent close by click or document click'">
+          <ngx-dropdown #unclosableDropdown
+            [closeOnClick]="false"
+            [closeOnOutsideClick]="false">
+            <ngx-dropdown-toggle>
+              <a href="#">
+                Open dropdown
+              </a>
+            </ngx-dropdown-toggle>
+            <ngx-dropdown-menu>
+              Only the close button can close the dropdown
+              <button class="btn btn-primary" (click)="unclosableDropdown.open = false">Close</button>
+            </ngx-dropdown-menu>
+          </ngx-dropdown>
+
+          <br />
+          <br />
+          <br />
+          <ngx-codemirror mode="htmlmixed" readOnly="true">
+            <![CDATA[
+            <ngx-dropdown>
+              <ngx-dropdown-toggle>
+                <a href="#">
+                  Link Content
+                </a>
+              </ngx-dropdown-toggle>
+              <ngx-dropdown-menu>
+                <h1>Hello!</h1>
+                <div>
+                  <ul>
+                    <li><a href="#">Foo</a></li>
+                  </ul>
+                </div>
+              </ngx-dropdown-menu>
+            </ngx-dropdown>
+            ]]>
+          </ngx-codemirror>
+
+        </ngx-section>
+
       </section>
     </div>
 

--- a/demo/app/app.template.html
+++ b/demo/app/app.template.html
@@ -3787,19 +3787,17 @@
           <br />
           <ngx-codemirror mode="htmlmixed" readOnly="true">
             <![CDATA[
-            <ngx-dropdown>
+            <ngx-dropdown #unclosableDropdown
+              [closeOnClick]="false"
+              [closeOnOutsideClick]="false">
               <ngx-dropdown-toggle>
                 <a href="#">
-                  Link Content
+                  Open dropdown
                 </a>
               </ngx-dropdown-toggle>
               <ngx-dropdown-menu>
-                <h1>Hello!</h1>
-                <div>
-                  <ul>
-                    <li><a href="#">Foo</a></li>
-                  </ul>
-                </div>
+                Only the close button can close the dropdown
+                <button class="btn btn-primary" (click)="unclosableDropdown.open = false">Close</button>
               </ngx-dropdown-menu>
             </ngx-dropdown>
             ]]>

--- a/src/components/dropdown/dropdown.component.ts
+++ b/src/components/dropdown/dropdown.component.ts
@@ -15,7 +15,7 @@ import { DropdownToggleDirective } from './dropdown-toggle.directive';
  *      <ul><li><a>...</a></li></ul>
  *    </ngx-dropdown-menu>
  *  </ngx-dropdown>
- * 
+ *
  */
 @Component({
   selector: 'ngx-dropdown',
@@ -33,6 +33,7 @@ export class DropdownComponent implements AfterContentInit, OnDestroy {
   open: boolean = false;
 
   @Input() closeOnClick: boolean = true;
+  @Input() closeOnOutsideClick: boolean = true;
   @Input() trigger: string = 'click';
 
   @ContentChild(DropdownToggleDirective)
@@ -60,7 +61,7 @@ export class DropdownComponent implements AfterContentInit, OnDestroy {
   }
 
   onDocumentClick({ target }): void {
-    if(this.open) {
+    if(this.open && this.closeOnOutsideClick) {
       const isToggling = this.dropdownToggle.element.contains(target);
       const isMenuClick = !this.closeOnClick && this.dropdownMenu.element.contains(target);
 


### PR DESCRIPTION
Adds a `closeOnOutsideClick` input to the dropdown component, which when set to false prevents the dropdown from being closed by clicking outside of it.

This was needed because when adding a date input or a select input inside a dropdown, selecting a value in them would close the dropdown too.