### PR TITLE
Minor Styling Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ---
 
+# 21.0.1 (2018-05-17)
+
+* Bug: Fix close button not visible in dialogs
+* Bug: Fix bolded ngx-icons inside of buttons
+
 # 21.0.0 (2018-05-06)
 
 * Breaking: Upgrade to Angular 6

--- a/src/components/dialog/dialog.component.scss
+++ b/src/components/dialog/dialog.component.scss
@@ -31,8 +31,8 @@ $dialog-body-color: $color-grey-300;
       position: absolute;
       font-size: 20px;
       color: $dialog-header-color;
-      right: -25px;
-      top: -25px;
+      right: 5px;
+      top: 10px;
     }
 
     .ngx-dialog-header {

--- a/src/styles/components/buttons.scss
+++ b/src/styles/components/buttons.scss
@@ -48,7 +48,7 @@ button {
   transition: background-color 200ms, box-shadow 200ms;
 
   .ngx-icon, .icon {
-    font-weight: inherit;
+    font-weight: normal;
     vertical-align: middle;
     line-height: 1em;
     font-size: 0.9em;


### PR DESCRIPTION
Fixes the dialog close button being invisible and sets the font weight of ngx-icons inside of buttons to "normal."