### PR TITLE
Dialog Close Button Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (Unreleased)
 
+* Bug: Move dialog close button back to proper position
+
 ---
 
 # 21.1.1 (2018-05-21)

--- a/src/components/dialog/dialog.component.scss
+++ b/src/components/dialog/dialog.component.scss
@@ -31,8 +31,8 @@ $dialog-body-color: $color-grey-300;
       position: absolute;
       font-size: 20px;
       color: $dialog-header-color;
-      right: 5px;
-      top: 10px;
+      right: -25px;
+      top: -25px;
     }
 
     .ngx-dialog-header {


### PR DESCRIPTION
Puts the dialog close button back where it belongs.
![screen shot 2018-05-22 at 1 09 19 pm](https://user-images.githubusercontent.com/6510436/40381507-75b151b0-5dc1-11e8-8d5b-919d984ac039.png)
