### PR TITLE
Update dialog zindex synchronously when destroying a dialog

### DIFF
--- a/src/components/dialog/dialog.service.ts
+++ b/src/components/dialog/dialog.service.ts
@@ -34,13 +34,12 @@ export class DialogService<T = DialogComponent> extends InjectionRegisteryServic
   destroy(component): void {
     const hasOverlay = component.instance.showOverlay;
 
+    this.zIndex = this.zIndex - 2;
     setTimeout(() => {
       if (hasOverlay) {
         this.overlayService.removeTriggerComponent(component);
       }
-
       super.destroy(component);
-      this.zIndex = this.zIndex - 2;
     });
   }
 


### PR DESCRIPTION
Fixes issue with newer dialogs appearing underneath older dialogs due to their zindexes being set improperly.