### PR TITLE
Mark *.css in pkg.sideEffects

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (Unreleased)
 
-- Fix: Add `[*.css]` in pkg.sideEffects to fix tree-shaking issues in bundlers like Webpack
+- Fix: Add `[*.css]` in pkg.sideEffects to fix tree shaking issues in bundlers like Webpack
 
 ---
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## HEAD (Unreleased)
 
-_(none)_
+- Fix: Add `[*.css]` in pkg.sideEffects to fix tree-shaking issues in bundlers like Webpack
 
 ---
+
 ## 22.0.2 (2018-11-27)
 
 - Fix: Update packages to address security vulnerability in flatmap-stream and event-stream

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/swimlane/ngx-ui/issues"
   },
   "homepage": "https://github.com/swimlane/ngx-ui#readme",
+  "sideEffects": [
+    "*.css"
+  ],
   "peerDependencies": {
     "@angular/common": "^7.0.0",
     "@angular/core": "^7.0.0",


### PR DESCRIPTION
# Summary
Sets `sideEffects` to `[*.css]` in package.json.

# Explanation
This field is used by module bundlers like Webpack to determine which files in a library are tree shakable. By default, the Angular CLI sets this field to `false` when building a library, which indicates to Webpack that all files in the library are tree shakable when Webpack's `optimization.sideEffects` flag is set to `true` or when the `SideEffectsFlagPlugin` is used, which is the default configuration when Webpack's `mode` is set to `'production'`. See [here](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) for more info about how Webpack uses the `sideEffects` field.

In cases where a consumer loads `ngx-ui/index.css`, it's not safe for Webpack or other module bundlers to attempt to tree shake the file, and this should be reflected in the `sideEffects` field.