### PR TITLE
ngx-button Background Fix

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (Unreleased)
 
+- Fix: Remove background color from `button` elements inside `.ngx-button`
+
 ---
 
 ## 22.1.0 (2018-12-07)

--- a/projects/swimlane/ngx-ui/src/lib/styles/components/buttons.scss
+++ b/projects/swimlane/ngx-ui/src/lib/styles/components/buttons.scss
@@ -26,8 +26,7 @@ button {
   }
 }
 
-.btn,
-.btn button {
+.btn {
   box-sizing: border-box;
   color: $button-text-color;
   display: inline-block;


### PR DESCRIPTION
Fixes weird inner-background on `button` elements inside an `.ngx-button`: 
![screen shot 2018-12-10 at 4 59 09 pm](https://user-images.githubusercontent.com/6510436/49767146-03e1e100-fc9d-11e8-989a-33b21cd685e6.png)
