### PR TITLE
Fix/more date time

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -1,9 +1,18 @@
 # CHANGELOG
 
 ## HEAD (Unreleased)
-- Fix: amTimeZone pipe now displays blank if inpout is undefined
+- Feature: Support parsing formats for ngx-date-time and ngx-calendar
+- Fix: ngx-date-time now displays hint line only once
+- Fix: min/max dates for ngx-date-time are now inclusive as intended
+- Fix: date selection in ngx-date-time dialog are now validated
+- Fix: ngx-date-time now updates if format changes from input
+- Fix: fixes issues where ngx-date-time does clear in some cases
+- Fix: time in ngx-calendar is preserved when changing months
 
 --------------------
+
+## 24.0.1 (2019-01-14)
+- Fix: amTimeZone pipe now displays blank if input is undefined
 
 ## 24.0.0 (2019-01-14)
 - Breaking: now requires moment-timezone

--- a/projects/swimlane/ngx-ui/package-lock.json
+++ b/projects/swimlane/ngx-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "24.0.0",
+  "version": "24.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "24.0.0",
+  "version": "24.0.1",
   "engines": {
     "node": ">=8.0.0"
   },

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar-utils.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar-utils.ts
@@ -35,6 +35,7 @@ export function range(start: number, finish: number): number[] {
  * @return days
  */
 export function getMonth(active: moment.Moment): Month {
+  active = active.clone();
   const days = getDaysForMonth(active);
   const offset = active.startOf('month').isoWeekday();
   return getWeeksForDays(days, offset);
@@ -113,7 +114,7 @@ export function getWeeksForDays(days: CalenderDay[], startDay: number): Month {
  */
 export function getDaysForMonth(active: moment.Moment): CalenderDay[] {
   return range(1, active.daysInMonth() + 1).map(i => {
-    const date = active.date(i).clone();
+    const date = active.clone().date(i);
     const today = date.isSame(new Date(), 'day');
 
     return {

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.module.ts
@@ -4,10 +4,11 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { MomentModule } from 'ngx-moment';
 import { CalendarComponent } from './calendar.component';
+import { PipesModule } from '../../pipes';
 
 @NgModule({
   declarations: [CalendarComponent],
   exports: [CalendarComponent],
-  imports: [CommonModule, FormsModule, MomentModule, FlexLayoutModule]
+  imports: [CommonModule, FormsModule, MomentModule, FlexLayoutModule, PipesModule]
 })
 export class CalendarModule {}

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -269,7 +269,6 @@ export class DateTimeComponent implements OnInit, OnDestroy, ControlValueAccesso
 
   apply(): void {
     this.value = this.dialogModel.toDate();
-    console.log('apply', this.dialogModel.toDate(), this.value);
     this.close();
   }
 
@@ -281,7 +280,6 @@ export class DateTimeComponent implements OnInit, OnDestroy, ControlValueAccesso
   }
 
   dateSelected(date: any): void {
-    console.log('dateSelected', date);
     this.dialogModel = this.createMoment(date);
     this.hour = +this.dialogModel.format('hh');
     this.minute = +this.dialogModel.format('mm');

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -9,8 +9,7 @@ import {
   ViewChild,
   TemplateRef,
   OnDestroy,
-  ElementRef,
-  ChangeDetectorRef
+  ElementRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
@@ -227,7 +226,7 @@ export class DateTimeComponent implements OnInit, OnDestroy, ControlValueAccesso
   minute: number;
   amPmVal: string;
 
-  constructor(private dialogService: DialogService, private changeDetectorRef: ChangeDetectorRef) {}
+  constructor(private dialogService: DialogService) {}
 
   ngOnInit(): void {
     if (!this.format) {

--- a/projects/swimlane/ngx-ui/src/lib/pipes/timezone.pipe.ts
+++ b/projects/swimlane/ngx-ui/src/lib/pipes/timezone.pipe.ts
@@ -7,6 +7,8 @@ const momentConstructor = moment;
 export class TimeZonePipe implements PipeTransform {
   transform(value: Date | moment.Moment | string | number, timezone: string): moment.Moment | string {
     if (!value) { return ''; }
-    return momentConstructor(value).tz(timezone);
+    return timezone ? 
+      momentConstructor(value).tz(timezone) :
+      momentConstructor(value);
   }
 }

--- a/src/app/app.template.html
+++ b/src/app/app.template.html
@@ -3267,6 +3267,7 @@
           <ngx-date-time name="time-input1"
             [inputType]="'datetime'"
             [label]="'Local Time'"
+            format="MMM DD, YYYY hh:mm A Z"
             [(ngModel)]="curDate"
             (change)="dateChanged($event)">
           </ngx-date-time>
@@ -3275,6 +3276,7 @@
             [inputType]="'datetime'"
             label="UTC"
             timezone="utc"
+            format="MMM DD, YYYY hh:mm A Z"
             [(ngModel)]="curDate"
             (change)="dateChanged($event)">
           </ngx-date-time>
@@ -3283,6 +3285,7 @@
             [inputType]="'datetime'"
             label="JST"
             timezone="Asia/Tokyo"
+            format="MMM DD, YYYY hh:mm A Z"
             [(ngModel)]="curDate"
             (change)="dateChanged($event)">
           </ngx-date-time>


### PR DESCRIPTION
- Feature: Support parsing formats for ngx-date-time and ngx-calendar
- Fix: ngx-date-time now displays hint line only once
- Fix: min/max dates for ngx-date-time are now inclusive as intended
- Fix: date selection in ngx-date-time dialog are now validated
- Fix: ngx-date-time now updates if format changes from input
- Fix: fixes issues where ngx-date-time does clear in some cases
- Fix: time in ngx-calendar is preserved when changing months