### PR TITLE
ngx-tabs now have a (selectTab) output to avoid conflict with (select)

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD (Unreleased)
 
 - Fix: Fixes date-time component throwing an error when format is undefined.
+- Fix: ngx-tabs now have a `(selectTab)` output to avoid conflict with `(select)`.
 
 ---
 

--- a/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.ts
@@ -44,6 +44,10 @@ import { TabComponent } from './tab.component';
 })
 export class TabsComponent implements AfterContentInit {
   @Input() vertical: boolean;
+
+  @Output() selectTab = new EventEmitter();
+
+  // For backwards compat... user selectTab instead.
   @Output() select = new EventEmitter();
 
   @ContentChildren(TabComponent) tabs: QueryList<TabComponent>;
@@ -71,6 +75,7 @@ export class TabsComponent implements AfterContentInit {
     activeTab.active = true;
 
     this.select.emit(activeTab);
+    this.selectTab.emit(activeTab);
   }
 
   move(offset: number) {


### PR DESCRIPTION
`(select)` event is emitted when text is selected within an element.  Added `selectTab` to avoid this.