### PR TITLE
Support allowIn in hotkeys

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
@@ -41,7 +41,24 @@ export function _add(combo, opts) {
   opts.keys = _getDisplay(combo);
   opts.visible = opts.visible !== undefined ? opts.visible : true;
 
-  Mousetrap.bind(combo, callback);
+  opts.allowIn = Array.isArray(opts.allowIn) ? (opts.allowIn || []).map(tag => {
+    return typeof tag === 'string' ? tag.toUpperCase() : ''
+  }) : [];
+
+  const mousetrap = new Mousetrap();
+
+  if (opts.allowIn.length) {
+    mousetrap.stopCallback = function (e, element, sequence) {
+      const tags = ['INPUT', 'SELECT', 'TEXTAREA'];
+      if (!tags.includes(element.tagName) || opts.allowIn.includes(element.tagName)) {
+        return false;
+      }
+
+      return true;
+    };
+  }
+
+  mousetrap.bind(combo, callback);
 
   if (hotkeys[combo] === undefined) {
     hotkeys[combo] = [];
@@ -144,7 +161,7 @@ export function _deregister(comp) {
 export function Hotkey(key, description: string, options?: any) {
   return (target: any, name: string, descriptor: TypedPropertyDescriptor<any>) => {
     const oldInit = target.ngOnInit;
-    target.ngOnInit = function() {
+    target.ngOnInit = function () {
       if (oldInit) oldInit.bind(this)();
 
       _add(key, {
@@ -159,7 +176,7 @@ export function Hotkey(key, description: string, options?: any) {
     };
 
     const oldDestroy = target.ngOnDestroy;
-    target.ngOnDestroy = function() {
+    target.ngOnDestroy = function () {
       if (oldDestroy) oldDestroy.bind(this)();
       _deregister(this);
     };
@@ -176,7 +193,7 @@ export class HotkeysService {
   unpauseOthers = _unpauseOthers;
   changeEvent: Observable<any> = hotkeyChangedSource.asObservable();
 
-  constructor(private ngZone: NgZone) {}
+  constructor(private ngZone: NgZone) { }
 
   add(combo, opts) {
     _add(combo, { zone: this.ngZone, ...opts });

--- a/src/app/components/hotkeys-page/hotkeys-page.component.html
+++ b/src/app/components/hotkeys-page/hotkeys-page.component.html
@@ -92,7 +92,8 @@
 
 <ngx-section class="shadow" sectionTitle="Pause all hotkeys">
 
-  <button type="button" class="btn" (click)="openDialogAndPauseHotkeys({ title: 'Alert!', context: { count: 19 }, content: 'Hello!' })">
+  <button type="button" class="btn"
+    (click)="openDialogAndPauseHotkeys({ title: 'Alert!', context: { count: 19 }, content: 'Hello!' })">
     Open Dialog and pause hotkeys
   </button>
 
@@ -116,6 +117,23 @@
 
       ngOnDestroy() {
         this.hotkeysService.unpauseOthers(this);
+      }
+    ]]>
+  </ngx-codemirror>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Allow hotkeys to fire on certain elements">
+  <p class="hint">By default, hotkeys are disable when focus is on input, textarea or select elements. To enable them
+    use the allowIn option. </p>
+
+  <ngx-codemirror mode="javascript" readOnly="true">
+    <![CDATA[
+      import { Hotkey, HotkeysService } from '@swimlane/ngx-ui';
+
+      ...
+      @Hotkey('ctrl+s', 'Works on inputs and textarea!', { allowIn: ['input', 'textarea'] })
+      onKey() {
+        console.log('Hotkey', this);
       }
     ]]>
   </ngx-codemirror>


### PR DESCRIPTION
By default, Mousetrap disables keyboard events when the focus is on an input, textarea or select element. We can now pass an optional `allowIn` property to the hotkey definition to override this behavior.