### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ cache:
     - ~/.cache
     - node_modules
 
+addons:
+  apt:
+    packages:
+    - libgconf-2-4
+
 before_install:
   - export NG_CLI_ANALYTICS=ci
 


### PR DESCRIPTION
# Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves