### PR TITLE
Aacebo/button on push

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -111,6 +111,7 @@
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "main": "projects/swimlane/ngx-ui/src/test.ts",
+            "codeCoverage": true,
             "tsConfig": "projects/swimlane/ngx-ui/tsconfig.spec.json",
             "karmaConfig": "projects/swimlane/ngx-ui/karma.conf.js",
             "stylePreprocessorOptions": {

--- a/projects/swimlane/ngx-ui/karma.conf.js
+++ b/projects/swimlane/ngx-ui/karma.conf.js
@@ -18,7 +18,16 @@ module.exports = function(config) {
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '../../../coverage'),
       reports: ['html', 'lcovonly'],
-      fixWebpackSourcePaths: true
+      fixWebpackSourcePaths: true,
+      skipFilesWithNoCoverage: true,
+      // thresholds: {
+      //   each: {
+      //     statements: 80,
+      //     lines: 80,
+      //     branches: 80,
+      //     functions: 80
+      //   }
+      // }
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button-state.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button-state.enum.ts
@@ -1,0 +1,6 @@
+export enum ButtonState {
+  InProgress = 'in-progress',
+  Active = 'active',
+  Success = 'success',
+  Fail = 'fail'
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.scss
@@ -1,5 +1,5 @@
-@import 'colors/variables';
-@import 'components/buttons';
+@import '../../styles/colors/variables.scss';
+@import '../../styles/components/buttons.scss';
 
 .ngx-button {
   transition: background-color 0.25s ease-out !important;

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.spec.ts
@@ -42,14 +42,6 @@ describe('ButtonComponent', () => {
       component.state = ButtonState.Fail;
       expect(spy).toHaveBeenCalledWith(true);
     });
-
-    it('should not set state when disabled', () => {
-      const spy = spyOn(component.success$, 'next');
-      component.disabled = true;
-      fixture.detectChanges();
-      component.state = ButtonState.Success;
-      expect(spy).not.toHaveBeenCalled();
-    });
   });
 
   describe('updatePromise', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.spec.ts
@@ -1,9 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+
 import { ButtonComponent } from './button.component';
+import { ButtonState } from './button-state.enum';
+
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
   let fixture: ComponentFixture<ButtonComponent>;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
@@ -12,29 +16,17 @@ describe('ButtonComponent', () => {
     fixture = TestBed.createComponent(ButtonComponent);
     component = fixture.componentInstance;
   });
+
   it('can load instance', () => {
     expect(component).toBeTruthy();
   });
+
   it('disabled defaults to: false', () => {
     expect(component.disabled).toEqual(false);
   });
+
   it('state defaults to: active', () => {
     expect(component.state).toEqual('active');
-  });
-  it('inProgress defaults to: false', () => {
-    expect(component.inProgress).toEqual(false);
-  });
-  it('active defaults to: true', () => {
-    expect(component.active).toEqual(true);
-  });
-  it('success defaults to: false', () => {
-    expect(component.success).toEqual(false);
-  });
-  it('fail defaults to: false', () => {
-    expect(component.fail).toEqual(false);
-  });
-  it('_disabled defaults to: false', () => {
-    expect(component._disabled).toEqual(false);
   });
 
   describe('ngOnInit', () => {
@@ -72,15 +64,17 @@ describe('ButtonComponent', () => {
     });
 
     it('should apply class based on state attribute', () => {
-      component.state = 'inProgress';
+      component.state = ButtonState.InProgress;
       component.ngOnChanges();
       fixture.detectChanges();
       expect(fixture.debugElement.classes['in-progress']).toBeTruthy();
-      component.state = 'success';
+
+      component.state = ButtonState.Success;
       component.ngOnChanges();
       fixture.detectChanges();
       expect(fixture.debugElement.classes['success']).toBeTruthy();
-      component.state = 'fail';
+
+      component.state = ButtonState.Fail;
       component.ngOnChanges();
       fixture.detectChanges();
       expect(fixture.debugElement.classes['fail']).toBeTruthy();

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, ViewEncapsulation, OnInit, OnChanges, HostListener, ChangeDetectionStrategy } from '@angular/core';
-import { BehaviorSubject, of } from 'rxjs';
-import { delay, tap, take } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
 
 import { coerceBoolean } from '../../utils';
 import { ButtonState } from './button-state.enum';

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
@@ -44,12 +44,10 @@ export class ButtonComponent implements OnInit, OnChanges {
   set state(v: ButtonState) {
     this._state = v;
 
-    if (!this.disabled) {
-      this.inProgress$.next(v === ButtonState.InProgress);
-      this.active$.next(v === ButtonState.Active);
-      this.success$.next(v === ButtonState.Success);
-      this.fail$.next(v === ButtonState.Fail);
-    }
+    this.inProgress$.next(v === ButtonState.InProgress);
+    this.active$.next(v === ButtonState.Active);
+    this.success$.next(v === ButtonState.Success);
+    this.fail$.next(v === ButtonState.Fail);
   }
 
   readonly inProgress$ = new BehaviorSubject(false);

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
@@ -7,6 +7,7 @@ import { ButtonState } from './button-state.enum';
 
 @Component({
   selector: 'ngx-button',
+  exportAs: 'ngxButton',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./button.component.scss'],
@@ -43,11 +44,12 @@ export class ButtonComponent implements OnInit, OnChanges {
   set state(v: ButtonState) {
     this._state = v;
 
-    if (!this.disabled)
-    this.inProgress$.next(v === ButtonState.InProgress);
-    this.active$.next(v === ButtonState.Active);
-    this.success$.next(v === ButtonState.Success);
-    this.fail$.next(v === ButtonState.Fail);
+    if (!this.disabled) {
+      this.inProgress$.next(v === ButtonState.InProgress);
+      this.active$.next(v === ButtonState.Active);
+      this.success$.next(v === ButtonState.Success);
+      this.fail$.next(v === ButtonState.Fail);
+    }
   }
 
   readonly inProgress$ = new BehaviorSubject(false);
@@ -72,7 +74,7 @@ export class ButtonComponent implements OnInit, OnChanges {
     if (this.promise) {
       this.state = ButtonState.InProgress;
       this.updateState();
-      this.promise
+      return this.promise
         .then(() => {
           this.state = ButtonState.Success;
           this.updateState();

--- a/projects/swimlane/ngx-ui/src/lib/utils/coerce-boolean/coerce-boolean.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/utils/coerce-boolean/coerce-boolean.spec.ts
@@ -1,0 +1,11 @@
+import { coerceBoolean } from './coerce-boolean';
+
+describe('coerceBoolean', () => {
+  it('should be true', () => {
+    expect(coerceBoolean('true')).toBe(true);
+  });
+
+  it('should be false', () => {
+    expect(coerceBoolean('false')).toBe(false);
+  });
+});

--- a/projects/swimlane/ngx-ui/src/lib/utils/coerce-boolean/coerce-boolean.ts
+++ b/projects/swimlane/ngx-ui/src/lib/utils/coerce-boolean/coerce-boolean.ts
@@ -1,0 +1,3 @@
+export function coerceBoolean(value: any): boolean {
+  return value != null && `${value}` !== 'false';
+}

--- a/projects/swimlane/ngx-ui/src/lib/utils/coerce-boolean/index.ts
+++ b/projects/swimlane/ngx-ui/src/lib/utils/coerce-boolean/index.ts
@@ -1,0 +1,1 @@
+export { coerceBoolean } from './coerce-boolean';

--- a/projects/swimlane/ngx-ui/src/lib/utils/index.ts
+++ b/projects/swimlane/ngx-ui/src/lib/utils/index.ts
@@ -3,3 +3,4 @@ export * from './throttle';
 export * from './id';
 export * from './position';
 export * from './keys';
+export * from './coerce-boolean';

--- a/src/app/forms/buttons-page/buttons-page.component.ts
+++ b/src/app/forms/buttons-page/buttons-page.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { FileUploader } from '@swimlane/ng2-file-upload';
 
 @Component({
   selector: 'app-buttons-page',
-  templateUrl: './buttons-page.component.html'
+  templateUrl: './buttons-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ButtonsPageComponent {
   buttonPromise: any = undefined;


### PR DESCRIPTION
Summary
- Make button component OnPush change detection, restructure component to support this.
- Add setter coerce boolean for Inputs
- Turn coverage on to generate reports so we can begin adding coverage for each class
- Rewrite unit tests to cover button 100%
- add `exportAs` so markup syntax `#var="ngxButton"` can be used 