### PR TITLE
Fix changed after check error

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.ts
@@ -55,7 +55,9 @@ export class TabsComponent implements AfterContentInit {
     if (actives.length > 1) {
       console.error(`Multiple active tabs set 'active'`);
     } else if (!actives.length && tabs.length) {
-      tabs[0].active = true;
+      setTimeout(() => {
+        tabs[0].active = true;
+      });
     }
   }
 


### PR DESCRIPTION
Addresses an issue where tabs component is throwing a `Expression has changed after it was checked` error after upgrading to Ivy.