### PR TITLE
fix bugged for look that failed to manipulate array properly

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
@@ -143,10 +143,10 @@ export function _deregister(comp) {
   for (const comb in hotkeys) {
     const hotkeyList = hotkeys[comb];
 
-    for (const hotkey of hotkeyList) {
-      if (hotkey.component === comp) {
-        hotkeys[comb].status = 'disabled';
-        hotkeys[comb].splice(hotkeys[comb].indexOf(hotkey), 1);
+    for (let i = 0; i < hotkeyList.length; i++) {
+      if (hotkeyList[i].component === comp) {
+        hotkeyList[i].status = 'disabled';
+        hotkeyList.splice(hotkeyList.indexOf(hotkeyList[i]), 1);
       }
     }
 


### PR DESCRIPTION
Summary:
- on component destroy, hotkey deregister service used by service and decorator is not removing callback bind

Fix:
- fix bad for loop so deregister works