### PR TITLE
do length check on toolbar menu items

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/toolbar/toolbar.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/toolbar/toolbar.component.html
@@ -7,8 +7,8 @@
     </h2>
   </div>
   <div class="ngx-toolbar-content-col" fxFlex>
-    <ng-content *ngIf="!menu" select="ngx-toolbar-content"></ng-content>
-    <ul class="horizontal-list ngx-toolbar-menu" *ngIf="menu">
+    <ng-content *ngIf="!menu.length" select="ngx-toolbar-content"></ng-content>
+    <ul class="horizontal-list ngx-toolbar-menu" *ngIf="menu.length">
       <li *ngFor="let item of toolbarItems">
         <button type="button" [disabled]="item.disabled" (click)="onMenuClicked(item, $event)">
           {{ item.label }}


### PR DESCRIPTION
Since there is now a default value for `menu`, do a length check on the menu array to determine whether to render the array values or `ngx-toolbar-content` if menu items are absent