### PR TITLE
Refactor PatternValidatorModule  to fix import

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/directives/directives.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/directives/directives.module.ts
@@ -5,10 +5,10 @@ import { DblClickCopyModule } from './dbl-click-copy/dbl-click-copy.module';
 import { VisibilityModule } from './visibility/visibility.module';
 import { LongPressModule } from './long-press/long-press.module';
 
-import * as validators from './validators';
+import { PatternValidatorModule } from './validators/pattern-validator/pattern-validator.module';
 
 @NgModule({
-  exports: [VisibilityModule, DblClickCopyModule, LongPressModule, validators.PatternValidatorModule],
-  imports: [CommonModule, VisibilityModule, DblClickCopyModule, LongPressModule, validators.PatternValidatorModule]
+  exports: [VisibilityModule, DblClickCopyModule, LongPressModule, PatternValidatorModule],
+  imports: [CommonModule, VisibilityModule, DblClickCopyModule, LongPressModule, PatternValidatorModule]
 })
 export class DirectivesModule {}


### PR DESCRIPTION
Getting this error while doing `ng serve`: 
``` ERROR in Unexpected value 'undefined' imported by the module 'ɵbb in /Users/duredhel/Documents/Swimlane/turbine/packages/turbine-ui/node_modules/@swimlane/ngx-ui/swimlane-ngx-ui.d.ts' ```

This fixes that issue.