### PR TITLE
Bugfix/fix cdr transclusion

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
@@ -63,7 +63,6 @@ export class DropdownComponent implements AfterContentInit, OnDestroy {
   }
 
   @ContentChild(DropdownToggleDirective) readonly dropdownToggle: DropdownToggleDirective;
-
   @ContentChild(DropdownMenuDirective) readonly dropdownMenu: DropdownMenuDirective;
 
   private _documentListener?: () => void;

--- a/projects/swimlane/ngx-ui/src/lib/components/notification/notification.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/notification/notification.service.spec.ts
@@ -145,14 +145,14 @@ describe('NotificationService', () => {
 
     it('should create container if doesnt exist', () => {
       spyOn(document, 'contains').and.returnValue(false);
-      service.injectComponent({}, {});
+      service.injectComponent({} as any, {});
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('should not create container if exists', () => {
       spyOn(document, 'contains').and.returnValue(true);
       service.container = { location: { nativeElement: {} } } as any;
-      service.injectComponent({}, {});
+      service.injectComponent({} as any, {});
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton-group.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton-group.component.ts
@@ -9,7 +9,8 @@ import {
   QueryList,
   OnDestroy,
   AfterContentInit,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  ChangeDetectorRef
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
@@ -93,7 +94,9 @@ export class RadioButtonGroupComponent implements ControlValueAccessor, OnDestro
   private _value: boolean = false;
   private _selected: RadioButtonComponent;
   private _disabled: boolean = false;
-  private _destroy = new Subject<void>();
+  private _destroy$ = new Subject<void>();
+
+  constructor(private readonly _cdr: ChangeDetectorRef) { }
 
   ngAfterContentInit() {
     this.subscribeToRadios();
@@ -105,8 +108,8 @@ export class RadioButtonGroupComponent implements ControlValueAccessor, OnDestro
   }
 
   ngOnDestroy() {
-    this._destroy.next();
-    this._destroy.complete();
+    this._destroy$.next();
+    this._destroy$.complete();
   }
 
   ngOnChanges() {
@@ -114,14 +117,16 @@ export class RadioButtonGroupComponent implements ControlValueAccessor, OnDestro
   }
 
   subscribeToRadios(): void {
-    this._destroy.next();
+    this._destroy$.next();
 
     /* istanbul ignore else */
     if (this._radios) {
       this._radios.map(radio => {
-        radio.change.pipe(takeUntil(this._destroy)).subscribe(this.onRadioSelected.bind(this));
+        radio.change.pipe(takeUntil(this._destroy$)).subscribe(this.onRadioSelected.bind(this));
       });
     }
+
+    this._cdr.markForCheck();
   }
 
   onRadioSelected(value: string) {

--- a/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton-group.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton-group.component.ts
@@ -96,7 +96,7 @@ export class RadioButtonGroupComponent implements ControlValueAccessor, OnDestro
   private _disabled: boolean = false;
   private _destroy$ = new Subject<void>();
 
-  constructor(private readonly _cdr: ChangeDetectorRef) { }
+  constructor(private readonly _cdr: ChangeDetectorRef) {}
 
   ngAfterContentInit() {
     this.subscribeToRadios();

--- a/projects/swimlane/ngx-ui/src/lib/components/select/index.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/index.ts
@@ -5,3 +5,4 @@ export * from './select-input.component';
 export * from './select-option.directive';
 export * from './select-option-template.directive';
 export * from './select-option-input-template.directive';
+export * from './select-dropdown-option.interface';

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -202,6 +202,8 @@ export class SelectComponent implements ControlValueAccessor, OnDestroy {
         this.options = arr;
       }
     }
+
+    this._cdr.markForCheck();
   }
 
   get invalid() {

--- a/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.ts
@@ -8,12 +8,16 @@ import {
   ViewEncapsulation,
   AfterContentInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  OnDestroy
 } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { TabComponent } from './tab.component';
 
 @Component({
+  exportAs: 'ngxTabs',
   selector: 'ngx-tabs',
   templateUrl: './tabs.component.html',
   host: {
@@ -23,22 +27,23 @@ import { TabComponent } from './tab.component';
   styleUrls: ['./tabs.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TabsComponent implements AfterContentInit {
+export class TabsComponent implements AfterContentInit, OnDestroy {
   @Input() vertical: boolean;
 
   @Output() selectTab = new EventEmitter();
-
   // For backwards compat... user selectTab instead.
   @Output() select = this.selectTab;
 
-  @ContentChildren(TabComponent) tabs: QueryList<TabComponent>;
+  @ContentChildren(TabComponent) readonly tabs: QueryList<TabComponent>;
 
   get index(): number {
     const tabs = this.tabs.toArray();
     return tabs.findIndex(tab => tab.active);
   }
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  private readonly _destroy$ = new Subject<void>();
+
+  constructor(private readonly _cdr: ChangeDetectorRef) {}
 
   ngAfterContentInit(): void {
     const tabs = this.tabs.toArray();
@@ -50,11 +55,16 @@ export class TabsComponent implements AfterContentInit {
       setTimeout(() => {
         tabs[0].active = true;
         tabs[0].detectChanges();
-        this.cdr.detectChanges();
+        this._cdr.markForCheck();
       });
     }
 
-    this.tabs.changes.subscribe(() => this.cdr.detectChanges());
+    this.tabs.changes.pipe(takeUntil(this._destroy$)).subscribe(() => this._cdr.markForCheck());
+  }
+
+  ngOnDestroy() {
+    this._destroy$.next();
+    this._destroy$.complete();
   }
 
   tabClicked(activeTab: TabComponent): void {
@@ -62,7 +72,7 @@ export class TabsComponent implements AfterContentInit {
 
     activeTab.active = true;
     this.tabs.forEach(tab => tab.detectChanges());
-    this.cdr.detectChanges();
+    this._cdr.markForCheck();
 
     this.selectTab.emit(activeTab);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 
 @Component({
+  exportAs: 'ngxTreeNode',
   selector: 'ngx-tree-node',
   templateUrl: './tree-node.component.html',
   encapsulation: ViewEncapsulation.None,

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree.component.ts
@@ -8,8 +8,13 @@ import {
   ContentChildren,
   TemplateRef,
   QueryList,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  OnInit,
+  ChangeDetectorRef,
+  OnDestroy
 } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { TreeNodeComponent } from './tree-node.component';
 
@@ -20,7 +25,7 @@ import { TreeNodeComponent } from './tree-node.component';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TreeComponent {
+export class TreeComponent implements OnInit, OnDestroy {
   @Input() nodes: any[];
 
   @Input('template')
@@ -29,19 +34,32 @@ export class TreeComponent {
   @ContentChild(TemplateRef, { static: true })
   _templateQuery: TemplateRef<any>;
 
-  get template(): TemplateRef<any> {
-    return this._templateInput || this._templateQuery;
-  }
-
-  @ContentChildren(TreeNodeComponent) nodeElms: QueryList<TreeNodeComponent>;
-
-  get hasOneLeaf(): boolean {
-    return (this.nodes && this.nodes.length === 1) || this.nodeElms.length === 1;
-  }
+  @ContentChildren(TreeNodeComponent) readonly nodeElms: QueryList<TreeNodeComponent>;
 
   @Output() expand = new EventEmitter();
   @Output() collapse = new EventEmitter();
   @Output() activate = new EventEmitter();
   @Output() deactivate = new EventEmitter();
   @Output() selectNode = new EventEmitter();
+
+  get hasOneLeaf(): boolean {
+    return (this.nodes && this.nodes.length === 1) || this.nodeElms.length === 1;
+  }
+
+  get template(): TemplateRef<any> {
+    return this._templateInput || this._templateQuery;
+  }
+
+  private readonly _destroy$ = new Subject<void>();
+
+  constructor(private readonly _cdr: ChangeDetectorRef) { }
+
+  ngOnInit() {
+    this.nodeElms.changes.pipe(takeUntil(this._destroy$)).subscribe(() => this._cdr.markForCheck());
+  }
+
+  ngOnDestroy() {
+    this._destroy$.next();
+    this._destroy$.complete();
+  }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree.component.ts
@@ -52,7 +52,7 @@ export class TreeComponent implements AfterContentInit, OnDestroy {
 
   private readonly _destroy$ = new Subject<void>();
 
-  constructor(private readonly _cdr: ChangeDetectorRef) { }
+  constructor(private readonly _cdr: ChangeDetectorRef) {}
 
   ngAfterContentInit() {
     this.nodeElms.changes.pipe(takeUntil(this._destroy$)).subscribe(() => this._cdr.markForCheck());

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree.component.ts
@@ -9,9 +9,9 @@ import {
   TemplateRef,
   QueryList,
   ChangeDetectionStrategy,
-  OnInit,
   ChangeDetectorRef,
-  OnDestroy
+  OnDestroy,
+  AfterContentInit
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -25,7 +25,7 @@ import { TreeNodeComponent } from './tree-node.component';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TreeComponent implements OnInit, OnDestroy {
+export class TreeComponent implements AfterContentInit, OnDestroy {
   @Input() nodes: any[];
 
   @Input('template')
@@ -54,7 +54,7 @@ export class TreeComponent implements OnInit, OnDestroy {
 
   constructor(private readonly _cdr: ChangeDetectorRef) { }
 
-  ngOnInit() {
+  ngAfterContentInit() {
     this.nodeElms.changes.pipe(takeUntil(this._destroy$)).subscribe(() => this._cdr.markForCheck());
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/pipes/cammel-to-snake/cammel-to-snake.pipe.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/pipes/cammel-to-snake/cammel-to-snake.pipe.spec.ts
@@ -1,17 +1,25 @@
 import { TestBed } from '@angular/core/testing';
+
 import { CammelToSnakePipe } from './cammel-to-snake.pipe';
 
 describe('CammelToSnakePipe', () => {
   let pipe: CammelToSnakePipe;
+
   beforeEach(() => {
     TestBed.configureTestingModule({ providers: [CammelToSnakePipe] });
     pipe = TestBed.get(CammelToSnakePipe);
   });
+
   it('can load instance', () => {
     expect(pipe).toBeTruthy();
   });
+
   it('transforms cammelToSnakePipe to cammel_to_snake_pipe', () => {
     const value: any = 'cammelToSnakePipe';
     expect(pipe.transform(value)).toEqual('cammel_to_snake_pipe');
+  });
+
+  it('should do nothing when !input', () => {
+    expect(pipe.transform()).toEqual('');
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/pipes/cammel-to-snake/cammel-to-snake.pipe.ts
+++ b/projects/swimlane/ngx-ui/src/lib/pipes/cammel-to-snake/cammel-to-snake.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'cammeltosnake' })
 export class CammelToSnakePipe implements PipeTransform {
-  transform(input: any): string {
+  transform(input?: any): string {
     if (!input) return '';
     const str = input.toString();
 

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -547,3 +547,14 @@
     ]]>
   </ngx-codemirror>
 </ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Async">
+  <ngx-select>
+    <ngx-select-option
+      *ngFor="let option of asyncOptions$ | async"
+      [name]="option.name"
+      [value]="option"
+      [disabled]="option.disabled"
+    ></ngx-select-option>
+  </ngx-select>
+</ngx-section>

--- a/src/app/forms/selects-page/selects-page.component.ts
+++ b/src/app/forms/selects-page/selects-page.component.ts
@@ -1,34 +1,46 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, OnInit } from '@angular/core';
+import { Observable, timer } from 'rxjs';
+import { map } from 'rxjs/operators';
+import * as faker from 'faker';
 
 @Component({
   selector: 'app-selects-page',
   templateUrl: './selects-page.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SelectsPageComponent {
-  selects = (function() {
+export class SelectsPageComponent implements OnInit {
+  selects = this._results;
+  selectsModel = [this.selects[0]];
+  singleSelectModel = this.selects[0];
+  asyncOptions$: Observable<any[]>;
+
+  private get _results() {
     let i = 50;
-    const results = [];
+    const results: any[] = [];
+
     while (i--) {
       results.push({
-        name: `Breach Level: ${i}`,
+        name: faker.random.word(),
         attr: `${i}_intrusion_breach`,
-        address: `${i}.${i}.${i}.12`,
+        address: `${faker.address.streetAddress(true)}`,
         disabled: i === 48
       });
     }
 
     return results;
-  })();
+  }
 
-  selectsModel = [this.selects[0]];
-  singleSelectModel = this.selects[0];
+  ngOnInit() {
+    this.asyncOptions$ = timer(0, 5000).pipe(
+      map(() => this._results),
+    );
+  }
 
-  onSelectKeyUp(event) {
+  onSelectKeyUp(event: KeyboardEvent) {
     console.log('key up', event);
   }
 
-  onEvent(name: string, event: any): void {
+  onEvent(name: string, event: Event): void {
     console.log(name, event);
   }
 }

--- a/src/app/forms/selects-page/selects-page.component.ts
+++ b/src/app/forms/selects-page/selects-page.component.ts
@@ -31,9 +31,7 @@ export class SelectsPageComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.asyncOptions$ = timer(0, 5000).pipe(
-      map(() => this._results),
-    );
+    this.asyncOptions$ = timer(0, 5000).pipe(map(() => this._results));
   }
 
   onSelectKeyUp(event: KeyboardEvent) {


### PR DESCRIPTION
Summary:
- when angular QueryLists (transcluded dom element array) changes on-push change detection should be triggered.
- add takeUntil(destroy$) to clean up subscriptions
- add async select example to demo bugfix
- cleanup failing tests and missing code coverage