### PR TITLE
Breaking: fix toggle ng model change

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.html
@@ -10,7 +10,6 @@
     [disabled]="disabled"
     [name]="name"
     (blur)="onBlur()"
-    (change)="onChange()"
   />
   <label [attr.for]="id" class="ngx-toggle-label"> </label>
   <label [attr.for]="id" class="ngx-toggle-text">

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.spec.ts
@@ -6,6 +6,7 @@ import { ToggleComponent } from './toggle.component';
 describe('ToggleComponent', () => {
   let component: ToggleComponent;
   let fixture: ComponentFixture<ToggleComponent>;
+  let changeSpy: jasmine.Spy;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -15,6 +16,12 @@ describe('ToggleComponent', () => {
 
     fixture = TestBed.createComponent(ToggleComponent);
     component = fixture.componentInstance;
+  });
+
+  beforeEach(() => {
+    const change = { onChange: () => undefined };
+    changeSpy = spyOn(change, 'onChange').and.callThrough();
+    component.registerOnChange(change.onChange);
   });
 
   it('can load instance', () => {
@@ -53,14 +60,10 @@ describe('ToggleComponent', () => {
     expect(component.getDisabled).toEqual('disabled');
   });
 
-  it('can register on change callback', done => {
-    const changeCallback = () => {
-      done();
-    };
-
-    component.registerOnChange(changeCallback);
+  it('can register on change callback', () => {
     component.writeValue(true);
     expect(component.value).toEqual(true);
+    expect(changeSpy).toHaveBeenCalled();
   });
 
   it('onBlur calls default callback if none have been registered', () => {
@@ -87,38 +90,30 @@ describe('ToggleComponent', () => {
     expect(component.value).toEqual(false);
   });
 
-  it('changing value triggers change emitter and callback to be called', () => {
-    spyOn(component.change, 'emit');
-
+  it('changing value triggers change callback to be called', () => {
     component.value = true;
 
     expect(component.value).toEqual(true);
-    expect(component.change.emit).toHaveBeenCalled();
+    expect(changeSpy).toHaveBeenCalled();
   });
 
-  it('setting value to existing value does not trigger change emit', () => {
-    spyOn(component.change, 'emit');
-
+  it('setting value to existing value does not trigger change', () => {
     component.value = false;
 
-    expect(component.change.emit).not.toHaveBeenCalled();
+    expect(changeSpy).not.toHaveBeenCalled();
   });
 
-  it('writing value triggers change emitter and callback to be called', () => {
-    spyOn(component.change, 'emit');
-
+  it('writing value triggers change callback to be called', () => {
     component.writeValue(true);
 
     expect(component.value).toEqual(true);
-    expect(component.change.emit).toHaveBeenCalled();
+    expect(changeSpy).toHaveBeenCalled();
   });
 
-  it('writing value to existing value does not trigger change emit', () => {
-    spyOn(component.change, 'emit');
-
+  it('writing value to existing value does not trigger change', () => {
     component.writeValue(false);
 
-    expect(component.change.emit).not.toHaveBeenCalled();
+    expect(changeSpy).not.toHaveBeenCalled();
   });
 
   it('writing null or undefined value defaults it to false', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.spec.ts
@@ -63,7 +63,7 @@ describe('ToggleComponent', () => {
   it('can register on change callback', () => {
     component.writeValue(true);
     expect(component.value).toEqual(true);
-    expect(changeSpy).toHaveBeenCalled();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 
   it('onBlur calls default callback if none have been registered', () => {
@@ -94,7 +94,7 @@ describe('ToggleComponent', () => {
     component.value = true;
 
     expect(component.value).toEqual(true);
-    expect(changeSpy).toHaveBeenCalled();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 
   it('setting value to existing value does not trigger change', () => {
@@ -107,7 +107,7 @@ describe('ToggleComponent', () => {
     component.writeValue(true);
 
     expect(component.value).toEqual(true);
-    expect(changeSpy).toHaveBeenCalled();
+    expect(changeSpy).toHaveBeenCalledTimes(1);
   });
 
   it('writing value to existing value does not trigger change', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
@@ -84,7 +84,7 @@ export class ToggleComponent implements ControlValueAccessor {
   private _required: boolean = false;
   private _tabIndex: number = 0;
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(private readonly cdr: ChangeDetectorRef) {}
 
   toggle(): void {
     this.value = !this.value;

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
@@ -1,8 +1,6 @@
 import {
   Component,
-  EventEmitter,
   Input,
-  Output,
   ViewEncapsulation,
   forwardRef,
   ChangeDetectionStrategy,
@@ -33,7 +31,6 @@ let nextId = 0;
   }
 })
 export class ToggleComponent implements ControlValueAccessor {
-  @Output() change = new EventEmitter();
   @Input() id: string = `toggle-${++nextId}`;
   @Input() name: string = null;
   @Input() label: string;
@@ -69,7 +66,7 @@ export class ToggleComponent implements ControlValueAccessor {
   set value(value) {
     if (this.value !== value) {
       this._value = value;
-      this.onChange();
+      this.onChangeCallback(value);
       this.cdr.markForCheck();
     }
   }
@@ -97,22 +94,13 @@ export class ToggleComponent implements ControlValueAccessor {
     this.onTouchedCallback();
   }
 
-  onChange(): void {
-    this.change.emit(this.value);
-
-    setTimeout(() => {
-      this.onChangeCallback(this._value);
-    });
-  }
-
   writeValue(val: any): void {
     if (val === null || val === undefined) {
       val = false;
     }
 
     if (val !== this._value) {
-      this._value = val;
-      this.onChange();
+      this.value = val;
       this.cdr.markForCheck();
     }
   }

--- a/src/app/forms/toggle-page/toggle-page.component.html
+++ b/src/app/forms/toggle-page/toggle-page.component.html
@@ -35,7 +35,7 @@
   </ngx-toggle>
   <ngx-codemirror mode="htmlmixed" readOnly="true">
     <![CDATA[
-      <ngx-toggle name="toggle3" [(ngModel)]="toggleChk" (change)="onToggleChange($event)">
+      <ngx-toggle name="toggle3" [(ngModel)]="toggleChk" (ngModelChange)="onToggleChange($event)">
         <strong class="color-red" [hidden]="!toggleChk">Alert Everyone!</strong>
         <strong class="color-green" [hidden]="toggleChk">All good!</strong>
       </ngx-toggle>

--- a/src/app/forms/toggle-page/toggle-page.component.html
+++ b/src/app/forms/toggle-page/toggle-page.component.html
@@ -29,7 +29,7 @@
   <br />
   <br />
 
-  <ngx-toggle name="toggle3" [(ngModel)]="toggleChk" (change)="onToggleChange($event)">
+  <ngx-toggle name="toggle3" [(ngModel)]="toggleChk" (ngModelChange)="onToggleChange($event)">
     <strong class="color-red" [hidden]="!toggleChk">Alert Everyone!</strong>
     <strong class="color-green" [hidden]="toggleChk">All good!</strong>
   </ngx-toggle>


### PR DESCRIPTION
Summary:
- @luisb90 pointed out ngModelChange firing multiple times per change
- fix duplicate change calls
- fix demo page component usage