### PR TITLE
Add selectable and disabled to tree node model

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/tree/fixtures/tree.fixture.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/fixtures/tree.fixture.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 import { TreeComponent } from '../tree.component';
+import { TreeNode } from '../tree-node.model';
 
 @Component({
   // tslint:disable-next-line: component-selector
@@ -10,7 +11,7 @@ export class TreeFixtureComponent {
   @ViewChild('tree1', { static: true }) treeComponent1: TreeComponent;
   @ViewChild('tree2', { static: true }) treeComponent2: TreeComponent;
 
-  nodes: any[] = [
+  nodes: TreeNode[] = [
     {
       label: 'Node1',
       model: { type: 'Array', count: 1 }

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.html
@@ -9,7 +9,7 @@
   <span
     *ngIf="expandable"
     class="ngx-expander"
-    (click)="onExpandClick()"
+    (click)="onExpandClick($event)"
     [class.disabled]="disabled"
     [ngClass]="expanded ? icons.expand : icons.collapse"
   >

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.html
@@ -23,6 +23,7 @@
     [nodes]="children"
     [template]="template"
     [icons]="icons"
+    (selectNode)="selectNode.emit($event)"
   >
   </ngx-tree>
 </li>

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.spec.ts
@@ -3,6 +3,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TreeNodeComponent } from './tree-node.component';
 import { TreeModule } from './tree.module';
 
+const MOCK_EVENT: any = {
+  stopPropagation: () => {
+    return;
+  }
+};
+
 describe('TreeNodeComponent', () => {
   let component: TreeNodeComponent;
   let fixture: ComponentFixture<TreeNodeComponent>;
@@ -37,7 +43,7 @@ describe('TreeNodeComponent', () => {
   it('clicking expand to expand node emits expand event', () => {
     spyOn(component.expand, 'emit').and.callThrough();
     component.expandable = true;
-    component.onExpandClick();
+    component.onExpandClick(MOCK_EVENT);
 
     expect(component.expanded).toBe(true);
     expect(component.expand.emit).toHaveBeenCalled();
@@ -47,8 +53,8 @@ describe('TreeNodeComponent', () => {
     spyOn(component.collapse, 'emit').and.callThrough();
     component.expandable = true;
     // click once to expand then again to collapse
-    component.onExpandClick();
-    component.onExpandClick();
+    component.onExpandClick(MOCK_EVENT);
+    component.onExpandClick(MOCK_EVENT);
 
     expect(component.expanded).toBe(false);
     expect(component.collapse.emit).toHaveBeenCalled();
@@ -56,13 +62,8 @@ describe('TreeNodeComponent', () => {
 
   it('onClick emits select event', () => {
     spyOn(component.selectNode, 'emit').and.callThrough();
-    const event = {
-      stopPropagation: () => {
-        return;
-      }
-    };
     component.selectable = true;
-    component.onClick(event);
+    component.onClick(MOCK_EVENT);
 
     expect(component.selectNode.emit).toHaveBeenCalled();
   });
@@ -75,19 +76,14 @@ describe('TreeNodeComponent', () => {
     });
 
     it('Expand click does not expand node when disabled', () => {
-      component.onExpandClick();
+      component.onExpandClick(MOCK_EVENT);
 
       expect(component.expanded).toBeFalsy();
     });
 
     it('select click does not select node when disabled', () => {
       spyOn(component.selectNode, 'emit').and.callThrough();
-      const event = {
-        stopPropagation: () => {
-          return;
-        }
-      };
-      component.onClick(event);
+      component.onClick(MOCK_EVENT);
 
       expect(component.selectNode.emit).not.toHaveBeenCalled();
     });

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.ts
@@ -52,8 +52,10 @@ export class TreeNodeComponent implements OnChanges {
     };
   }
 
-  onExpandClick(): void {
+  onExpandClick(event): void {
     if (this.disabled || !this.expandable) return;
+
+    event.stopPropagation();
 
     this.expanded = !this.expanded;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.model.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.model.ts
@@ -4,6 +4,8 @@ export interface TreeNode {
   model: {
     [key: string]: any;
   };
+  disabled?: boolean;
   expandable?: boolean;
   expanded?: boolean;
+  selectable?: boolean;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree.component.html
@@ -3,8 +3,10 @@
     <ngx-tree-node
       *ngFor="let node of nodes"
       [node]="node"
+      [disabled]="node.disabled"
       [expandable]="node.expandable"
       [expanded]="node.expanded"
+      [selectable]="node.selectable"
       [icons]="icons"
       [label]="node.label"
       [model]="node.model"


### PR DESCRIPTION
It seems `selectable` and `disabled` are not configurable for ngx-tree when no templates are used.

As a result it's not possible to disable or make anything selectable with the stock configuration of ngx tree.

In addition I've added `selectNode` to the nested trees in order for that event to 'bubble' up and I'm canceling propagation when a node is expanded otherwise an expand will also trigger a select which seems undesirable.

This pr purposes a suggested change and does not have to be merged perse.