### PR TITLE
Export schema on model update

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -118,11 +118,16 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit {
   }
 
   deleteProperty(propName: string): void {
-    delete this.schema.properties[propName];
-    delete this.schemaRef.properties[propName];
-    this.toggleRequiredValue(false, propName);
-    super.deleteProperty(propName);
+    if (this.schemaBuilderMode) {
+      delete this.schema.properties[propName];
+      delete this.schemaRef.properties[propName];
+      this.toggleRequiredValue(false, propName);
+    } else if (!this.schema.required.includes(propName) && !(propName in this.schema.properties)) {
+      delete this.schemaRef.properties[propName];
+    }
+
     this.schemaChange.emit();
+    super.deleteProperty(propName);
   }
 
   drop(event: CdkDragDrop<string[]>): void {

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -22,12 +22,15 @@
           [schema]="jsonEditorSchema"
           label="Model"
           [typeCheckOverrides]="typeOverrides"
+          (schemaChange)="modelSchemaChange($event)"
         >
         </ngx-json-editor-flat>
 
         <hr />
         <h3>Model</h3>
         <pre>{{ jsonEditorModelFlat | json }}</pre>
+        <h3>Schema</h3>
+        <pre>{{ modelSchemaRef | json }}</pre>
       </ngx-section>
 
       <br />

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -100,6 +100,7 @@ export class JsonEditorPageComponent {
   jsonEditorSchemaBuilderModel: any = {};
 
   schemaRef: JSONSchema7 = {};
+  modelSchemaRef: JSONSchema7 = {};
 
   customFormats = ['password', 'code', 'date', 'date-time', 'custom'];
 
@@ -124,5 +125,9 @@ export class JsonEditorPageComponent {
 
   schemaChange(schema: JSONSchema7): void {
     this.schemaRef = schema;
+  }
+
+  modelSchemaChange(schema: JSONSchema7): void {
+    this.modelSchemaRef = schema;
   }
 }


### PR DESCRIPTION
Expose a schema update when model changes, without modifying the original schema.
Updates on add property are already on master. This PR fixes the delete property.