### PR TITLE
json editor hide root node

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
@@ -2,6 +2,7 @@
   <ngx-json-editor-node-flat
     [(model)]="model"
     [schema]="schema"
+    [hideRoot]="hideRoot"
     [schemaRef]="schemaRef"
     (modelChange)="modelChangedCallback($event)"
     [errors]="errors"

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
@@ -38,6 +38,8 @@ export class JsonEditorFlatComponent extends JsonEditor {
 
   @Input() compressed = false;
 
+  @Input() hideRoot = false;
+
   @ContentChildren(JsonEditorNodeFlatComponent) nodeElms: QueryList<JsonEditorNodeFlatComponent>;
 
   @ViewChild('propertyConfigTmpl') propertyConfigTmpl: TemplateRef<PropertyConfigComponent>;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="model !== undefined" class="json-tree-node-flat">
-  <div class="node-container">
+  <div class="node-container" *ngIf="!(level === -1 && hideRoot)">
     <div class="indentation" *ngIf="level > 0" [style.left]="-1 * (level * 20) + 'px'">
       <span class="separator" *ngFor="let separator of indentationArray"></span>
     </div>
@@ -234,6 +234,7 @@
       [schemaRef]="schemaRef"
       [model]="model"
       [expanded]="expanded"
+      [hideRoot]="hideRoot"
       (modelChange)="updateModel($event)"
       [path]="path"
       [errors]="childrenErrors"
@@ -255,6 +256,7 @@
       [model]="model"
       [expanded]="expanded"
       [formats]="formats"
+      [hideRoot]="hideRoot"
       (modelChange)="updateModel($event)"
       [path]="path"
       [compressed]="compressed"

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
@@ -31,7 +31,7 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
 
   @Input() label: string;
 
-  @Input() level: number = -1;
+  @Input() level: number;
 
   @Input() schemaBuilderMode?: boolean;
 
@@ -40,6 +40,8 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
   @Input() formats: JsonSchemaDataType[];
 
   @Input() arrayItem = false;
+
+  @Input() hideRoot = false;
 
   @Input() arrayName = '';
 
@@ -57,7 +59,11 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
   }
 
   ngOnInit() {
-    this.level += 1;
+    if (this.level === undefined) {
+      this.level = this.hideRoot ? -1 : 0;
+    } else {
+      this.level += 1;
+    }
   }
 
   updatePropertyName(id: string | number, name: string): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
@@ -12,6 +12,7 @@
       [errors]="errors"
       [typeCheckOverrides]="typeCheckOverrides"
       [level]="level"
+      [hideRoot]="hideRoot"
       [compressed]="compressed"
       [schemaRef]="schemaRef?.items || null"
       [schemaBuilderMode]="schemaBuilderMode"
@@ -56,10 +57,10 @@
     *ngIf="!schemaBuilderMode || !model.length"
     class="add-button"
     [class.compressed]="compressed"
-    [class.background]="level"
+    [class.background]="hideRoot ? level > -1 : level"
   >
     <span class="separator" *ngFor="let separator of indentationArray"></span>
-    <div class="indented-content">
+    <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">
         <ngx-dropdown-toggle>
           <button type="button">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
@@ -30,6 +30,8 @@ export class ArrayNodeFlatComponent extends ArrayNode implements OnInit {
 
   @Input() compressed: boolean;
 
+  @Input() hideRoot;
+
   indentationArray: number[] = [];
 
   constructor(private dialogService: DialogService) {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-types.extensions.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-types.extensions.scss
@@ -15,6 +15,10 @@
   position: relative;
   display: flex;
 
+  ngx-dropdown {
+    padding-bottom: 0;
+  }
+
   &.compressed {
     max-height: 80px;
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -20,6 +20,7 @@
       [inline]="prop.type !== 'array' && prop.type !== 'object'"
       [path]="path + getPath(prop.propertyName)"
       [errors]="errors"
+      [hideRoot]="hideRoot"
       [typeCheckOverrides]="typeCheckOverrides"
       [level]="level"
       [schemaBuilderMode]="schemaBuilderMode"
@@ -81,14 +82,14 @@
     ></div>
   </div>
 
-  <div class="add-button" [class.compressed]="compressed" [class.background]="level">
+  <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level">
     <span class="separator" *ngFor="let separator of indentationArray"></span>
-    <div class="indented-content">
+    <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">
         <ngx-dropdown-toggle>
           <button type="button">
             <i class="ngx-icon ngx-tree-expand"></i>
-            <span>Add a property</span>
+            <span>Add {{ objectKeys(propertyIndex).length ? 'a' : 'your first' }} property</span>
           </button>
         </ngx-dropdown-toggle>
         <ngx-dropdown-menu class="ngx-dropdown-dark-outline">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -37,7 +37,11 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit {
 
   @Input() compressed: boolean;
 
+  @Input() hideRoot;
+
   indentationArray: number[] = [];
+
+  objectKeys = Object.keys;
 
   constructor(private dialogService: DialogService, protected cdr: ChangeDetectorRef) {
     super(cdr);

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.extensions.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.extensions.scss
@@ -1,5 +1,6 @@
 %ngx-dropdown-menu {
   white-space: nowrap;
+  margin-top: 10px;
 
   .dropdown-column {
     vertical-align: top;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.scss
@@ -62,6 +62,7 @@
 
   .ngx-dropdown-menu {
     white-space: nowrap;
+    left: 16px !important;
 
     .dropdown-column {
       vertical-align: top;


### PR DESCRIPTION
 Add the ability to hide the root note on the json editor flat component.
Usage:

`<ngx-json-editor-flat [hideRoot]="true" ... ></ngx-json-editor-flat>`