### PR TITLE
Move click event on tree nodes to avoid propagation

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (Unreleased)
 
+- Fix: move click event on tree node to avoid propagation
+
 ## 28.2.0 (2020-02-18)
 
 - Enhancement: Json Editor Schema Builder: hide root node (#391)

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.html
@@ -13,9 +13,9 @@
     [ngClass]="expanded ? icons.collapse : icons.expand"
     >
   </span>
-  <span *ngIf="!template" [innerHTML]="label" [class.disabled]="disabled" class="ngx-node-label" (click)="onClick($event)"> </span>
-  <ng-template *ngIf="template" [ngTemplateOutlet]="template" [ngTemplateOutletContext]="data" (click)="onClick($event)"> </ng-template>  
-  <ng-content *ngIf="expanded"></ng-content> 
+  <span *ngIf="!template" [innerHTML]="label" [class.disabled]="disabled" class="ngx-node-label" (click)="onClick()"> </span>
+  <ng-template *ngIf="template" [ngTemplateOutlet]="template" [ngTemplateOutletContext]="data"> </ng-template>  
+  <ng-content *ngIf="expanded"></ng-content>
   <ngx-tree
     *ngIf="children?.length && expandable && expanded"
     class="ngx-sub-tree"

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.html
@@ -1,7 +1,6 @@
 <li
   class="ngx-tree-node"
   [class.selectable]="selectable"
-  (click)="onClick($event)"
   (focus)="activate.emit(this.data)"
   (blur)="deactivate.emit(this.data)"
   tabindex="-1"
@@ -12,11 +11,11 @@
     (click)="onExpandClick($event)"
     [class.disabled]="disabled"
     [ngClass]="expanded ? icons.collapse : icons.expand"
-  >
+    >
   </span>
-  <span *ngIf="!template" [innerHTML]="label" [class.disabled]="disabled" class="ngx-node-label"> </span>
-  <ng-template *ngIf="template" [ngTemplateOutlet]="template" [ngTemplateOutletContext]="data"> </ng-template>
-  <ng-content *ngIf="expanded"></ng-content>
+  <span *ngIf="!template" [innerHTML]="label" [class.disabled]="disabled" class="ngx-node-label" (click)="onClick($event)"> </span>
+  <ng-template *ngIf="template" [ngTemplateOutlet]="template" [ngTemplateOutletContext]="data" (click)="onClick($event)"> </ng-template>  
+  <ng-content *ngIf="expanded"></ng-content> 
   <ngx-tree
     *ngIf="children?.length && expandable && expanded"
     class="ngx-sub-tree"

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.spec.ts
@@ -63,7 +63,7 @@ describe('TreeNodeComponent', () => {
   it('onClick emits select event', () => {
     spyOn(component.selectNode, 'emit').and.callThrough();
     component.selectable = true;
-    component.onClick(MOCK_EVENT);
+    component.onClick();
 
     expect(component.selectNode.emit).toHaveBeenCalled();
   });
@@ -83,7 +83,7 @@ describe('TreeNodeComponent', () => {
 
     it('select click does not select node when disabled', () => {
       spyOn(component.selectNode, 'emit').and.callThrough();
-      component.onClick(MOCK_EVENT);
+      component.onClick();
 
       expect(component.selectNode.emit).not.toHaveBeenCalled();
     });

--- a/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tree/tree-node.component.ts
@@ -52,7 +52,7 @@ export class TreeNodeComponent implements OnChanges {
     };
   }
 
-  onExpandClick(event): void {
+  onExpandClick(event: Event): void {
     if (this.disabled || !this.expandable) return;
 
     event.stopPropagation();
@@ -66,8 +66,7 @@ export class TreeNodeComponent implements OnChanges {
     }
   }
 
-  onClick(event): void {
-    event.stopPropagation();
+  onClick(): void {
     if (!this.selectable || this.disabled) return;
     this.selectNode.emit(this.data);
   }

--- a/src/app/components/tree-page/tree-page.component.html
+++ b/src/app/components/tree-page/tree-page.component.html
@@ -86,8 +86,8 @@
         <ngx-tree-node [label]="'Node 3'"></ngx-tree-node>
       </ngx-tree>
     </ngx-tree-node>
-    <ngx-tree-node [label]="'Node 3'" [selectable]="true"></ngx-tree-node>
-    <ngx-tree-node [label]="'Node 4'" [selectable]="true" [expandable]="true" [expanded]="false">
+    <ngx-tree-node [label]="'Node 3'" [selectable]="true" (selectNode)="selectNode($event)"></ngx-tree-node>
+    <ngx-tree-node [label]="'Node 4'" [selectable]="true" (selectNode)="selectNode($event)" [expandable]="true" [expanded]="false">
       <ngx-tree>
         <ngx-tree-node [label]="'Node 1'"></ngx-tree-node>
         <ngx-tree-node [label]="'Node 2'" [expandable]="true" [expanded]="true" [disabled]="true">
@@ -100,8 +100,8 @@
         <ngx-tree-node [label]="'Node 3'"></ngx-tree-node>
       </ngx-tree>
     </ngx-tree-node>
-    <ngx-tree-node [label]="'Node 1'" [selectable]="true"></ngx-tree-node>
-    <ngx-tree-node [label]="'Node 5'" [selectable]="true"></ngx-tree-node>
+    <ngx-tree-node [label]="'Node 1'" [selectable]="true" (selectNode)="selectNode($event)"></ngx-tree-node>
+    <ngx-tree-node [label]="'Node 5'" [selectable]="true" (selectNode)="selectNode($event)"></ngx-tree-node>
   </ngx-tree>
 
   <ngx-codemirror mode="htmlmixed" readOnly="true">

--- a/src/app/components/tree-page/tree-page.component.ts
+++ b/src/app/components/tree-page/tree-page.component.ts
@@ -7,6 +7,8 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TreePageComponent {
+  activeNode = null;
+
   nodes: any[] = [
     { label: 'Node 1' },
     {
@@ -88,4 +90,8 @@ export class TreePageComponent {
     "children": [],
     "spouse": null
   }`);
+
+  selectNode(e: Event) {
+    console.log({ e });
+  }
 }


### PR DESCRIPTION
* Moved click event on node to avoid using stop propagation in click event.