### PR TITLE
Support tabindex on select inputs

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -1,13 +1,15 @@
-<div tabindex="-1" (keydown)="onKeyDown($event)" class="ngx-select-input-box" (click)="onClick($event)">
+<div
+  [tabindex]="tabindex"
+  (keydown)="onKeyDown($event)"
+  (keyup)="onGlobalKeyUp($event)"
+  class="ngx-select-input-box"
+  (click)="onClick($event)"
+>
   <span *ngIf="label !== undefined" class="ngx-select-label">
     <span [innerHTML]="label"></span>
     <span [innerHTML]="requiredIndicator"></span>
   </span>
-  <span
-    *ngIf="!selected?.length && placeholder !== undefined"
-    class="ngx-select-placeholder"
-    [innerHTML]="placeholder"
-  >
+  <span *ngIf="!selected?.length && placeholder !== undefined" class="ngx-select-placeholder" [innerHTML]="placeholder">
   </span>
   <ul class="horizontal-list ngx-select-input-list">
     <li *ngFor="let option of selectedOptions" class="ngx-select-input-option" [class.disabled]="option.disabled">
@@ -32,7 +34,6 @@
         #tagInput
         type="search"
         class="ng-select-text-box"
-        tabindex=""
         autocomplete="off"
         autocorrect="off"
         spellcheck="off"

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
@@ -29,6 +29,7 @@ export class SelectInputComponent implements AfterViewInit {
   @Input() hint: string;
   @Input() selectCaret: string | TemplateRef<any>;
   @Input() requiredIndicator: string | boolean;
+  @Input() tabindex: number;
 
   @Input()
   get autofocus() {
@@ -148,6 +149,15 @@ export class SelectInputComponent implements AfterViewInit {
     }
 
     this.keyup.emit({ event, value });
+  }
+
+  onGlobalKeyUp(event: KeyboardEvent) {
+    event.stopPropagation();
+    const key = event.key;
+
+    if (key === KeyboardKeys.ARROW_DOWN) {
+      this.activate.emit(event);
+    }
   }
 
   onKeyDown(event: KeyboardEvent): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -278,8 +278,6 @@ export class SelectComponent implements ControlValueAccessor, OnDestroy {
   private _multiple: boolean = false;
   private _disabled: boolean = false;
 
-  private onTouchedCallback: () => void;
-
   constructor(
     private readonly _element: ElementRef,
     private readonly _renderer: Renderer2,
@@ -371,7 +369,7 @@ export class SelectComponent implements ControlValueAccessor, OnDestroy {
   }
 
   onKeyUp({ event, value }: { event: KeyboardEvent; value?: string }): void {
-    if (event && event.key === (KeyboardKeys.ARROW_DOWN as any)) {
+    if (event && event.key === (KeyboardKeys.ARROW_DOWN as any) && this.focusIndex < this.options.length) {
       ++this.focusIndex;
     } else {
       this.filterQuery = value;
@@ -409,6 +407,11 @@ export class SelectComponent implements ControlValueAccessor, OnDestroy {
 
   /* istanbul ignore next */
   private onChangeCallback(_: any): void {
+    // placeholder
+  }
+
+  /* istanbul ignore next */
+  private onTouchedCallback(): void {
     // placeholder
   }
 }


### PR DESCRIPTION
Currently tab fails on a form for ngx-select. They will just skip that input. This PR fixes that and also allow the user to open the dropdown with the down arrow key making it close to a common HTML select behavior.