### PR TITLE
Fix mouse leave firing if returning to source

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.directive.ts
@@ -151,15 +151,15 @@ export class TooltipDirective implements OnDestroy {
     }
   }
 
-  @HostListener('mouseleave', ['$event.target'])
-  onMouseLeave(target: HTMLElement): void {
+  @HostListener('mouseleave', ['$event'])
+  onMouseLeave(event: any): void {
     if (this.listensForHover && this.tooltipCloseOnMouseLeave) {
       clearTimeout(this.timeout);
 
       /* istanbul ignore if */
       if (this.component) {
         const contentDom = this.component.instance.element.nativeElement;
-        const contains = contentDom.contains(target);
+        const contains = contentDom.contains(event.toElement);
         if (contains) return;
       }
 
@@ -241,7 +241,11 @@ export class TooltipDirective implements OnDestroy {
       this.mouseLeaveContentEvent = this.renderer.listen(
         tooltip,
         'mouseleave',
-        /* istanbul ignore next */ () => {
+        /* istanbul ignore next */ (event: any) => {
+          const contentDom = this.element.nativeElement;
+          const contains = contentDom.contains(event.toElement);
+          if (contains) return;
+
           this.hideTooltip();
         }
       );


### PR DESCRIPTION
Fixes two issues:

1) If the mouse leaves the tooltip source element to the tooltip content, then returns to the original source the mouse leave event was fired, closing the tooltip.

2) Sometimes when the tooltip content is bein rendered in the DOM, before being pleaced in the correct position, it will be located over the tooltip source element... triggering #1.

Now if the mouse leaves the tooltip content but the target is the source element, the tooltip is not closed.