### PR TITLE
set touched to true on function body

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -412,6 +412,6 @@ export class SelectComponent implements ControlValueAccessor, OnDestroy {
 
   /* istanbul ignore next */
   private onTouchedCallback(): void {
-    // placeholder
+    this.touched = true;
   }
 }


### PR DESCRIPTION
## Summary

Set `touched` value inside `onTouchedCallback` to make sure it is modified when `registerOnTouched` is not being called.
`registerOnTouched` seems to only be called when the select has an `ngModel` associated to it.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
