### PR TITLE
Fix required icon missing when hideRoot is true

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- Feature: support dynamic `hideRoot` inputs
+- Fix: required icon not showing for top level when `hideRoot` is true
+
 ## 28.6.0 (2020-05-07)
 
 - Feature: New ngx-navbar component (#437)

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -1,13 +1,13 @@
 <div *ngIf="model !== undefined" class="json-tree-node-flat">
-  <div class="node-container" *ngIf="!(level === -1 && hideRoot)">
-    <div class="indentation" *ngIf="level > 0" [style.left]="-1 * (level * 20) + 'px'">
+  <div class="node-container" *ngIf="!(nextLevel === -1 && hideRoot)">
+    <div class="indentation" *ngIf="nextLevel > 0" [style.left]="-1 * (nextLevel * 20) + 'px'">
       <span class="separator" *ngFor="let separator of indentationArray"></span>
     </div>
     <div class="node" [class.compressed]="compressed">
       <div class="error-box" *ngIf="!valid && !schemaBuilderMode"></div>
 
       <div class="left-options">
-        <ng-container *ngIf="level > 0 && !arrayItem">
+        <ng-container *ngIf="hideRoot || (nextLevel > 0 && !arrayItem)">
           <div class="required-indicator">
             <span
               *ngIf="required"
@@ -239,7 +239,7 @@
       [path]="path"
       [errors]="childrenErrors"
       [typeCheckOverrides]="typeCheckOverrides"
-      [level]="level"
+      [level]="nextLevel"
       [compressed]="compressed"
       [schemaBuilderMode]="schemaBuilderMode"
       [formats]="formats"
@@ -262,7 +262,7 @@
       [compressed]="compressed"
       [errors]="childrenErrors"
       [typeCheckOverrides]="typeCheckOverrides"
-      [level]="level"
+      [level]="nextLevel"
       [schemaBuilderMode]="schemaBuilderMode"
       (schemaChange)="schemaChange.emit(schemaRef)"
     >

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
@@ -5,7 +5,8 @@ import {
   ViewEncapsulation,
   EventEmitter,
   Output,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  SimpleChanges
 } from '@angular/core';
 import { JsonEditorNode } from '../../json-editor-node';
 
@@ -53,17 +54,17 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
 
   requiredIndicator: SafeHtml;
 
-  get nextLevel() {
-    if (this.level === undefined) {
-      return this.hideRoot ? -1 : 0;
-    } else {
-      return this.level + 1;
-    }
-  }
+  nextLevel: number = 0;
 
   constructor(public dialogMngr: DialogService, private domSanitizer: DomSanitizer) {
     super(dialogMngr);
     this.requiredIndicator = this.domSanitizer.bypassSecurityTrustHtml(requiredIndicatorIcon);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if ('level' in changes || 'hideRoot' in changes) {
+      this.nextLevel = this.level === undefined ? (this.hideRoot ? -1 : 0) : this.level + 1;
+    }
   }
 
   updatePropertyName(id: string | number, name: string): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
@@ -53,17 +53,17 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
 
   requiredIndicator: SafeHtml;
 
+  get nextLevel() {
+    if (this.level === undefined) {
+      return this.hideRoot ? -1 : 0;
+    } else {
+      return this.level + 1;
+    }
+  }
+
   constructor(public dialogMngr: DialogService, private domSanitizer: DomSanitizer) {
     super(dialogMngr);
     this.requiredIndicator = this.domSanitizer.bypassSecurityTrustHtml(requiredIndicatorIcon);
-  }
-
-  ngOnInit() {
-    if (this.level === undefined) {
-      this.level = this.hideRoot ? -1 : 0;
-    } else {
-      this.level += 1;
-    }
   }
 
   updatePropertyName(id: string | number, name: string): void {

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -2,57 +2,17 @@
 <ngx-section class="shadow" [sectionTitle]="'JSON Editor'">
   <ngx-tabs>
     <ngx-tab label="Editor">
-      <ngx-section class="shadow" [sectionTitle]="'ngx-json-editor'">
-        <ngx-json-editor
-          [(model)]="jsonEditorModel"
-          [schema]="jsonEditorSchema"
-          label="Model"
-          [typeCheckOverrides]="typeOverrides"
-        >
-        </ngx-json-editor>
+      <ngx-json-editor
+        [(model)]="jsonEditorModel"
+        [schema]="jsonEditorSchema"
+        label="Model"
+        [typeCheckOverrides]="typeOverrides"
+      >
+      </ngx-json-editor>
 
-        <hr />
-        <h3>Model</h3>
-        <pre>{{ jsonEditorModel | json }}</pre>
-      </ngx-section>
-
-      <ngx-section class="shadow" [sectionTitle]="'ngx-json-editor-flat'">
-        <ngx-json-editor-flat
-          [(model)]="jsonEditorModelFlat"
-          [schema]="jsonEditorSchema"
-          label="Model"
-          [typeCheckOverrides]="typeOverrides"
-          (schemaChange)="modelSchemaChange($event)"
-        >
-        </ngx-json-editor-flat>
-
-        <hr />
-        <h3>Model</h3>
-        <pre>{{ jsonEditorModelFlat | json }}</pre>
-        <h3>Schema</h3>
-        <pre>{{ modelSchemaRef | json }}</pre>
-      </ngx-section>
-
-      <br />
-      <ngx-section class="shadow" [sectionTitle]="'Schema Builder Mode'">
-        <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"
-          >Toggle compressed mode</ngx-button
-        >
-        <ngx-json-editor-flat
-          [(model)]="jsonEditorSchemaBuilderModel"
-          [schema]="{}"
-          label="Schema"
-          [compressed]="compressed"
-          [typeCheckOverrides]="typeOverrides"
-          [schemaBuilderMode]="true"
-          [formats]="customFormats"
-          (schemaChange)="schemaChange($event)"
-        >
-        </ngx-json-editor-flat>
-        <hr />
-        <h3>Schema</h3>
-        <pre>{{ schemaRef | json }}</pre>
-      </ngx-section>
+      <hr />
+      <h3>Model</h3>
+      <pre>{{ jsonEditorModel | json }}</pre>
     </ngx-tab>
     <ngx-tab label="Schema">
       <ngx-button class="btn btn-primary" (click)="updateJsonEditorSchema(_jsonEditorSchema)">Update Schema</ngx-button>
@@ -63,28 +23,76 @@
       ></ngx-codemirror>
     </ngx-tab>
   </ngx-tabs>
-
-  <ngx-tabs>
-    <ngx-tab label="Markup">
-      <ngx-codemirror mode="htmlmixed" readOnly="true">
-        <![CDATA[ <ngx-json-editor [(model)]="jsonEditorModel" [schema]="jsonEditorSchema" label="Model"
-        [typeCheckOverrides]="typeOverrides"> </ngx-json-editor> ]]>
-      </ngx-codemirror>
-      <ngx-codemirror mode="htmlmixed" readOnly="true">
-        <![CDATA[ <ngx-json-editor-flat [(model)]="jsonEditorModel" [schema]="jsonEditorSchema" label="Model"
-        [typeCheckOverrides]="typeOverrides"> </ngx-json-editor-flat> ]]>
-      </ngx-codemirror>
-      <ngx-codemirror mode="htmlmixed" readOnly="true">
-        <![CDATA[ <ngx-json-editor-flat [(model)]="jsonEditorModel" [schema]="{}" label="Schema"
-        [typeCheckOverrides]="typeOverrides" [formats]="customFormats" [compressed]="compressed"
-        [schemaBuilderMode]="true" (schemaChange)="schemaChange($event)"> </ngx-json-editor-flat> ]]>
-      </ngx-codemirror>
-    </ngx-tab>
-    <ngx-tab label="Typescript">
-      <ngx-codemirror mode="javascript" readOnly="true">
-        <![CDATA[ typeOverrides: any = { 'string=code': (value: any) => { if (typeof value !== 'string') { return false;
-        } const regex = new RegExp(/^<<(.*)>>$/, 's'); return regex.test(value); } }; ]]>
-      </ngx-codemirror>
-    </ngx-tab>
-  </ngx-tabs>
 </ngx-section>
+
+<ngx-section class="shadow" [sectionTitle]="'ngx-json-editor-flat'">
+  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"
+    >Toggle compressed mode</ngx-button
+  >
+  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="hideRoot = !hideRoot"
+    >Toggle hide root</ngx-button
+  >
+  
+  <ngx-json-editor-flat
+    [(model)]="jsonEditorModelFlat"
+    [schema]="jsonEditorSchema"
+    label="Model"
+    [typeCheckOverrides]="typeOverrides"
+    [compressed]="compressed"
+    [hideRoot]="hideRoot"
+    (schemaChange)="modelSchemaChange($event)"
+  >
+  </ngx-json-editor-flat>
+
+  <hr />
+  <h3>Model</h3>
+  <pre>{{ jsonEditorModelFlat | json }}</pre>
+  <h3>Schema</h3>
+  <pre>{{ modelSchemaRef | json }}</pre>
+</ngx-section>
+
+<br />
+
+<ngx-section class="shadow" [sectionTitle]="'Schema Builder Mode'">
+  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"
+    >Toggle compressed mode</ngx-button
+  >
+  <ngx-json-editor-flat
+    [(model)]="jsonEditorSchemaBuilderModel"
+    [schema]="{}"
+    label="Schema"
+    [compressed]="compressed"
+    [typeCheckOverrides]="typeOverrides"
+    [schemaBuilderMode]="true"
+    [formats]="customFormats"
+    (schemaChange)="schemaChange($event)"
+  >
+  </ngx-json-editor-flat>
+  <hr />
+  <h3>Schema</h3>
+  <pre>{{ schemaRef | json }}</pre>
+</ngx-section>
+
+<ngx-tabs>
+  <ngx-tab label="Markup">
+    <ngx-codemirror mode="htmlmixed" readOnly="true">
+      <![CDATA[ <ngx-json-editor [(model)]="jsonEditorModel" [schema]="jsonEditorSchema" label="Model"
+      [typeCheckOverrides]="typeOverrides"> </ngx-json-editor> ]]>
+    </ngx-codemirror>
+    <ngx-codemirror mode="htmlmixed" readOnly="true">
+      <![CDATA[ <ngx-json-editor-flat [(model)]="jsonEditorModel" [schema]="jsonEditorSchema" label="Model"
+      [typeCheckOverrides]="typeOverrides"> </ngx-json-editor-flat> ]]>
+    </ngx-codemirror>
+    <ngx-codemirror mode="htmlmixed" readOnly="true">
+      <![CDATA[ <ngx-json-editor-flat [(model)]="jsonEditorModel" [schema]="{}" label="Schema"
+      [typeCheckOverrides]="typeOverrides" [formats]="customFormats" [compressed]="compressed"
+      [schemaBuilderMode]="true" (schemaChange)="schemaChange($event)"> </ngx-json-editor-flat> ]]>
+    </ngx-codemirror>
+  </ngx-tab>
+  <ngx-tab label="Typescript">
+    <ngx-codemirror mode="javascript" readOnly="true">
+      <![CDATA[ typeOverrides: any = { 'string=code': (value: any) => { if (typeof value !== 'string') { return false;
+      } const regex = new RegExp(/^<<(.*)>>$/, 's'); return regex.test(value); } }; ]]>
+    </ngx-codemirror>
+  </ngx-tab>
+</ngx-tabs>

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -86,6 +86,7 @@ export class JsonEditorPageComponent {
   };
 
   compressed = false;
+  hideRoot = false;
 
   _jsonEditorSchema: any = {};
 


### PR DESCRIPTION
## Summary

- Feature: support dynamic `hideRoot` inputs
- Fix: required icon not showing for top level when `hideRoot` is true

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
