### PR TITLE
show all properties option

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (Unreleased)
 
+- Feature: allow showing all object properties by defualt
+
 ## 28.6.0 (2020-05-07)
 
 - Feature: New ngx-navbar component (#437)

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
@@ -11,6 +11,7 @@
     [compressed]="compressed"
     [formats]="customFormats"
     [schemaBuilderMode]="schemaBuilderMode"
+    [showAllObjectProperties]="showAllObjectProperties"
     (schemaChange)="schemaChange.emit($event)"
   >
     <div class="node-options" node-options>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
@@ -11,7 +11,7 @@
     [compressed]="compressed"
     [formats]="customFormats"
     [schemaBuilderMode]="schemaBuilderMode"
-    [showAllObjectProperties]="showAllObjectProperties"
+    [showKnownProperties]="showKnownProperties"
     (schemaChange)="schemaChange.emit($event)"
   >
     <div class="node-options" node-options>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.scss
@@ -5,7 +5,7 @@
   width: 100%;
 
   .node-options {
-    flex: 0 0 55px;
+    flex: 0 0 80px;
 
     .node-options-btn {
       color: $color-blue-grey-400;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
@@ -42,7 +42,7 @@ export class JsonEditorFlatComponent extends JsonEditor {
 
   @Input() hideRoot = false;
 
-  @Input() showAllObjectProperties = false;
+  @Input() showKnownProperties = false;
 
   @ContentChildren(JsonEditorNodeFlatComponent) nodeElms: QueryList<JsonEditorNodeFlatComponent>;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
@@ -41,6 +41,8 @@ export class JsonEditorFlatComponent extends JsonEditor {
 
   @Input() hideRoot = false;
 
+  @Input() showAllObjectProperties = false;
+
   @ContentChildren(JsonEditorNodeFlatComponent) nodeElms: QueryList<JsonEditorNodeFlatComponent>;
 
   @ViewChild('propertyConfigTmpl') propertyConfigTmpl: TemplateRef<PropertyConfigComponent>;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -23,15 +23,15 @@
       <div class="node-content" [class.extra-margin]="schema.nameEditable && !schemaBuilderMode">
         <div class="node-info">
           <!-- Property name/title -->
-          <div
+          <div 
             class="info-name"
             *ngIf="(!schema.nameEditable || schemaBuilderMode) && (schema?.propertyName || label || arrayItem)"
           >
             <span class="name">
               {{ schema?.title || label || (arrayItem ? 'Items' : (schema?.propertyName | titlecase)) }}
             </span>
+            
             <ngx-icon
-              *ngIf="schema?.description || schema?.examples"
               class="info-btn"
               fontIcon="info-filled"
               ngx-tooltip
@@ -51,11 +51,11 @@
                   <div class="label">Description</div>
                   <div>{{ description }}</div>
                 </div>
-                <div class="separator" *ngIf="model?.description && model?.examples"></div>
-                <div *ngIf="model?.examples">
+                <ng-container *ngIf="model?.examples">
+                  <div class="separator"></div>
                   <div class="label">Examples</div>
-                  <div *ngFor="let example of model?.examples">{{ example }}</div>
-                </div>
+                  <div *ngFor="let example of model?.examples">{{ example }}</div>          
+                </ng-container>
               </div>
             </ng-template>
           </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -199,7 +199,7 @@
       [compressed]="compressed"
       [schemaBuilderMode]="schemaBuilderMode"
       [formats]="formats"
-      [showAllObjectProperties]="showAllObjectProperties"
+      [showKnownProperties]="showKnownProperties"
       (schemaChange)="schemaChange.emit(schemaRef)"
     >
     </ngx-json-object-node-flat>
@@ -221,7 +221,7 @@
       [typeCheckOverrides]="typeCheckOverrides"
       [level]="nextLevel"
       [schemaBuilderMode]="schemaBuilderMode"
-      [showAllObjectProperties]="showAllObjectProperties"
+      [showKnownProperties]="showKnownProperties"
       (schemaChange)="schemaChange.emit(schemaRef)"
     >
     </ngx-json-array-node-flat>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -243,6 +243,7 @@
       [compressed]="compressed"
       [schemaBuilderMode]="schemaBuilderMode"
       [formats]="formats"
+      [showAllObjectProperties]="showAllObjectProperties"
       (schemaChange)="schemaChange.emit(schemaRef)"
     >
     </ngx-json-object-node-flat>
@@ -264,6 +265,7 @@
       [typeCheckOverrides]="typeCheckOverrides"
       [level]="level"
       [schemaBuilderMode]="schemaBuilderMode"
+      [showAllObjectProperties]="showAllObjectProperties"
       (schemaChange)="schemaChange.emit(schemaRef)"
     >
     </ngx-json-array-node-flat>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -22,67 +22,16 @@
 
       <div class="node-content" [class.extra-margin]="schema.nameEditable && !schemaBuilderMode">
         <div class="node-info">
-          <!-- Property name/title -->
-          <div 
-            class="info-name"
-            *ngIf="(!schema.nameEditable || schemaBuilderMode) && (schema?.propertyName || label || arrayItem)"
-          >
-            <span class="name">
-              {{ schema?.title || label || (arrayItem ? 'Items' : (schema?.propertyName | titlecase)) }}
-            </span>
-            
-            <ngx-icon
-              class="info-btn"
-              fontIcon="info-filled"
-              ngx-tooltip
-              [tooltipContext]="schema"
-              [tooltipType]="'popover'"
-              [tooltipPlacement]="'top'"
-              [tooltipTemplate]="popoverTemplate"
-            ></ngx-icon>
-
-            <ng-template #popoverTemplate let-model="model">
-              <div class="json-editor--popover-template">
-                <div *ngIf="schema?.title || label || (arrayItem ? 'Items' : (schema?.propertyName | titlecase)) as name">
-                  <div class="label">Name</div>
-                  <div>{{ name }}</div>
-                </div>
-                <div *ngIf="model?.description as description">
-                  <div class="label">Description</div>
-                  <div>{{ description }}</div>
-                </div>
-                <ng-container *ngIf="model?.examples">
-                  <div class="separator"></div>
-                  <div class="label">Examples</div>
-                  <div *ngFor="let example of model?.examples">{{ example }}</div>          
-                </ng-container>
-              </div>
-            </ng-template>
-          </div>
-
-          <!-- Inline text editing-->
-          <ngx-input
-            class="editable-name"
-            type="text"
-            *ngIf="schema.nameEditable && !schemaBuilderMode"
-            [ngModel]="schema?.propertyName"
-            (ngModelChange)="updatePropertyName(schema.id, $event)"
-          ></ngx-input>
-
-          <div class="info-type">
-            <span class="type"
-              >{{ schema?.format || schema?.type | titlecase }}{{ schema?.enum?.length ? ' + Enum' : '' }}</span
-            >
-            <ngx-icon
-              *ngIf="schema?.propertyName || arrayName"
-              class="dot-separator"
-              fontIcon="circle-filled"
-            ></ngx-icon>
-            <span class="property-name">{{ arrayName ? arrayName : schema?.propertyName }}</span>
-          </div>
-
-          <!-- Description -->
-          <span *ngIf="!compressed" class="description">{{ schema?.description }}</span>
+          <ngx-json-editor-node-info
+            [nameEditable]="schema.nameEditable && !schemaBuilderMode"
+            [propertyName]="arrayName ? arrayName : schema?.propertyName"
+            (propertyNameChange)="updatePropertyName(schema.id, $event)"
+            [title]="schema?.title || label || (arrayItem ? 'Items' : schema?.propertyName)"
+            [type]="(schema?.format || schema?.type | titlecase) + (schema?.enum?.length ? ' + Enum' : '')"
+            [description]="schema?.description"
+            [examples]="schema?.examples"
+            [compressed]="compressed">
+          </ngx-json-editor-node-info>
         </div>
 
         <div *ngIf="!schemaBuilderMode" class="node-input">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
@@ -6,6 +6,7 @@
   font-size: 12px;
   line-height: 13px;
   max-width: 300px;
+  color: $color-blue-grey-800;
 
   .label {
     color: $color-blue-grey-550;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
@@ -8,7 +8,7 @@
   max-width: 300px;
 
   .label {
-    color: $color-blue-grey-400;
+    color: $color-blue-grey-550;
     font-size: 10px;
     font-weight: bold;
     text-transform: uppercase;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
@@ -42,10 +42,11 @@ ngx-json-editor-node-flat {
     padding: 25px 10px;
     position: relative;
     flex: 0 1 100%;
+    height: 120px;
     min-width: 0; // https://css-tricks.com/flexbox-truncated-text/#the-solution-is-min-width-0-on-the-flex-child
 
     &.compressed {
-      max-height: 80px;
+      height: 80px;
     }
 
     .error-box {
@@ -111,73 +112,14 @@ ngx-json-editor-node-flat {
       }
 
       .node-info {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
         flex: 0 0 40%;
         padding-right: 25px;
         overflow: hidden;
-
-        .info-name {
-          display: flex;
-          align-items: baseline;
-
-          .info-btn {
-            color: $color-blue-grey-350;
-            font-size: 12px;
-            margin-left: 5px;
-            position: relative;
-            z-index: 1;
-            white-space: nowrap;
-          }
-        }
-
-        .name,
-        .editable-name input {
-          font-weight: 600;
-          font-size: 18px;
-          line-height: 23px;
-          color: #f0f1f6;
-        }
-
-        .name,
-        .description,
-        .info-type {
-          display: inline-block;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-          max-width: calc(100% - 30px);
-          overflow: hidden;
-        }
-
-        .property-name,
-        .dot-separator,
-        .description {
-          color: $color-blue-grey-250;
-        }
-
-        .dot-separator {
-          font-size: 0.2em;
-          margin: 0 5px;
-          vertical-align: middle;
-        }
-
-        .type {
-          color: #f0f1f6;
-        }
-
-        .editable-name {
-          margin: 0;
-          padding-top: 15px;
-
-          .ngx-input-hint {
-            display: none;
-          }
-        }
       }
 
       .node-input {
         flex: 0 1 60%;
+        padding-top: 1em;
 
         ngx-input {
           padding: 0;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
@@ -50,7 +50,7 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
 
   @Input() indentationArray: number[];
 
-  @Input() showAllObjectProperties = false;
+  @Input() showKnownProperties = false;
 
   @Output() updatePropertyNameEvent = new EventEmitter<{ id: string | number; name: string }>();
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
@@ -49,6 +49,8 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
 
   @Input() indentationArray: number[];
 
+  @Input() showAllObjectProperties = false;
+
   @Output() updatePropertyNameEvent = new EventEmitter<{ id: string | number; name: string }>();
 
   requiredIndicator: SafeHtml;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
@@ -20,6 +20,7 @@
       [arrayItem]="schemaBuilderMode"
       [arrayName]="(schema.title ? schema.title : schema.propertyName) + '[' + (schemaBuilderMode ? '' : i) + ']'"
       [indentationArray]="indentationArray"
+      [showAllObjectProperties]="showAllObjectProperties"
     >
       <div class="node-options" node-options>
         <button

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
@@ -20,7 +20,7 @@
       [arrayItem]="schemaBuilderMode"
       [arrayName]="(schema.title ? schema.title : schema.propertyName) + '[' + (schemaBuilderMode ? '' : i) + ']'"
       [indentationArray]="indentationArray"
-      [showAllObjectProperties]="showAllObjectProperties"
+      [showKnownProperties]="showKnownProperties"
     >
       <div class="node-options" node-options>
         <button

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
@@ -30,7 +30,7 @@ export class ArrayNodeFlatComponent extends ArrayNode implements OnInit {
 
   @Input() compressed: boolean;
 
-  @Input() hideRoot;
+  @Input() hideRoot = false;
 
   indentationArray: number[] = [];
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
@@ -5,7 +5,9 @@ import {
   ViewChild,
   TemplateRef,
   OnInit,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  SimpleChanges,
+  OnChanges
 } from '@angular/core';
 import { ArrayNode } from '../../../../node-types/array-node.component';
 import { JSONEditorSchema, JsonSchemaDataType, jsonSchemaDataTypes } from '../../../../json-editor.helper';
@@ -19,7 +21,7 @@ import { PropertyConfigOptions, PropertyConfigComponent } from '../property-conf
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ArrayNodeFlatComponent extends ArrayNode implements OnInit {
+export class ArrayNodeFlatComponent extends ArrayNode implements OnInit, OnChanges {
   @ViewChild('propertyConfigTmpl', { static: false }) propertyConfigTmpl: TemplateRef<PropertyConfigComponent>;
 
   @Input() level: number;
@@ -47,8 +49,13 @@ export class ArrayNodeFlatComponent extends ArrayNode implements OnInit {
       this.model.push(this.schemaRef.items);
     }
 
-    if (this.level > 0) {
-      this.indentationArray = Array(this.level).fill(this.level);
+    this.indentationArray = this.level > 0 ? Array(this.level).fill(this.level) : [];
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
+    if ('level' in changes) {
+      this.indentationArray = this.level > 0 ? Array(this.level).fill(this.level) : [];
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.html
@@ -1,0 +1,60 @@
+<!-- Property name/title -->
+<div class="info-name" *ngIf="!nameEditable && title">
+  <span class="name">
+    {{ title }}
+  </span>
+
+  <ngx-icon
+    class="info-btn"
+    fontIcon="info-filled"
+    ngx-tooltip
+    tooltipType="popover"
+    tooltipPlacement="top"
+    [tooltipTemplate]="popoverTemplate"
+  ></ngx-icon>
+
+  <ng-template #popoverTemplate>
+    <div class="json-editor--popover-template">
+      <div *ngIf="title">
+        <div class="label">Title</div>
+        <div>{{ title }}</div>
+      </div>
+      <div *ngIf="propertyName">
+        <div class="label">Name</div>
+        <div>{{ propertyName }}</div>
+      </div>
+      <div *ngIf="description">
+        <div class="label">Description</div>
+        <div>{{ description }}</div>
+      </div>
+      <ng-container *ngIf="examples">
+        <div class="separator"></div>
+        <div class="label">Examples</div>
+        <div *ngFor="let example of examples">{{ example }}</div>          
+      </ng-container>
+    </div>
+  </ng-template>
+</div>
+
+<!-- Inline text editing-->
+<ngx-input
+  class="editable-name"
+  type="text"
+  *ngIf="nameEditable"
+  [ngModel]="propertyName"
+  (ngModelChange)="propertyNameChange.emit($event)"
+></ngx-input>
+
+<!-- Type info -->
+<div class="info-type">
+  <span class="type">{{ type }}</span>
+  <ngx-icon
+    *ngIf="propertyName"
+    class="dot-separator"
+    fontIcon="circle-filled"
+  ></ngx-icon>
+  <span class="property-name">{{ propertyName }}</span>
+</div>
+
+<!-- Description -->
+<span *ngIf="!compressed" class="description">{{ description }}</span>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.html
@@ -26,8 +26,8 @@
         <div class="label">Description</div>
         <div>{{ description }}</div>
       </div>
-      <ng-container *ngIf="examples">
-        <div class="separator"></div>
+      <div *ngIf="(description && compressed) && examples?.length" class="separator"></div>
+      <ng-container *ngIf="examples?.length">
         <div class="label">Examples</div>
         <div *ngFor="let example of examples">{{ example }}</div>          
       </ng-container>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.html
@@ -1,10 +1,17 @@
 <!-- Property name/title -->
 <div class="info-name" *ngIf="!nameEditable && title">
-  <span class="name">
+  <span class="name"
+    ngx-tooltip
+    tooltipType="tooltip"
+    [tooltipTitle]="title"
+    [tooltipShowCaret]="false"
+    tooltipCssClass="narrow"
+    [tooltipShowTimeout]="750">
     {{ title }}
   </span>
 
   <ngx-icon
+    *ngIf="(description && compressed) || examples?.length"
     class="info-btn"
     fontIcon="info-filled"
     ngx-tooltip
@@ -15,15 +22,7 @@
 
   <ng-template #popoverTemplate>
     <div class="json-editor--popover-template">
-      <div *ngIf="title">
-        <div class="label">Title</div>
-        <div>{{ title }}</div>
-      </div>
-      <div *ngIf="propertyName">
-        <div class="label">Name</div>
-        <div>{{ propertyName }}</div>
-      </div>
-      <div *ngIf="description">
+      <div *ngIf="description && compressed">
         <div class="label">Description</div>
         <div>{{ description }}</div>
       </div>
@@ -53,8 +52,24 @@
     class="dot-separator"
     fontIcon="circle-filled"
   ></ngx-icon>
-  <span class="property-name">{{ propertyName }}</span>
+  <span class="property-name"
+    ngx-tooltip
+    tooltipType="tooltip"
+    [tooltipTitle]="propertyName"
+    [tooltipShowCaret]="false"
+    [tooltipShowTimeout]="750"
+    tooltipCssClass="narrow">
+      {{ propertyName }}
+    </span>
 </div>
 
 <!-- Description -->
-<span *ngIf="!compressed" class="description">{{ description }}</span>
+<span *ngIf="!compressed" class="description"
+  ngx-tooltip
+  tooltipType="tooltip"
+  [tooltipTitle]="description"
+  [tooltipShowCaret]="false"
+  [tooltipShowTimeout]="750"
+  tooltipCssClass="narrow">
+  {{ description }}
+</span>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.scss
@@ -1,0 +1,64 @@
+@import 'colors/variables';
+
+ngx-json-editor-node-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  .info-name {
+    display: flex;
+    align-items: baseline;
+
+    .info-btn {
+      color: $color-blue-grey-350;
+      font-size: 12px;
+      margin-left: 5px;
+      position: relative;
+      z-index: 1;
+      white-space: nowrap;
+    }
+  }
+
+  .name,
+  .editable-name input {
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 23px;
+    color: #f0f1f6;
+  }
+
+  .name,
+  .description,
+  .info-type {
+    display: inline-block;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: calc(100% - 30px);
+    overflow: hidden;
+  }
+
+  .property-name,
+  .dot-separator,
+  .description {
+    color: $color-blue-grey-250;
+  }
+
+  .dot-separator {
+    font-size: 0.2em;
+    margin: 0 5px;
+    vertical-align: middle;
+  }
+
+  .type {
+    color: #f0f1f6;
+  }
+
+  .editable-name {
+    margin: 0;
+    padding-top: 15px;
+
+    .ngx-input-hint {
+      display: none;
+    }
+  }
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.spec.ts
@@ -1,0 +1,25 @@
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { JsonEditorNodeInfoComponent } from './node-info.component';
+
+describe('JsonEditorNodeInfoComponent', () => {
+  let component: JsonEditorNodeInfoComponent;
+  let fixture: ComponentFixture<JsonEditorNodeInfoComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [JsonEditorNodeInfoComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(JsonEditorNodeInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.ts
@@ -1,0 +1,36 @@
+import { Component, Input, ViewEncapsulation, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  selector: 'ngx-json-editor-node-info',
+  templateUrl: './node-info.component.html',
+  styleUrls: ['./node-info.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class JsonEditorNodeInfoComponent {
+  @Input()
+  nameEditable = false;
+
+  @Input()
+  title: string;
+
+  @Input()
+  propertyName: string;
+
+  @Input()
+  description: string;
+
+  @Input()
+  type: string;
+
+  @Input()
+  examples: string[];
+
+  @Input()
+  compressed = false;
+
+  @Output() propertyNameChange = new EventEmitter<string>();
+
+  updatePropertyName() {
+    this.propertyNameChange.emit(name);
+  }
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-types.extensions.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-types.extensions.scss
@@ -5,6 +5,10 @@
   margin-bottom: 5px;
   position: relative;
 
+  &:last-child {
+    margin-bottom: 0;
+  }
+
   ngx-json-editor-node-flat {
     flex: 1;
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -27,7 +27,7 @@
       [formats]="formats"
       [compressed]="compressed"
       [indentationArray]="indentationArray"
-      [showAllObjectProperties]="showAllObjectProperties"
+      [showKnownProperties]="showKnownProperties"
       (schemaChange)="schemaChange.emit(schemaRef)"
       (updatePropertyNameEvent)="onUpdatePropertyName($event)"
     >
@@ -83,7 +83,7 @@
     ></div>
   </div>
 
-  <ng-container *ngIf="showAllObjectProperties">
+  <ng-container *ngIf="showKnownProperties">
     <ng-container *ngFor="let prop of schema.properties | keyvalue">
       <div class="node-container add-button add-prop-button" [class.compressed]="compressed" *ngIf="model[prop.key] === undefined">
 
@@ -126,7 +126,7 @@
     </ng-container>
   </ng-container>
 
-  <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level" *ngIf="!showAllObjectProperties || schema.additionalProperties !== false">
+  <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level" *ngIf="!showKnownProperties || schema.additionalProperties !== false">
     <span class="json-editor--vertical-separator" *ngFor="let separator of indentationArray"></span>
     <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">
@@ -137,7 +137,7 @@
           </button>
         </ngx-dropdown-toggle>
         <ngx-dropdown-menu class="ngx-dropdown-dark-outline">
-          <ul class="vertical-list dropdown-column" *ngIf="schema.properties && !schemaBuilderMode && !showAllObjectProperties">
+          <ul class="vertical-list dropdown-column" *ngIf="schema.properties && !schemaBuilderMode && !showKnownProperties">
             <li *ngFor="let prop of schema.properties | keyvalue" (click)="addSchemaProperty(prop.key)">
               <button [disabled]="model[prop.key] !== undefined" type="button">
                 {{ prop.value.title ? prop.value.title : prop.key }}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -41,7 +41,7 @@
           <i class="ngx-icon ngx-cog"></i>
         </button>
         <ngx-dropdown [showCaret]="true">
-          <ngx-dropdown-toggle *ngIf="canEdit">
+          <ngx-dropdown-toggle>
             <button type="button" class="node-options-btn">
               <i class="ngx-icon ngx-dots-vert-round"></i>
             </button>
@@ -83,7 +83,82 @@
     ></div>
   </div>
 
-  <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level" *ngIf="canEdit">
+  <ng-container *ngIf="showAllObjectProperties">
+    <ng-container *ngFor="let prop of schema.properties | keyvalue">
+      <div class="node-container add-button add-prop-button" *ngIf="model[prop.key] === undefined">
+
+        <span class="separator" *ngFor="let separator of indentationArray"></span>
+
+        <div class="node indented-content object-node-content" [class.compressed]="compressed" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
+
+          <div class="left-options">
+          </div>
+
+          <div class="node-content">
+
+            <div class="node-info">
+              <div class="info-name">
+                <span class="name">
+                  {{ prop.value.title ? prop.value.title : prop.key }}
+                </span>
+
+                <ngx-icon
+                  *ngIf="prop.value.description || prop.value.examples"
+                  class="info-btn"
+                  fontIcon="info-filled"
+                  ngx-tooltip
+                  [tooltipContext]="prop.value"
+                  tooltipType="popover"
+                  tooltipPlacement="top"
+                  [tooltipTemplate]="popoverTemplate"
+                ></ngx-icon>
+
+                <ng-template #popoverTemplate let-model="model">
+                  <div class="popover-template">
+                    <div *ngIf="model?.description">
+                      <div class="label">DESCRIPTION</div>
+                      <div>{{ model?.description }}</div>
+                    </div>
+                    <div class="separator" *ngIf="model?.description && model?.examples"></div>
+                    <div *ngIf="model?.examples">
+                      <div class="label">EXAMPLES</div>
+                      <div *ngFor="let example of model?.examples">{{ example }}</div>
+                    </div>
+                  </div>
+                </ng-template>              
+              </div>
+
+              <div class="info-type">
+                <span class="type"
+                  >{{ prop.value.format || prop.value.type | titlecase }}{{ prop.value.enum?.length ? ' + Enum' : '' }}</span
+                >
+                <ngx-icon
+                  *ngIf="prop.key"
+                  class="dot-separator"
+                  fontIcon="circle-filled"
+                ></ngx-icon>
+                <span class="property-name">{{ prop.key }}</span>
+              </div>
+
+              <span *ngIf="!compressed" class="description">{{ schema?.description }}</span>
+            </div>
+
+            <div class="node-input">
+              <button type="button" (click)="addSchemaProperty(prop.key)">
+                <i class="ngx-icon ngx-tree-expand"></i>
+                <span>Add property</span>
+              </button>              
+            </div>
+          
+          </div>
+
+        </div>
+
+      </div>
+    </ng-container>
+  </ng-container>
+
+  <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level" *ngIf="!showAllObjectProperties || schema.additionalProperties !== false">
     <span class="separator" *ngFor="let separator of indentationArray"></span>
     <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -54,7 +54,7 @@
                   (click)="deleteProperty(prop.propertyName)"
                   [disabled]="requiredCache[prop.propertyName] && !schemaBuilderMode"
                 >
-                  Delete
+                  {{ !schema.properties[prop.propertyName] ? 'Delete' : 'Remove' }}
                 </button>
               </li>
               <ng-container *ngIf="prop?.$meta?.type && !schemaBuilderMode">
@@ -89,7 +89,10 @@
 
         <span class="json-editor--vertical-separator" *ngFor="let separator of indentationArray"></span>
 
-        <div class="node indented-content object-node-content" [class.compressed]="compressed" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
+        <div class="node"
+          [class.compressed]="compressed"
+          [style.marginLeft]="level === 0 ? '20px' : '0'"
+          (click)="addSchemaProperty(prop.key)">
 
           <div class="left-options">
           </div>
@@ -97,54 +100,19 @@
           <div class="node-content">
 
             <div class="node-info">
-              <div class="info-name">
-                <span class="name">
-                  {{ prop.value.title ? prop.value.title : (prop.key | titlecase) }}
-                </span>
-
-                <ngx-icon
-                  class="info-btn"
-                  fontIcon="info-filled"
-                  ngx-tooltip
-                  [tooltipContext]="prop.value"
-                  tooltipType="popover"
-                  tooltipPlacement="top"
-                  [tooltipTemplate]="popoverTemplate"
-                ></ngx-icon>
-
-                <ng-template #popoverTemplate let-model="model">
-                  <div class="popover-template">
-                    <div *ngIf="model?.description">
-                      <div class="label">DESCRIPTION</div>
-                      <div>{{ model?.description }}</div>
-                    </div>
-                    <div class="separator" *ngIf="model?.description && model?.examples"></div>
-                    <div *ngIf="model?.examples">
-                      <div class="label">EXAMPLES</div>
-                      <div *ngFor="let example of model?.examples">{{ example }}</div>
-                    </div>
-                  </div>
-                </ng-template>              
-              </div>
-
-              <div class="info-type">
-                <span class="type"
-                  >{{ prop.value.format || prop.value.type | titlecase }}{{ prop.value.enum?.length ? ' + Enum' : '' }}</span
-                >
-                <ngx-icon
-                  *ngIf="prop.key"
-                  class="dot-separator"
-                  fontIcon="circle-filled"
-                ></ngx-icon>
-                <span class="property-name">{{ prop.key }}</span>
-              </div>
-
-               <!-- Description -->
-              <span *ngIf="!compressed" class="description">{{ prop.value?.description }}</span>
+              <ngx-json-editor-node-info
+                [nameEditable]="false"
+                [propertyName]="prop.key"
+                [title]="prop.value.title ? prop.value.title : prop.key"
+                [type]="(prop.value.format || prop.value.type | titlecase) + (prop.value.enum?.length ? ' + Enum' : '')"
+                [description]="prop.value?.description"
+                [examples]="prop.value.examples"
+                [compressed]="compressed">
+              </ngx-json-editor-node-info>
             </div>
 
-            <div class="node-input">
-              <button type="button" (click)="addSchemaProperty(prop.key)">
+            <div class="indented-content">
+              <button type="button">
                 <i class="ngx-icon ngx-tree-expand"></i>
                 <span>Add property</span>
               </button>              
@@ -169,7 +137,7 @@
           </button>
         </ngx-dropdown-toggle>
         <ngx-dropdown-menu class="ngx-dropdown-dark-outline">
-          <ul class="vertical-list dropdown-column" *ngIf="schema.properties && !schemaBuilderMode">
+          <ul class="vertical-list dropdown-column" *ngIf="schema.properties && !schemaBuilderMode && !showAllObjectProperties">
             <li *ngFor="let prop of schema.properties | keyvalue" (click)="addSchemaProperty(prop.key)">
               <button [disabled]="model[prop.key] !== undefined" type="button">
                 {{ prop.value.title ? prop.value.title : prop.key }}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -114,7 +114,7 @@
             <div class="indented-content">
               <button type="button">
                 <i class="ngx-icon ngx-tree-expand"></i>
-                <span>Add property</span>
+                <span>Include</span>
               </button>              
             </div>
           

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -85,9 +85,9 @@
 
   <ng-container *ngIf="showAllObjectProperties">
     <ng-container *ngFor="let prop of schema.properties | keyvalue">
-      <div class="node-container add-button add-prop-button" *ngIf="model[prop.key] === undefined">
+      <div class="node-container add-button add-prop-button" [class.compressed]="compressed" *ngIf="model[prop.key] === undefined">
 
-        <span class="separator" *ngFor="let separator of indentationArray"></span>
+        <span class="json-editor--vertical-separator" *ngFor="let separator of indentationArray"></span>
 
         <div class="node indented-content object-node-content" [class.compressed]="compressed" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
 
@@ -99,11 +99,10 @@
             <div class="node-info">
               <div class="info-name">
                 <span class="name">
-                  {{ prop.value.title ? prop.value.title : prop.key }}
+                  {{ prop.value.title ? prop.value.title : (prop.key | titlecase) }}
                 </span>
 
                 <ngx-icon
-                  *ngIf="prop.value.description || prop.value.examples"
                   class="info-btn"
                   fontIcon="info-filled"
                   ngx-tooltip
@@ -140,7 +139,8 @@
                 <span class="property-name">{{ prop.key }}</span>
               </div>
 
-              <span *ngIf="!compressed" class="description">{{ schema?.description }}</span>
+               <!-- Description -->
+              <span *ngIf="!compressed" class="description">{{ prop.value?.description }}</span>
             </div>
 
             <div class="node-input">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -27,6 +27,7 @@
       [formats]="formats"
       [compressed]="compressed"
       [indentationArray]="indentationArray"
+      [showAllObjectProperties]="showAllObjectProperties"
       (schemaChange)="schemaChange.emit(schemaRef)"
       (updatePropertyNameEvent)="onUpdatePropertyName($event)"
     >
@@ -40,7 +41,7 @@
           <i class="ngx-icon ngx-cog"></i>
         </button>
         <ngx-dropdown [showCaret]="true">
-          <ngx-dropdown-toggle>
+          <ngx-dropdown-toggle *ngIf="canEdit">
             <button type="button" class="node-options-btn">
               <i class="ngx-icon ngx-dots-vert-round"></i>
             </button>
@@ -82,7 +83,7 @@
     ></div>
   </div>
 
-  <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level">
+  <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level" *ngIf="canEdit">
     <span class="separator" *ngFor="let separator of indentationArray"></span>
     <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.scss
@@ -26,13 +26,13 @@
       margin-bottom: 0;
       justify-content: unset !important;
       background-color: rgba($color-blue-grey-700, 0.5);
-      opacity: 0.3;
+      opacity: 0.2;
       cursor: pointer;
       outline: 2px dotted rgba(red($color-blue-grey-650), green($color-blue-grey-650), blue($color-blue-grey-650), 0.5);
       outline-offset: -2px;
 
       &:hover {
-        opacity: 1;
+        opacity: 0.6;
       }
 
       .indented-content {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.scss
@@ -12,6 +12,28 @@
   .add-button {
     @extend %add-button;
   }
+
+  .add-prop-button {
+    background-color: rgba(red($color-blue-grey-700), green($color-blue-grey-700), blue($color-blue-grey-700), 0.4);
+    margin-bottom: 5px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    .object-node-content {
+      margin-bottom: 0;
+    }
+
+    .indented-content {
+      background-color: rgba($color-blue-grey-700, 0.5);
+      opacity: 0.3;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
 }
 
 .cdk-drag-preview {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.scss
@@ -16,22 +16,33 @@
   .add-prop-button {
     background-color: rgba(red($color-blue-grey-700), green($color-blue-grey-700), blue($color-blue-grey-700), 0.4);
     margin-bottom: 5px;
+    height: 120px;
 
     &:last-child {
       margin-bottom: 0;
     }
 
-    .object-node-content {
+    .node {
       margin-bottom: 0;
-    }
-
-    .indented-content {
+      justify-content: unset !important;
       background-color: rgba($color-blue-grey-700, 0.5);
       opacity: 0.3;
+      cursor: pointer;
+      outline: 2px dotted rgba(red($color-blue-grey-650), green($color-blue-grey-650), blue($color-blue-grey-650), 0.5);
+      outline-offset: -2px;
 
       &:hover {
         opacity: 1;
       }
+
+      .indented-content {
+        border: unset;
+        justify-content: start;
+      }
+    }
+
+    .node-input {
+      padding-top: 0 !important;
     }
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -6,7 +6,9 @@ import {
   TemplateRef,
   OnInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  SimpleChanges,
+  OnChanges
 } from '@angular/core';
 import { ObjectNode } from '../../../../node-types/object-node.component';
 import { DialogService } from '../../../../../dialog/dialog.service';
@@ -26,7 +28,7 @@ import { PropertyConfigOptions, PropertyConfigComponent } from '../property-conf
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ObjectNodeFlatComponent extends ObjectNode implements OnInit {
+export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnChanges {
   @ViewChild('propertyConfigTmpl', { static: false }) propertyConfigTmpl: TemplateRef<PropertyConfigComponent>;
 
   @Input() level: number;
@@ -57,8 +59,13 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit {
       this.initSchemaProperties(this.schemaRef);
     });
 
-    if (this.level > 0) {
-      this.indentationArray = Array(this.level).fill(this.level);
+    this.indentationArray = this.level > 0 ? Array(this.level).fill(this.level) : [];
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
+    if ('level' in changes) {
+      this.indentationArray = this.level > 0 ? Array(this.level).fill(this.level) : [];
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -37,7 +37,7 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit {
 
   @Input() compressed: boolean;
 
-  @Input() hideRoot;
+  @Input() hideRoot = false;
 
   indentationArray: number[] = [];
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-node.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-node.ts
@@ -29,7 +29,7 @@ export class JsonEditorNode implements OnInit, OnChanges {
 
   @Input() typeCheckOverrides?: any;
 
-  @Input() showAllObjectProperties = false;
+  @Input() showKnownProperties = false;
 
   @Output() modelChange: EventEmitter<any> = new EventEmitter();
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-node.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-node.ts
@@ -130,7 +130,6 @@ export class JsonEditorNode implements OnInit, OnChanges {
    * Inits the model if it is not defined
    */
   initModel(): void {
-    console.log('initModel', JSON.parse(JSON.stringify(this.model)));
     if (this.model !== undefined) {
       return;
     }
@@ -140,7 +139,6 @@ export class JsonEditorNode implements OnInit, OnChanges {
     }
 
     const value: any = createValueForSchema(this.schema);
-    console.log({ value });
 
     if (value !== undefined) {
       this.updateModel(value);
@@ -172,7 +170,6 @@ export class JsonEditorNode implements OnInit, OnChanges {
    * @param value
    */
   updateModel(value: any): void {
-    console.log('updateModel');
     this.model = value;
     this.modelChange.emit(this.model);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-node.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-node.ts
@@ -29,6 +29,8 @@ export class JsonEditorNode implements OnInit, OnChanges {
 
   @Input() typeCheckOverrides?: any;
 
+  @Input() showAllObjectProperties = false;
+
   @Output() modelChange: EventEmitter<any> = new EventEmitter();
 
   @Output() schemaChange: EventEmitter<JSONEditorSchema> = new EventEmitter();
@@ -128,6 +130,7 @@ export class JsonEditorNode implements OnInit, OnChanges {
    * Inits the model if it is not defined
    */
   initModel(): void {
+    console.log('initModel', JSON.parse(JSON.stringify(this.model)));
     if (this.model !== undefined) {
       return;
     }
@@ -137,6 +140,7 @@ export class JsonEditorNode implements OnInit, OnChanges {
     }
 
     const value: any = createValueForSchema(this.schema);
+    console.log({ value });
 
     if (value !== undefined) {
       this.updateModel(value);
@@ -168,6 +172,7 @@ export class JsonEditorNode implements OnInit, OnChanges {
    * @param value
    */
   updateModel(value: any): void {
+    console.log('updateModel');
     this.model = value;
     this.modelChange.emit(this.model);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.module.ts
@@ -28,6 +28,7 @@ import { ObjectNodeFlatComponent } from './json-editor-flat/json-editor-node-fla
 import { PropertyConfigComponent } from './json-editor-flat/json-editor-node-flat/node-types/property-config/property-config.component';
 import { OrderableInputsListComponent } from './json-editor-flat/orderable-inputs-list/orderable-inputs-list.component';
 import { ObjectValuesPipe } from './object-values.pipe';
+import { JsonEditorNodeInfoComponent } from './json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component';
 
 @NgModule({
   declarations: [
@@ -37,6 +38,7 @@ import { ObjectValuesPipe } from './object-values.pipe';
     ArrayNodeComponent,
     JsonEditorFlatComponent,
     JsonEditorNodeFlatComponent,
+    JsonEditorNodeInfoComponent,
     ArrayNodeFlatComponent,
     ObjectNodeFlatComponent,
     PropertyConfigComponent,
@@ -50,6 +52,7 @@ import { ObjectValuesPipe } from './object-values.pipe';
     ArrayNodeComponent,
     JsonEditorFlatComponent,
     JsonEditorNodeFlatComponent,
+    JsonEditorNodeInfoComponent,
     ArrayNodeFlatComponent,
     ObjectNodeFlatComponent,
     PropertyConfigComponent

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.ts
@@ -14,7 +14,7 @@ export class JsonEditor implements OnChanges {
 
   @Input() schemaValidator?: (schema: any, ...args: any[]) => any[];
 
-  @Input() showAllObjectProperties = false;
+  @Input() showKnownProperties = false;
 
   @Output() modelChange: EventEmitter<any> = new EventEmitter();
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.ts
@@ -23,10 +23,6 @@ export class JsonEditor implements OnChanges {
 
   constructor(protected schemaValidatorService: SchemaValidatorService) {}
 
-  ngOnInit() {
-    console.log('on init', JSON.parse(JSON.stringify(this.model)));
-  }
-
   ngOnChanges(changes: SimpleChanges) {
     if (changes.schema) {
       this.schema = JSON.parse(JSON.stringify(this.schema));

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.ts
@@ -13,6 +13,8 @@ export class JsonEditor implements OnChanges {
 
   @Input() schemaValidator?: (schema: any, ...args: any[]) => any[];
 
+  @Input() showAllObjectProperties = false;
+
   @Output() modelChange: EventEmitter<any> = new EventEmitter();
 
   @Output() schemaChange: EventEmitter<JSONEditorSchema> = new EventEmitter();
@@ -20,6 +22,10 @@ export class JsonEditor implements OnChanges {
   errors: any[];
 
   constructor(protected schemaValidatorService: SchemaValidatorService) {}
+
+  ngOnInit() {
+    console.log('on init', JSON.parse(JSON.stringify(this.model)));
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.schema) {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
@@ -39,7 +39,7 @@
         [path]="path"
         [errors]="childrenErrors"
         [typeCheckOverrides]="typeCheckOverrides"
-        [showAllObjectProperties]="showAllObjectProperties"
+        [showKnownProperties]="showKnownProperties"
       ></ngx-json-object-node>
     </div>
 
@@ -53,7 +53,7 @@
         [path]="path"
         [errors]="childrenErrors"
         [typeCheckOverrides]="typeCheckOverrides"
-        [showAllObjectProperties]="showAllObjectProperties"
+        [showKnownProperties]="showKnownProperties"
       ></ngx-json-array-node>
     </div>
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
@@ -39,6 +39,7 @@
         [path]="path"
         [errors]="childrenErrors"
         [typeCheckOverrides]="typeCheckOverrides"
+        [showAllObjectProperties]="showAllObjectProperties"
       ></ngx-json-object-node>
     </div>
 
@@ -52,6 +53,7 @@
         [path]="path"
         [errors]="childrenErrors"
         [typeCheckOverrides]="typeCheckOverrides"
+        [showAllObjectProperties]="showAllObjectProperties"
       ></ngx-json-array-node>
     </div>
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
@@ -20,6 +20,8 @@ export class JsonEditorNodeComponent extends JsonEditorNode {
 
   @Input() errors: any[];
 
+  @Input() showAllObjectProperties = false;
+
   placeholder: string = '';
 
   constructor(public dialogMngr: DialogService) {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
@@ -20,7 +20,7 @@ export class JsonEditorNodeComponent extends JsonEditorNode {
 
   @Input() errors: any[];
 
-  @Input() showAllObjectProperties = false;
+  @Input() showKnownProperties = false;
 
   placeholder: string = '';
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
@@ -30,6 +30,7 @@
       [path]="path + '[' + i + ']'"
       [errors]="errors"
       [typeCheckOverrides]="typeCheckOverrides"
+      [showAllObjectProperties]="showAllObjectProperties"
     >
     </ngx-json-editor-node>
   </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
@@ -30,7 +30,7 @@
       [path]="path + '[' + i + ']'"
       [errors]="errors"
       [typeCheckOverrides]="typeCheckOverrides"
-      [showAllObjectProperties]="showAllObjectProperties"
+      [showKnownProperties]="showKnownProperties"
     >
     </ngx-json-editor-node>
   </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
@@ -64,7 +64,7 @@
     </ngx-json-editor-node>
   </div>
 
-  <ngx-dropdown [showCaret]="true" *ngIf="canEdit">
+  <ngx-dropdown [showCaret]="true">
     <ngx-dropdown-toggle>
       <div class="add-button">
         <ngx-icon fontIcon="plus-bold"></ngx-icon>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
@@ -59,11 +59,12 @@
       [path]="path + getPath(prop.propertyName)"
       [errors]="errors"
       [typeCheckOverrides]="typeCheckOverrides"
+      [showAllObjectProperties]="showAllObjectProperties"
     >
     </ngx-json-editor-node>
   </div>
 
-  <ngx-dropdown [showCaret]="true">
+  <ngx-dropdown [showCaret]="true" *ngIf="canEdit">
     <ngx-dropdown-toggle>
       <div class="add-button">
         <ngx-icon fontIcon="plus-bold"></ngx-icon>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
@@ -59,7 +59,7 @@
       [path]="path + getPath(prop.propertyName)"
       [errors]="errors"
       [typeCheckOverrides]="typeCheckOverrides"
-      [showAllObjectProperties]="showAllObjectProperties"
+      [showKnownProperties]="showKnownProperties"
     >
     </ngx-json-editor-node>
   </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.html
@@ -15,7 +15,7 @@
     (modelChange)="modelChangedCallback($event)"
     [errors]="errors"
     [typeCheckOverrides]="typeCheckOverrides"
-    [showAllObjectProperties]="showAllObjectProperties"
+    [showKnownProperties]="showKnownProperties"
   >
   </ngx-json-editor-node>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.html
@@ -15,6 +15,7 @@
     (modelChange)="modelChangedCallback($event)"
     [errors]="errors"
     [typeCheckOverrides]="typeCheckOverrides"
+    [showAllObjectProperties]="showAllObjectProperties"
   >
   </ngx-json-editor-node>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/array-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/array-node.component.ts
@@ -30,6 +30,8 @@ export class ArrayNode implements OnChanges {
 
   @Input() schemaRef: JSONEditorSchema;
 
+  @Input() showAllObjectProperties = false;
+
   @Output() modelChange: EventEmitter<any[]> = new EventEmitter();
 
   @Output() schemaChange: EventEmitter<JSONEditorSchema> = new EventEmitter();

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/array-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/array-node.component.ts
@@ -30,7 +30,7 @@ export class ArrayNode implements OnChanges {
 
   @Input() schemaRef: JSONEditorSchema;
 
-  @Input() showAllObjectProperties = false;
+  @Input() showKnownProperties = false;
 
   @Output() modelChange: EventEmitter<any[]> = new EventEmitter();
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -39,10 +39,6 @@ export class ObjectNode implements OnInit, OnChanges {
 
   @Output() schemaChange: EventEmitter<JSONEditorSchema> = new EventEmitter();
 
-  get canEdit() {
-    return this.schemaBuilderMode || this.schema.additionalProperties !== false || !this.showAllObjectProperties;
-  }
-
   requiredCache: { [key: string]: boolean } = {};
 
   dataTypes: JsonSchemaDataType[] = [...jsonSchemaDataTypes, ...jsonSchemaDataFormats];
@@ -304,7 +300,7 @@ export class ObjectNode implements OnInit, OnChanges {
           continue;
         }
 
-        if (this.showAllObjectProperties || this.requiredCache[propName] || this.schemaBuilderMode) {
+        if (this.requiredCache[propName] || this.schemaBuilderMode) {
           // List all properties not only required if we are in schema builder mode
           this.addSchemaProperty(propName);
         }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -33,9 +33,15 @@ export class ObjectNode implements OnInit, OnChanges {
 
   @Input() schemaRef: JSONEditorSchema;
 
+  @Input() showAllObjectProperties = false;
+
   @Output() modelChange: EventEmitter<any> = new EventEmitter();
 
   @Output() schemaChange: EventEmitter<JSONEditorSchema> = new EventEmitter();
+
+  get canEdit() {
+    return this.schemaBuilderMode || this.schema.additionalProperties !== false || !this.showAllObjectProperties;
+  }
 
   requiredCache: { [key: string]: boolean } = {};
 
@@ -298,7 +304,7 @@ export class ObjectNode implements OnInit, OnChanges {
           continue;
         }
 
-        if (this.requiredCache[propName] || this.schemaBuilderMode) {
+        if (this.showAllObjectProperties || this.requiredCache[propName] || this.schemaBuilderMode) {
           // List all properties not only required if we are in schema builder mode
           this.addSchemaProperty(propName);
         }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -33,7 +33,7 @@ export class ObjectNode implements OnInit, OnChanges {
 
   @Input() schemaRef: JSONEditorSchema;
 
-  @Input() showAllObjectProperties = false;
+  @Input() showKnownProperties = false;
 
   @Output() modelChange: EventEmitter<any> = new EventEmitter();
 

--- a/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.component.scss
@@ -121,4 +121,8 @@ $popover-spacing: 10px;
     transition: opacity 0.3s, transform 0.3s;
     transform: translate3d(0, 0, 0);
   }
+
+  &.narrow {
+    max-width: 300px;
+  }
 }

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -1,4 +1,5 @@
 <h3 class="style-header">JSON Editor</h3>
+
 <ngx-section class="shadow" [sectionTitle]="'JSON Editor'">
   <ngx-tabs>
     <ngx-tab label="Editor">
@@ -23,6 +24,35 @@
       ></ngx-codemirror>
     </ngx-tab>
   </ngx-tabs>
+
+  <ngx-tabs>
+    <ngx-tab label="Markup">
+      <ngx-codemirror mode="htmlmixed" readOnly="true">
+        <![CDATA[ 
+        <ngx-json-editor
+          [(model)]="jsonEditorModel"
+          [schema]="jsonEditorSchema"
+          label="Model"
+          [typeCheckOverrides]="typeOverrides">
+        </ngx-json-editor> ]]>
+      </ngx-codemirror>
+    </ngx-tab>
+    <ngx-tab label="Typescript">
+      <ngx-codemirror mode="javascript" readOnly="true">
+        <![CDATA[
+          typeOverrides: any = { 
+            'string=code': (value: any) => {
+              if (typeof value !== 'string') {
+                return false;
+              }
+              const regex = new RegExp(/^<<(.*)>>$/, 's');
+              return regex.test(value);
+            }
+          }; ]]>
+      </ngx-codemirror>
+    </ngx-tab>
+  </ngx-tabs>
+
 </ngx-section>
 
 <ngx-section class="shadow" [sectionTitle]="'ngx-json-editor-flat'">
@@ -33,6 +63,64 @@
     >Toggle hide root</ngx-button
   >
   
+  <ngx-json-editor-flat
+    [(model)]="jsonEditorModelFlat"
+    [schema]="jsonEditorSchema"
+    label="Model"
+    [typeCheckOverrides]="typeOverrides"
+    [compressed]="compressed"
+    [hideRoot]="hideRoot"
+    (schemaChange)="modelSchemaChange($event)"
+  >
+  </ngx-json-editor-flat>
+
+  <hr />
+  <h3>Model</h3>
+  <pre>{{ jsonEditorModelFlat | json }}</pre>
+  <h3>Schema</h3>
+  <pre>{{ modelSchemaRef | json }}</pre>
+
+  <ngx-tabs>
+    <ngx-tab label="Markup">
+      <ngx-codemirror mode="htmlmixed" readOnly="true">
+        <![CDATA[
+        <ngx-json-editor-flat
+          [(model)]="jsonEditorModelFlat"
+          [schema]="jsonEditorSchema"
+          label="Model"
+          [typeCheckOverrides]="typeOverrides"
+          [compressed]="compressed"
+          [hideRoot]="hideRoot"
+          (schemaChange)="modelSchemaChange($event)">
+        </ngx-json-editor-flat>
+        ]]>
+      </ngx-codemirror>
+    </ngx-tab>
+    <ngx-tab label="Typescript">
+      <ngx-codemirror mode="javascript" readOnly="true">
+        <![CDATA[
+          typeOverrides: any = { 
+            'string=code': (value: any) => {
+              if (typeof value !== 'string') {
+                return false;
+              }
+              const regex = new RegExp(/^<<(.*)>>$/, 's');
+              return regex.test(value);
+            }
+          }; ]]>
+      </ngx-codemirror>
+    </ngx-tab>
+  </ngx-tabs>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="ngx-json-editor-flat w/ showAllObjectProperties">
+  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"
+    >Toggle compressed mode</ngx-button
+  >
+  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="hideRoot = !hideRoot"
+    >Toggle hide root</ngx-button
+  >
+
   <ngx-json-editor-flat
     [(model)]="jsonEditorModelFlat"
     [schema]="jsonEditorSchema"
@@ -50,6 +138,39 @@
   <pre>{{ jsonEditorModelFlat | json }}</pre>
   <h3>Schema</h3>
   <pre>{{ modelSchemaRef | json }}</pre>
+
+  <ngx-tabs>
+    <ngx-tab label="Markup">
+      <ngx-codemirror mode="htmlmixed" readOnly="true">
+        <![CDATA[
+        <ngx-json-editor-flat
+          [(model)]="jsonEditorModelFlat"
+          [schema]="jsonEditorSchema"
+          label="Model"
+          [typeCheckOverrides]="typeOverrides"
+          [showAllObjectProperties]="true"
+          [compressed]="compressed"
+          [hideRoot]="true"
+          (schemaChange)="modelSchemaChange($event)">
+        </ngx-json-editor-flat>
+        ]]>
+      </ngx-codemirror>
+    </ngx-tab>
+    <ngx-tab label="Typescript">
+      <ngx-codemirror mode="javascript" readOnly="true">
+        <![CDATA[
+          typeOverrides: any = { 
+            'string=code': (value: any) => {
+              if (typeof value !== 'string') {
+                return false;
+              }
+              const regex = new RegExp(/^<<(.*)>>$/, 's');
+              return regex.test(value);
+            }
+          }; ]]>
+      </ngx-codemirror>
+    </ngx-tab>
+  </ngx-tabs>
 </ngx-section>
 
 <br />
@@ -72,55 +193,37 @@
   <hr />
   <h3>Schema</h3>
   <pre>{{ schemaRef | json }}</pre>
+
+  <ngx-tabs>
+    <ngx-tab label="Markup">
+      <ngx-codemirror mode="htmlmixed" readOnly="true">
+        <![CDATA[
+        <ngx-json-editor-flat
+          [(model)]="jsonEditorSchemaBuilderModel"
+          [schema]="{}"
+          label="Schema"
+          [compressed]="compressed"
+          [typeCheckOverrides]="typeOverrides"
+          [schemaBuilderMode]="true"
+          [formats]="customFormats"
+          (schemaChange)="schemaChange($event)">
+        </ngx-json-editor-flat> ]]>
+      </ngx-codemirror>
+    </ngx-tab>
+    <ngx-tab label="Typescript">
+      <ngx-codemirror mode="javascript" readOnly="true">
+        <![CDATA[
+          typeOverrides: any = { 
+            'string=code': (value: any) => {
+              if (typeof value !== 'string') {
+                return false;
+              }
+              const regex = new RegExp(/^<<(.*)>>$/, 's');
+              return regex.test(value);
+            }
+          }; ]]>
+      </ngx-codemirror>
+    </ngx-tab>
+  </ngx-tabs>
 </ngx-section>
 
-<ngx-tabs>
-  <ngx-tab label="Markup">
-    <ngx-codemirror mode="htmlmixed" readOnly="true">
-      <![CDATA[ 
-      <ngx-json-editor
-        [(model)]="jsonEditorModel"
-        [schema]="jsonEditorSchema"
-        label="Model"
-        [typeCheckOverrides]="typeOverrides">
-      </ngx-json-editor> ]]>
-    </ngx-codemirror>
-    <ngx-codemirror mode="htmlmixed" readOnly="true">
-      <![CDATA[
-      <ngx-json-editor-flat
-        [(model)]="jsonEditorModel"
-        [schema]="jsonEditorSchema"
-        label="Model"
-        [typeCheckOverrides]="typeOverrides">
-      </ngx-json-editor-flat>
-      ]]>
-    </ngx-codemirror>
-    <ngx-codemirror mode="htmlmixed" readOnly="true">
-      <![CDATA[
-      <ngx-json-editor-flat
-        [(model)]="jsonEditorModel"
-        [schema]="{}"
-        label="Schema"
-        [typeCheckOverrides]="typeOverrides"
-        [formats]="customFormats"
-        [compressed]="compressed"
-        [schemaBuilderMode]="true"
-        (schemaChange)="schemaChange($event)"> 
-      </ngx-json-editor-flat> ]]>
-    </ngx-codemirror>
-  </ngx-tab>
-  <ngx-tab label="Typescript">
-    <ngx-codemirror mode="javascript" readOnly="true">
-      <![CDATA[
-        typeOverrides: any = { 
-          'string=code': (value: any) => {
-            if (typeof value !== 'string') {
-              return false;
-            }
-            const regex = new RegExp(/^<<(.*)>>$/, 's');
-            return regex.test(value);
-          }
-        }; ]]>
-    </ngx-codemirror>
-  </ngx-tab>
-</ngx-tabs>

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -58,7 +58,7 @@
 <ngx-section class="shadow" [sectionTitle]="'ngx-json-editor-flat'">
   <ngx-toggle
     [(ngModel)]="compressed"
-    label="Compressed mode">
+    label="Compressed Mode">
   </ngx-toggle>
 
   <ngx-toggle
@@ -67,8 +67,8 @@
   </ngx-toggle>
 
   <ngx-toggle
-    [(ngModel)]="showAllObjectProperties"
-    label="Show All Object Properties">
+    [(ngModel)]="showKnownProperties"
+    label="Show Known Object Properties">
   </ngx-toggle>
 
   <ngx-json-editor-flat
@@ -78,7 +78,7 @@
     [typeCheckOverrides]="typeOverrides"
     [compressed]="compressed"
     [hideRoot]="hideRoot"
-    [showAllObjectProperties]="showAllObjectProperties"
+    [showKnownProperties]="showKnownProperties"
     (schemaChange)="modelSchemaChange($event)"
   >
   </ngx-json-editor-flat>
@@ -100,7 +100,7 @@
           [typeCheckOverrides]="typeOverrides"
           [compressed]="compressed"
           [hideRoot]="hideRoot"
-          [showAllObjectProperties]="showAllObjectProperties"
+          [showKnownProperties]="showKnownProperties"
           (schemaChange)="modelSchemaChange($event)">
         </ngx-json-editor-flat>
         ]]>

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -17,11 +17,16 @@
       </ngx-section>
 
       <ngx-section class="shadow" [sectionTitle]="'ngx-json-editor-flat'">
+        <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"
+          >Toggle compressed mode</ngx-button
+        >
         <ngx-json-editor-flat
           [(model)]="jsonEditorModelFlat"
           [schema]="jsonEditorSchema"
           label="Model"
           [typeCheckOverrides]="typeOverrides"
+          [compressed]="compressed"
+          [showAllObjectProperties]="true"
           (schemaChange)="modelSchemaChange($event)"
         >
         </ngx-json-editor-flat>

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -56,13 +56,21 @@
 </ngx-section>
 
 <ngx-section class="shadow" [sectionTitle]="'ngx-json-editor-flat'">
-  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"
-    >Toggle compressed mode</ngx-button
-  >
-  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="hideRoot = !hideRoot"
-    >Toggle hide root</ngx-button
-  >
-  
+  <ngx-toggle
+    [(ngModel)]="compressed"
+    label="Compressed mode">
+  </ngx-toggle>
+
+  <ngx-toggle
+    [(ngModel)]="hideRoot"
+    label="Hide Root">
+  </ngx-toggle>
+
+  <ngx-toggle
+    [(ngModel)]="showAllObjectProperties"
+    label="Show All Object Properties">
+  </ngx-toggle>
+
   <ngx-json-editor-flat
     [(model)]="jsonEditorModelFlat"
     [schema]="jsonEditorSchema"
@@ -70,6 +78,7 @@
     [typeCheckOverrides]="typeOverrides"
     [compressed]="compressed"
     [hideRoot]="hideRoot"
+    [showAllObjectProperties]="showAllObjectProperties"
     (schemaChange)="modelSchemaChange($event)"
   >
   </ngx-json-editor-flat>
@@ -91,66 +100,7 @@
           [typeCheckOverrides]="typeOverrides"
           [compressed]="compressed"
           [hideRoot]="hideRoot"
-          (schemaChange)="modelSchemaChange($event)">
-        </ngx-json-editor-flat>
-        ]]>
-      </ngx-codemirror>
-    </ngx-tab>
-    <ngx-tab label="Typescript">
-      <ngx-codemirror mode="javascript" readOnly="true">
-        <![CDATA[
-          typeOverrides: any = { 
-            'string=code': (value: any) => {
-              if (typeof value !== 'string') {
-                return false;
-              }
-              const regex = new RegExp(/^<<(.*)>>$/, 's');
-              return regex.test(value);
-            }
-          }; ]]>
-      </ngx-codemirror>
-    </ngx-tab>
-  </ngx-tabs>
-</ngx-section>
-
-<ngx-section class="shadow" sectionTitle="ngx-json-editor-flat w/ showAllObjectProperties">
-  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"
-    >Toggle compressed mode</ngx-button
-  >
-  <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="hideRoot = !hideRoot"
-    >Toggle hide root</ngx-button
-  >
-
-  <ngx-json-editor-flat
-    [(model)]="jsonEditorModelFlat"
-    [schema]="jsonEditorSchema"
-    label="Model"
-    [typeCheckOverrides]="typeOverrides"
-    [showAllObjectProperties]="true"
-    [compressed]="compressed"
-    [hideRoot]="hideRoot"
-    (schemaChange)="modelSchemaChange($event)"
-  >
-  </ngx-json-editor-flat>
-
-  <hr />
-  <h3>Model</h3>
-  <pre>{{ jsonEditorModelFlat | json }}</pre>
-  <h3>Schema</h3>
-  <pre>{{ modelSchemaRef | json }}</pre>
-
-  <ngx-tabs>
-    <ngx-tab label="Markup">
-      <ngx-codemirror mode="htmlmixed" readOnly="true">
-        <![CDATA[
-        <ngx-json-editor-flat
-          [(model)]="jsonEditorModelFlat"
-          [schema]="jsonEditorSchema"
-          label="Model"
-          [typeCheckOverrides]="typeOverrides"
-          [showAllObjectProperties]="true"
-          [compressed]="compressed"
-          [hideRoot]="true"
+          [showAllObjectProperties]="showAllObjectProperties"
           (schemaChange)="modelSchemaChange($event)">
         </ngx-json-editor-flat>
         ]]>

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -59,9 +59,13 @@ export class JsonEditorPageComponent {
           },
           height: {
             type: 'number'
+          },
+          name: {
+            type: 'string'
           }
         },
-        required: ['length', 'width', 'height']
+        required: ['length', 'width', 'height'],
+        additionalProperties: false
       },
       warehouseLocation: {
         description: 'Coordinates of the warehouse where the product is located.',

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -90,34 +90,9 @@ export class JsonEditorPageComponent {
     required: ['productId', 'productName', 'price', 'availability', 'onSale', 'dimensions']
   };
 
-  jsonEditorSchema2 = {
-    $schema: 'http://json-schema.org/draft-07/schema#',
-    title: 'Product',
-    description: "A product from Acme's catalog",
-    type: 'object',
-    properties: {
-      given: {
-        type: 'string',
-        description: 'Given (first) name'
-      },
-      middle: {
-        type: 'string',
-        description: 'Middle name'
-      },
-      family: {
-        type: 'string',
-        description: 'Family (last) name'
-      },
-      age: {
-        type: 'integer'
-      }
-    },
-    additionalProperties: false,
-    required: ['given', 'family']
-  };
-
   compressed = false;
   hideRoot = false;
+  showAllObjectProperties = false;
 
   _jsonEditorSchema: any = {};
 
@@ -130,8 +105,6 @@ export class JsonEditorPageComponent {
   };
 
   jsonEditorSchemaBuilderModel: any = {};
-
-  jsonEditorModelFlat2: any = {};
 
   schemaRef: JSONSchema7 = {};
   modelSchemaRef: JSONSchema7 = {};

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -58,13 +58,11 @@ export class JsonEditorPageComponent {
             type: 'number'
           },
           height: {
-            type: 'number'
-          },
-          name: {
-            type: 'string'
+            type: 'number',
+            description: 'Height if dimensions are a volume'
           }
         },
-        required: ['length', 'width', 'height'],
+        required: ['length', 'width'],
         additionalProperties: false
       },
       warehouseLocation: {
@@ -89,6 +87,32 @@ export class JsonEditorPageComponent {
     required: ['productId', 'productName', 'price', 'availability', 'onSale', 'dimensions']
   };
 
+  jsonEditorSchema2 = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Product',
+    description: "A product from Acme's catalog",
+    type: 'object',
+    properties: {
+      given: {
+        type: 'string',
+        description: 'Given (first) name'
+      },
+      middle: {
+        type: 'string',
+        description: 'Middle name'
+      },
+      family: {
+        type: 'string',
+        description: 'Family (last) name'
+      },
+      age: {
+        type: 'integer'
+      }
+    },
+    additionalProperties: false,
+    required: ['given', 'family']
+  };
+
   compressed = false;
   hideRoot = false;
 
@@ -103,6 +127,8 @@ export class JsonEditorPageComponent {
   };
 
   jsonEditorSchemaBuilderModel: any = {};
+
+  jsonEditorModelFlat2: any = {};
 
   schemaRef: JSONSchema7 = {};
   modelSchemaRef: JSONSchema7 = {};

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -92,7 +92,7 @@ export class JsonEditorPageComponent {
 
   compressed = false;
   hideRoot = false;
-  showAllObjectProperties = false;
+  showKnownProperties = false;
 
   _jsonEditorSchema: any = {};
 


### PR DESCRIPTION
## Summary

- Added option to show all properties on an object
- Shows placeholder for optionl properties defined in schema but not in model
- Hides new property and when show all properties and additionalProperties is false
- Hide known properties column in dropdown when `showAllObjectProperties` is true

![image](https://user-images.githubusercontent.com/509946/84453307-da4ca180-ac14-11ea-944c-58e8da94d355.png)

- click on whole node to add property

![image](https://user-images.githubusercontent.com/509946/84453467-11bb4e00-ac15-11ea-9ac6-8f0afe6c1ab0.png)

- known properties say remove instead of delete in action dropdown

![image](https://user-images.githubusercontent.com/509946/84453518-3a434800-ac15-11ea-961b-938632641943.png)

- in both compressed and expanded views node height is fixed.

https://www.screencast.com/t/nAK68ntEEY

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
