### PR TITLE
Add isNotEmpty keyword to default SchemaValidator

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (Unreleased)
 
+- Feature: Added isNotEmpty validation to schema validator
+
 ## 28.6.0 (2020-05-07)
 
 - Feature: New ngx-navbar component (#437)

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
@@ -11,6 +11,24 @@ export class SchemaValidatorService {
     });
     this.ajv.addFormat('password', '.*');
     this.ajv.addFormat('code', '.*');
+
+    this.ajv.addKeyword('isNotEmpty', {
+      type: 'string',
+      validate: function myValidation(_schema: any, data: any) {
+        if ((myValidation as any).errors === null) (myValidation as any).errors = [];
+
+        if (typeof data === 'string' && data.trim() === '') {
+          (myValidation as any).errors.push({
+            keyword: 'isNotEmpty',
+            message: 'required',
+            params: { keyword: 'isNotEmpty' }
+          });
+          return false;
+        }
+        return true;
+      },
+      errors: true
+    });
   }
 
   /**

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -23,7 +23,8 @@ export class JsonEditorPageComponent {
       productName: {
         description: 'Name of the product',
         type: 'string',
-        examples: ['Apples', 'Oranges']
+        examples: ['Apples', 'Oranges'],
+        isNotEmpty: true
       },
       price: {
         description: 'The price of the product',


### PR DESCRIPTION
## Summary

- Added `isNotEmpty` validation to schema validator

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
