### PR TITLE
Allow add new value on selects when filter query matches some options

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
@@ -36,6 +36,23 @@
           <span *ngIf="!kv.option.optionTemplate" [innerHTML]="kv.option.name"> </span>
         </li>
         <li
+          *ngIf="filterQuery && group.options?.length && !filterQueryIsInOptions"
+          class="ngx-select-empty-placeholder"
+        >
+          <a
+            *ngIf="allowAdditions"
+            href="#"
+            class="ngx-select-add-current-value"
+            (click)="onAddClicked($event, filterQuery)"
+          >
+            <span *ngIf="isNotTemplate; else tpl" [innerHTML]="allowAdditionsText"> </span>
+            <ng-template #tpl>
+              <ng-container *ngTemplateOutlet="allowAdditionsText"></ng-container>
+            </ng-template>
+          </a>
+        </li>
+
+        <li
           *ngIf="filterQuery && filterEmptyPlaceholder && !group.options?.length"
           class="ngx-select-empty-placeholder"
         >

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -116,6 +116,10 @@ export class SelectDropdownComponent implements AfterViewInit {
     return !(typeof this.allowAdditionsText === 'object' && this.allowAdditionsText instanceof TemplateRef);
   }
 
+  get filterQueryIsInOptions() {
+    return this.options.some(o => o.name === this.filterQuery);
+  }
+
   groups: any[];
 
   private _options: SelectDropdownOption[];

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -15,7 +15,7 @@ import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coerci
 import { KeyboardKeys } from '../../enums/keyboard-keys.enum';
 import { containsFilter } from './contains-filter.util';
 import { SelectDropdownOption } from './select-dropdown-option.interface';
-import { debounceable } from '@swimlane/ngx-ui/decorators/debounceable/debounceable.decorator';
+import { debounceable } from '../../decorators/debounceable/debounceable.decorator';
 
 @Component({
   exportAs: 'ngxSelectDropdown',

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -376,6 +376,13 @@ $color-chip-text: $color-grey-100;
         font-style: normal;
         float: right;
       }
+      .ngx-select-add-current-value {
+        font-style: normal;
+        span {
+          text-align: right;
+          display: block;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

When using the `allowAdditions` property on the select component, when the filter query string matches one of the options, the user has no way of adding a new value until the filterQuery does not match any of the options. At that point the `add new value` element is available and a new value can be added. This fix introduces the possibility to the user of adding a new value even when the filterQuery matches at least one option.

Before:

![image](https://user-images.githubusercontent.com/62297014/83464928-7fa29100-a42f-11ea-90d8-5b1de5cc685e.png)

After:

![image](https://user-images.githubusercontent.com/62297014/83464966-98ab4200-a42f-11ea-9c21-a38876e383a3.png)


## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
