### PR TITLE
fix resize overlay leak css

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (Unreleased)
 
+- Fix: resize-overlay component css leak issues
+
 ## 28.6.2 (2020-05-29)
 
 - Fix: errors in flat JSON editor not being updated on changes

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/resize-overlay.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/resize-overlay.component.html
@@ -1,4 +1,5 @@
 <ngx-overlay
+  class="resize-overlay"
   [class.visible]="!disabled && (visible$ | async)"
   [visible]="!disabled && (visible$ | async)"
   [zIndex]="10000"

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/resize-overlay.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/resize-overlay.component.scss
@@ -1,6 +1,6 @@
 @import 'colors/variables';
 
-ngx-overlay {
+.resize-overlay {
   .ngx-overlay {
     opacity: 1 !important;
     background-color: rgba(0, 0, 0, 0);


### PR DESCRIPTION
## Summary

Fix resize overlay leak css

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
