### PR TITLE
Source Sans Pro fonts now defined with `font-display: swap` for better UX

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (Unreleased)
 
+- Feature: Source Sans Pro fonts now defined with `font-display: swap` for better UX
+
 ## 28.6.3 (2020-06-04)
 
 - Fix: resize-overlay component css leak issues

--- a/projects/swimlane/ngx-ui/src/lib/styles/fonts/source-sans.scss
+++ b/projects/swimlane/ngx-ui/src/lib/styles/fonts/source-sans.scss
@@ -11,12 +11,14 @@ $source-sans-stack: 'Source Sans Pro', 'Open Sans', Arial, sans-serif;
   font-family: $font-name;
   font-style: normal;
   src: url('#{$font-src}/#{$font-filename}-Regular.ttf') format('truetype');
+  font-display: swap;
 }
 
 @font-face {
   font-family: $font-name;
   font-style: italic;
   src: url('#{$font-src}/#{$font-filename}-Italic.ttf') format('truetype');
+  font-display: swap;
 }
 
 @font-face {
@@ -24,6 +26,7 @@ $source-sans-stack: 'Source Sans Pro', 'Open Sans', Arial, sans-serif;
   font-weight: 300;
   font-style: normal;
   src: url('#{$font-src}/#{$font-filename}-Light.ttf') format('truetype');
+  font-display: swap;
 }
 
 @font-face {
@@ -31,6 +34,7 @@ $source-sans-stack: 'Source Sans Pro', 'Open Sans', Arial, sans-serif;
   font-weight: 300;
   font-style: italic;
   src: url('#{$font-src}/#{$font-filename}-LightItalic.ttf') format('truetype');
+  font-display: swap;
 }
 
 @font-face {
@@ -38,6 +42,7 @@ $source-sans-stack: 'Source Sans Pro', 'Open Sans', Arial, sans-serif;
   font-weight: 600;
   font-style: normal;
   src: url('#{$font-src}/#{$font-filename}-Semibold.ttf') format('truetype');
+  font-display: swap;
 }
 
 @font-face {
@@ -45,6 +50,7 @@ $source-sans-stack: 'Source Sans Pro', 'Open Sans', Arial, sans-serif;
   font-weight: 600;
   font-style: italic;
   src: url('#{$font-src}/#{$font-filename}-SemiboldItalic.ttf') format('truetype');
+  font-display: swap;
 }
 
 @font-face {
@@ -52,6 +58,7 @@ $source-sans-stack: 'Source Sans Pro', 'Open Sans', Arial, sans-serif;
   font-weight: bold;
   font-style: normal;
   src: url('#{$font-src}/#{$font-filename}-Bold.ttf') format('truetype');
+  font-display: swap;
 }
 
 @font-face {
@@ -59,4 +66,5 @@ $source-sans-stack: 'Source Sans Pro', 'Open Sans', Arial, sans-serif;
   font-weight: bold;
   font-style: italic;
   src: url('#{$font-src}/#{$font-filename}-BoldItalic.ttf') format('truetype');
+  font-display: swap;
 }

--- a/scripts/prep-global-styles.js
+++ b/scripts/prep-global-styles.js
@@ -23,7 +23,7 @@ const copyDir = dir =>
 
 const compileCss = () =>
   new Promise((resolve, reject) => {
-    console.log('Compliing index.css...');
+    console.log('Compiling index.css...');
     fs.readFile('dist/swimlane/ngx-ui/lib/styles/index.scss', (err, data) => {
       if (err) {
         return reject(err);


### PR DESCRIPTION

## Summary

- Ensure text remains visible during webfont load (https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools)

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
