### PR TITLE
Adjsut flat JSON editor layout

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.scss
@@ -2,8 +2,11 @@
 
 .ngx-json-editor-flat {
   position: relative;
+  width: 100%;
 
   .node-options {
+    flex: 0 0 55px;
+
     .node-options-btn {
       color: $color-blue-grey-400;
       padding: 1px 3px 2px;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -214,7 +214,10 @@
             </ng-template>
           </ng-container>
 
-          <div class="input-error" *ngFor="let error of ownErrors">{{ error.message }}</div>
+          <div class="input-error">
+            <span *ngFor="let error of ownErrors">{{ error.message }}</span>
+          </div>
+
         </div>
 
         <div *ngIf="schemaBuilderMode" class="node-constrains">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -28,7 +28,7 @@
             *ngIf="(!schema.nameEditable || schemaBuilderMode) && (schema?.propertyName || label || arrayItem)"
           >
             <span class="name">
-              {{ schema?.title || label || (arrayItem ? 'Items' : schema?.propertyName) }}
+              {{ schema?.title || label || (arrayItem ? 'Items' : (schema?.propertyName | titlecase)) }}
             </span>
             <ngx-icon
               *ngIf="schema?.description || schema?.examples"
@@ -42,14 +42,18 @@
             ></ngx-icon>
 
             <ng-template #popoverTemplate let-model="model">
-              <div class="popover-template">
-                <div *ngIf="model?.description">
-                  <div class="label">DESCRIPTION</div>
-                  <div>{{ model?.description }}</div>
+              <div class="json-editor--popover-template">
+                <div *ngIf="schema?.title || label || (arrayItem ? 'Items' : (schema?.propertyName | titlecase)) as name">
+                  <div class="label">Name</div>
+                  <div>{{ name }}</div>
+                </div>
+                <div *ngIf="model?.description as description">
+                  <div class="label">Description</div>
+                  <div>{{ description }}</div>
                 </div>
                 <div class="separator" *ngIf="model?.description && model?.examples"></div>
                 <div *ngIf="model?.examples">
-                  <div class="label">EXAMPLES</div>
+                  <div class="label">Examples</div>
                   <div *ngFor="let example of model?.examples">{{ example }}</div>
                 </div>
               </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
@@ -1,15 +1,17 @@
 @import 'colors/variables';
 @import '../../json-editor.extensions.scss';
 
-.popover-template {
+.json-editor--popover-template {
   font-weight: 600;
   font-size: 12px;
   line-height: 13px;
+  max-width: 300px;
 
   .label {
     color: $color-blue-grey-400;
     font-size: 10px;
     font-weight: bold;
+    text-transform: uppercase;
   }
 
   .separator {
@@ -18,10 +20,14 @@
   }
 }
 
+ngx-json-editor-node-flat {
+  max-width: 100%;
+}
+
 .json-tree-node-flat {
   .indentation {
     @extend %indentation;
-    min-width: 20px;
+    flex: 1 0 20px;
   }
 
   .node-container {
@@ -35,7 +41,8 @@
     display: flex;
     padding: 25px 10px;
     position: relative;
-    flex: 1;
+    flex: 0 1 100%;
+    min-width: 0; // https://css-tricks.com/flexbox-truncated-text/#the-solution-is-min-width-0-on-the-flex-child
 
     &.compressed {
       max-height: 80px;
@@ -57,7 +64,7 @@
       justify-content: center;
       margin-right: 10px;
       color: $color-blue-grey-400;
-      width: 15px;
+      flex: 0 0 15px;
 
       .required-indicator {
         position: absolute;
@@ -95,8 +102,9 @@
     .node-content {
       display: flex;
       justify-content: space-between;
-      flex: 1;
+      flex: 0 0 100%;
       align-items: center;
+      min-width: 0;
 
       &.extra-margin {
         margin-top: -15px;
@@ -106,15 +114,22 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
-        flex-basis: 30%;
+        flex: 0 0 40%;
         padding-right: 25px;
+        overflow: hidden;
 
-        .info-name .info-btn {
-          color: $color-blue-grey-350;
-          font-size: 12px;
-          margin-left: 5px;
-          position: relative;
-          z-index: 1;
+        .info-name {
+          display: flex;
+          align-items: baseline;
+
+          .info-btn {
+            color: $color-blue-grey-350;
+            font-size: 12px;
+            margin-left: 5px;
+            position: relative;
+            z-index: 1;
+            white-space: nowrap;
+          }
         }
 
         .name,
@@ -123,6 +138,16 @@
           font-size: 18px;
           line-height: 23px;
           color: #f0f1f6;
+        }
+
+        .name,
+        .description,
+        .info-type {
+          display: inline-block;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          max-width: calc(100% - 30px);
+          overflow: hidden;
         }
 
         .property-name,
@@ -152,7 +177,7 @@
       }
 
       .node-input {
-        flex: 1;
+        flex: 0 1 60%;
 
         ngx-input {
           padding: 0;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.scss
@@ -207,6 +207,7 @@ ngx-json-editor-node-flat {
 
         .input-error {
           color: $color-red-500;
+          min-height: 1.2em; // min height keeps input from shifing when error is shown
         }
       }
     }

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -1,5 +1,5 @@
 <h3 class="style-header">JSON Editor</h3>
-<ngx-section class="shadow" [sectionTitle]="'JSON Editor'">
+<!-- <ngx-section class="shadow" [sectionTitle]="'JSON Editor'">
   <ngx-tabs>
     <ngx-tab label="Editor">
       <ngx-json-editor
@@ -23,7 +23,7 @@
       ></ngx-codemirror>
     </ngx-tab>
   </ngx-tabs>
-</ngx-section>
+</ngx-section> -->
 
 <ngx-section class="shadow" [sectionTitle]="'ngx-json-editor-flat'">
   <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -1,5 +1,5 @@
 <h3 class="style-header">JSON Editor</h3>
-<!-- <ngx-section class="shadow" [sectionTitle]="'JSON Editor'">
+<ngx-section class="shadow" [sectionTitle]="'JSON Editor'">
   <ngx-tabs>
     <ngx-tab label="Editor">
       <ngx-json-editor
@@ -23,7 +23,7 @@
       ></ngx-codemirror>
     </ngx-tab>
   </ngx-tabs>
-</ngx-section> -->
+</ngx-section>
 
 <ngx-section class="shadow" [sectionTitle]="'ngx-json-editor-flat'">
   <ngx-button class="btn btn-primary" [style.marginBottom]="'8px'" (click)="toggleCompressed()"

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -17,6 +17,7 @@ export class JsonEditorPageComponent {
         type: ['string', 'string=code', 'number', 'object']
       },
       productId: {
+        title: 'The unique identifier for a product',
         description: 'The unique identifier for a product',
         type: 'number'
       },


### PR DESCRIPTION
## Summary

- Nodes are not 40/60 between info and input.
- Info lines no longer warp and truncate with ellipsies
- Inputs now keep position when error is shown

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
