### PR TITLE
Fix style leak from json-editor--horizontal-separator

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -83,7 +83,7 @@
   </div>
 
   <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level">
-    <span class="separator" *ngFor="let separator of indentationArray"></span>
+    <span class="json-editor--horizontal-separator" *ngFor="let separator of indentationArray"></span>
     <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">
         <ngx-dropdown-toggle>


### PR DESCRIPTION
## Summary

Fix style leak from JSON editor horizontal-separator

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
