### PR TITLE
Validate on change

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD (Unreleased)
 
 - Feature: Source Sans Pro fonts now defined with `font-display: swap` for better UX
+- Fix: Text inputs in flat JSON editor now trigger validation on change.
 
 ## 28.6.3 (2020-06-04)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -112,7 +112,7 @@
                 *ngIf="!schema?.enum"
                 type="text"
                 [ngModel]="model"
-                (change)="updateModel($event)"
+                (ngModelChange)="updateModel($event)"
                 [requiredIndicator]="false"
                 [required]="required"
               >

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -23,7 +23,9 @@ export class JsonEditorPageComponent {
       productName: {
         description: 'Name of the product',
         type: 'string',
-        examples: ['Apples', 'Oranges']
+        examples: ['Apples', 'Oranges'],
+        minLength: 3,
+        maxLength: 20
       },
       price: {
         description: 'The price of the product',


### PR DESCRIPTION
## Summary

With this PR validation is trigger when text input changes, rather than on blur.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
