### PR TITLE
Only add add value li when allow additions is set to true

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
@@ -36,15 +36,10 @@
           <span *ngIf="!kv.option.optionTemplate" [innerHTML]="kv.option.name"> </span>
         </li>
         <li
-          *ngIf="filterQuery && group.options?.length && !filterQueryIsInOptions"
+          *ngIf="allowAdditions && filterQuery && group.options?.length && !filterQueryIsInOptions"
           class="ngx-select-empty-placeholder"
         >
-          <a
-            *ngIf="allowAdditions"
-            href="#"
-            class="ngx-select-add-current-value"
-            (click)="onAddClicked($event, filterQuery)"
-          >
+          <a href="#" class="ngx-select-add-current-value" (click)="onAddClicked($event, filterQuery)">
             <span *ngIf="isNotTemplate; else tpl" [innerHTML]="allowAdditionsText"> </span>
             <ng-template #tpl>
               <ng-container *ngTemplateOutlet="allowAdditionsText"></ng-container>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
@@ -1,10 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, flush, fakeAsync } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA, ElementRef } from '@angular/core';
 import * as faker from 'faker';
 
 import { KeyboardKeys } from '../../enums/keyboard-keys.enum';
 import { SelectDropdownComponent } from './select-dropdown.component';
 import { selectDropdownOptionMock } from './select-dropdown-option.mock';
+import { By } from '@angular/platform-browser';
 
 describe('SelectDropdownComponent', () => {
   let component: SelectDropdownComponent;
@@ -163,6 +164,85 @@ describe('SelectDropdownComponent', () => {
       component.onInputKeyUp(event);
       expect(component.filterQuery).toEqual('');
     });
+
+    it('should call updatefilterQueryIsInOptions', fakeAsync(() => {
+      const spy = spyOnProperty(component, 'updatefilterQueryIsInOptions').and.callThrough();
+      component.onInputKeyUp(event);
+      flush();
+      fixture.detectChanges();
+      expect(spy).toHaveBeenCalled();
+    }));
+
+    it('should set filterQueryIsInOptions to false if filterQuery does not equal any of the options name property', fakeAsync(() => {
+      component.onInputKeyUp(event);
+      flush();
+      fixture.detectChanges();
+      expect(component.filterQueryIsInOptions).toBeFalsy();
+    }));
+
+    it('should set filterQueryIsInOptions to true if filterQuery equals one of the options name property', fakeAsync(() => {
+      event.target.value = component.groups[0].options[0].option.name;
+      component.onInputKeyUp(event);
+      flush();
+      fixture.detectChanges();
+      expect(component.filterQueryIsInOptions).toBeTruthy();
+    }));
+
+    it('should display Add Value button when allow additions is true and there is at least still one option on dropdown', fakeAsync(() => {
+      event.target.value = component.groups[0].options[0].option.name.substring(0, 2);
+      component.allowAdditions = true;
+      component.filterable = true;
+
+      component.onInputKeyUp(event);
+      flush();
+      fixture.detectChanges();
+      const allowAdditionsButton = fixture.debugElement.queryAll(By.css('.ngx-select-empty-placeholder'));
+      expect(allowAdditionsButton[0].nativeElement).toBeDefined();
+      expect(allowAdditionsButton[0].nativeElement.innerText).toBe('Add Value');
+    }));
+
+    it('should not display Add Value button when allow additions is false', fakeAsync(() => {
+      event.target.value = component.groups[0].options[0].option.name.substring(0, 2);
+      component.allowAdditions = false;
+      component.filterable = true;
+
+      component.onInputKeyUp(event);
+      flush();
+      fixture.detectChanges();
+      const allowAdditionsButton = fixture.debugElement.queryAll(By.css('.ngx-select-empty-placeholder'));
+      expect(allowAdditionsButton.length).toEqual(0);
+    }));
+
+    it('should display the filterEmptyPlaceholder text and Add Value button when there are no options', fakeAsync(() => {
+      event.target.value = `${component.groups[0].options[0].option.name} + dummyText`;
+      component.allowAdditions = true;
+      component.filterable = true;
+      component.filterEmptyPlaceholder = 'No Matches';
+
+      component.onInputKeyUp(event);
+      flush();
+      fixture.detectChanges();
+      const allowAdditionsButton = fixture.debugElement.queryAll(By.css('.ngx-select-empty-placeholder'));
+
+      expect(allowAdditionsButton.length).toEqual(1);
+      expect(allowAdditionsButton[0].nativeElement.children[0].innerText).toEqual('No Matches');
+      expect(allowAdditionsButton[0].nativeElement.children[1].innerText).toEqual('Add Value');
+    }));
+
+    it('should only display the filterEmptyPlaceholder text when there are no options and allowAddition is false', fakeAsync(() => {
+      event.target.value = `${component.groups[0].options[0].option.name} + dummyText`;
+      component.allowAdditions = false;
+      component.filterable = true;
+      component.filterEmptyPlaceholder = 'No Matches';
+
+      component.onInputKeyUp(event);
+      flush();
+      fixture.detectChanges();
+      const allowAdditionsButton = fixture.debugElement.queryAll(By.css('.ngx-select-empty-placeholder'));
+
+      expect(allowAdditionsButton.length).toEqual(1);
+      expect(allowAdditionsButton[0].nativeElement.children.length).toEqual(1);
+    }));
   });
 
   describe('onOptionKeyDown', () => {


### PR DESCRIPTION
## Summary

Only display the Add Value `<li>` when the `allowAdditions` flag is set to true. Currently, when a user is filtering and the `allowAdditions` flag is false, the `<li>` is still being added with nothing inside it. 

Before:

![image](https://user-images.githubusercontent.com/62297014/86054887-333f7680-ba18-11ea-8461-16fea237f0c4.png)

After:

![image](https://user-images.githubusercontent.com/62297014/86054928-45211980-ba18-11ea-84dc-7e89058f37fb.png)


## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
