### PR TITLE
SPT-6965/fill-input

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD (Unreleased)
 
+- Feature: autosize input width
+- Feature: fill input style
+- Feature: sm, md, lg input sizing
+
 ## 29.1.0 (2020-06-29)
 
 - Feature: Show step labels in horizontal stepper

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-animations.constant.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-animations.constant.ts
@@ -1,0 +1,38 @@
+import { trigger, state, style, transition, animate } from '@angular/animations';
+
+export const INPUT_ANIMATIONS = [
+  trigger('labelState', [
+    state(
+      'inside',
+      style({
+        'font-size': '1em',
+        top: '0'
+      })
+    ),
+    state(
+      'outside',
+      style({
+        'font-size': '.7rem',
+        top: '-15px'
+      })
+    ),
+    transition('inside => outside', animate('150ms ease-out')),
+    transition('outside => inside', animate('150ms ease-out'))
+  ]),
+  trigger('underlineState', [
+    state(
+      'collapsed',
+      style({
+        width: '0%'
+      })
+    ),
+    state(
+      'expanded',
+      style({
+        width: '100%'
+      })
+    ),
+    transition('collapsed => expanded', animate('150ms ease-out')),
+    transition('expanded => collapsed', animate('150ms ease-out'))
+  ])
+];

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosave.directive.fixture.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosave.directive.fixture.ts
@@ -1,15 +1,34 @@
-import { Component, ChangeDetectionStrategy, ViewChild } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 
 import { AutosizeDirective } from './input-autosize.directive';
+import { InputTypes } from './input-types.enum';
 
 @Component({
   selector: `ngx-input-autosize-fixture`,
-  template: ` <textarea [(ngModel)]="value" autosize></textarea> `,
+  template: `
+    <input #input *ngIf="(type$ | async) === 'text'" [(ngModel)]="value" [autosize]="enabled$ | async" />
+    <textarea
+      #textarea
+      *ngIf="(type$ | async) === 'textarea'"
+      [(ngModel)]="value"
+      [autosize]="enabled$ | async"
+    ></textarea>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AutosizeDirectiveFixture {
   value = 'test';
 
-  @ViewChild(AutosizeDirective, { static: false })
+  readonly type$ = new BehaviorSubject<InputTypes>(InputTypes.text);
+  readonly enabled$ = new BehaviorSubject<boolean>(true);
+
+  @ViewChild(AutosizeDirective)
   readonly autosize: AutosizeDirective;
+
+  @ViewChild('input')
+  readonly input?: ElementRef<HTMLInputElement>;
+
+  @ViewChild('textarea')
+  readonly textarea?: ElementRef<HTMLTextAreaElement>;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosave.directive.fixture.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosave.directive.fixture.ts
@@ -7,7 +7,13 @@ import { InputTypes } from './input-types.enum';
 @Component({
   selector: `ngx-input-autosize-fixture`,
   template: `
-    <input #input *ngIf="(type$ | async) === 'text'" [(ngModel)]="value" [autosize]="enabled$ | async" />
+    <input
+      #input
+      [style.max-width.px]="maxWidth$ | async"
+      *ngIf="(type$ | async) === 'text'"
+      [(ngModel)]="value"
+      [autosize]="enabled$ | async"
+    />
     <textarea
       #textarea
       *ngIf="(type$ | async) === 'textarea'"
@@ -22,6 +28,7 @@ export class AutosizeDirectiveFixture {
 
   readonly type$ = new BehaviorSubject<InputTypes>(InputTypes.text);
   readonly enabled$ = new BehaviorSubject<boolean>(true);
+  readonly maxWidth$ = new BehaviorSubject<number>(undefined);
 
   @ViewChild(AutosizeDirective)
   readonly autosize: AutosizeDirective;

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
@@ -2,9 +2,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import * as faker from 'faker';
 
 import { AutosizeDirective } from './input-autosize.directive';
 import { AutosizeDirectiveFixture } from './input-autosave.directive.fixture';
+import { InputTypes } from './input-types.enum';
 
 describe('AutosizeDirective', () => {
   let component: AutosizeDirectiveFixture;
@@ -26,5 +28,65 @@ describe('AutosizeDirective', () => {
 
   it('should be defined', () => {
     expect(component).toBeDefined();
+  });
+
+  it('should be enabled', () => {
+    expect(component.autosize?.enabled).toBeTruthy();
+  });
+
+  describe('input', () => {
+    beforeEach(() => {
+      component.type$.next(InputTypes.text);
+      fixture.detectChanges();
+    });
+
+    it('should be defined', () => {
+      expect(component.input.nativeElement).toBeTruthy();
+    });
+
+    it('should set width on input', () => {
+      component.input.nativeElement.value = faker.random.words(5);
+      component.input.nativeElement.dispatchEvent(new Event('input'));
+      expect(component.input.nativeElement.scrollWidth).toEqual(component.input.nativeElement.clientWidth);
+    });
+
+    it('should do nothing when disabled', () => {
+      component.enabled$.next(false);
+      fixture.detectChanges();
+
+      component.input.nativeElement.value = faker.random.words(5);
+      component.input.nativeElement.dispatchEvent(new Event('input'));
+
+      expect(component.input.nativeElement.scrollWidth).not.toEqual(component.input.nativeElement.clientWidth);
+    });
+  });
+
+  describe('textarea', () => {
+    beforeEach(() => {
+      component.type$.next(InputTypes.textarea);
+      fixture.detectChanges();
+    });
+
+    it('should be defined', () => {
+      expect(component.textarea.nativeElement).toBeTruthy();
+    });
+
+    it('should set height on input', () => {
+      component.textarea.nativeElement.value = faker.random.words(500);
+      component.textarea.nativeElement.dispatchEvent(new Event('input'));
+      expect(component.textarea.nativeElement.scrollHeight - 2).toEqual(component.textarea.nativeElement.clientHeight);
+    });
+
+    it('should do nothing when disabled', () => {
+      component.enabled$.next(false);
+      fixture.detectChanges();
+
+      component.textarea.nativeElement.value = faker.random.words(500);
+      component.textarea.nativeElement.dispatchEvent(new Event('input'));
+
+      expect(component.textarea.nativeElement.scrollHeight - 2).not.toEqual(
+        component.textarea.nativeElement.clientHeight
+      );
+    });
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
@@ -47,6 +47,8 @@ describe('AutosizeDirective', () => {
     it('should set width on input', () => {
       component.input.nativeElement.value = faker.random.words(5);
       component.input.nativeElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
       expect(component.input.nativeElement.scrollWidth).toEqual(component.input.nativeElement.clientWidth);
     });
 
@@ -56,8 +58,21 @@ describe('AutosizeDirective', () => {
 
       component.input.nativeElement.value = faker.random.words(5);
       component.input.nativeElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
 
       expect(component.input.nativeElement.scrollWidth).not.toEqual(component.input.nativeElement.clientWidth);
+    });
+
+    it('should not extend past max width', () => {
+      component.maxWidth$.next(100);
+      fixture.detectChanges();
+
+      component.input.nativeElement.value = faker.random.words(500);
+      component.input.nativeElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(component.input.nativeElement.style.maxWidth).toEqual('100px');
+      expect(component.input.nativeElement.clientWidth).toBeLessThanOrEqual(component.input.nativeElement.scrollWidth);
     });
   });
 
@@ -74,6 +89,8 @@ describe('AutosizeDirective', () => {
     it('should set height on input', () => {
       component.textarea.nativeElement.value = faker.random.words(500);
       component.textarea.nativeElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
       expect(component.textarea.nativeElement.scrollHeight - 2).toEqual(component.textarea.nativeElement.clientHeight);
     });
 
@@ -83,6 +100,7 @@ describe('AutosizeDirective', () => {
 
       component.textarea.nativeElement.value = faker.random.words(500);
       component.textarea.nativeElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
 
       expect(component.textarea.nativeElement.scrollHeight - 2).not.toEqual(
         component.textarea.nativeElement.clientHeight

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
@@ -27,11 +27,4 @@ describe('AutosizeDirective', () => {
   it('should be defined', () => {
     expect(component).toBeDefined();
   });
-
-  it('should adjust size on input', () => {
-    const spy = spyOn(component.autosize, 'adjust');
-    component.value = 'ttttttttttttttttttttttttttttttttttt';
-    component.autosize.onInput();
-    expect(spy).toHaveBeenCalled();
-  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
@@ -49,7 +49,7 @@ describe('AutosizeDirective', () => {
       component.input.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
 
-      expect(component.input.nativeElement.scrollWidth).toEqual(component.input.nativeElement.clientWidth);
+      expect(component.input.nativeElement.style.width).not.toEqual('auto');
     });
 
     it('should do nothing when disabled', () => {
@@ -74,6 +74,14 @@ describe('AutosizeDirective', () => {
       expect(component.input.nativeElement.style.maxWidth).toEqual('100px');
       expect(component.input.nativeElement.clientWidth).toBeLessThanOrEqual(component.input.nativeElement.scrollWidth);
     });
+
+    it('should set width auto when no scroll', () => {
+      component.input.nativeElement.value = 't';
+      component.input.nativeElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(component.input.nativeElement.style.width).toEqual('auto');
+    });
   });
 
   describe('textarea', () => {
@@ -91,7 +99,15 @@ describe('AutosizeDirective', () => {
       component.textarea.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
 
-      expect(component.textarea.nativeElement.scrollHeight).toEqual(component.textarea.nativeElement.offsetHeight);
+      expect(component.textarea.nativeElement.style.height).not.toEqual('auto');
+    });
+
+    it('should set height auto when no scroll', () => {
+      component.textarea.nativeElement.value = faker.random.words(3);
+      component.textarea.nativeElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(component.textarea.nativeElement.style.height).toEqual('auto');
     });
 
     it('should do nothing when disabled', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
@@ -91,7 +91,7 @@ describe('AutosizeDirective', () => {
       component.textarea.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
 
-      expect(component.textarea.nativeElement.scrollHeight - 2).toEqual(component.textarea.nativeElement.clientHeight);
+      expect(component.textarea.nativeElement.scrollHeight).toEqual(component.textarea.nativeElement.offsetHeight);
     });
 
     it('should do nothing when disabled', () => {
@@ -102,9 +102,7 @@ describe('AutosizeDirective', () => {
       component.textarea.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
 
-      expect(component.textarea.nativeElement.scrollHeight - 2).not.toEqual(
-        component.textarea.nativeElement.clientHeight
-      );
+      expect(component.textarea.nativeElement.scrollHeight).not.toEqual(component.textarea.nativeElement.offsetHeight);
     });
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
@@ -1,25 +1,16 @@
-import { ElementRef, HostListener, Directive, AfterContentChecked, Renderer2 } from '@angular/core';
+import { ElementRef, HostListener, Directive } from '@angular/core';
 
 @Directive({
   // tslint:disable-next-line:directive-selector
   exportAs: 'ngxAutosize',
   selector: 'textarea[autosize]'
 })
-export class AutosizeDirective implements AfterContentChecked {
-  constructor(public element: ElementRef, private renderer: Renderer2) {}
-
-  ngAfterContentChecked(): void {
-    this.adjust();
-  }
+export class AutosizeDirective {
+  constructor(readonly element: ElementRef<HTMLElement>) {}
 
   @HostListener('input', ['$event.target'])
   onInput(_?: HTMLTextAreaElement): void {
-    this.adjust();
-  }
-
-  adjust(): void {
     const height = this.element.nativeElement.scrollHeight + 'px';
-    this.renderer.setStyle(this.element.nativeElement, 'overflow', 'hidden');
-    this.renderer.setStyle(this.element.nativeElement, 'height', height);
+    this.element.nativeElement.style.height = height;
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
@@ -28,13 +28,18 @@ export class AutosizeDirective {
 
   onInput() {
     if (this._enabled) {
-      const height = this.element.nativeElement.scrollHeight + 'px';
-      const width = this.element.nativeElement.scrollWidth + 'px';
-
       if (this.nodeName === 'TEXTAREA') {
-        this.element.nativeElement.style.height = height;
+        this.element.nativeElement.style.height = 'auto';
+
+        if (this.element.nativeElement.clientHeight < this.element.nativeElement.scrollHeight) {
+          this.element.nativeElement.style.height = `${this.element.nativeElement.scrollHeight}px`;
+        }
       } else {
-        this.element.nativeElement.style.width = width;
+        this.element.nativeElement.style.width = 'auto';
+
+        if (this.element.nativeElement.clientWidth < this.element.nativeElement.scrollWidth) {
+          this.element.nativeElement.style.width = `${this.element.nativeElement.scrollWidth}px`;
+        }
       }
     }
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
@@ -1,16 +1,41 @@
-import { ElementRef, HostListener, Directive } from '@angular/core';
+import { ElementRef, Directive, Input } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 @Directive({
   // tslint:disable-next-line:directive-selector
   exportAs: 'ngxAutosize',
-  selector: 'textarea[autosize]'
+  selector: 'textarea[autosize], input[autosize]',
+  host: {
+    class: 'ngx-autosize',
+    '(input)': 'onInput()'
+  }
 })
 export class AutosizeDirective {
+  @Input('autosize')
+  get enabled() {
+    return this._enabled;
+  }
+  set enabled(v: boolean) {
+    this._enabled = coerceBooleanProperty(v);
+  }
+  private _enabled = false;
+
+  get nodeName() {
+    return this.element.nativeElement.nodeName as 'TEXTAREA' | 'INPUT';
+  }
+
   constructor(readonly element: ElementRef<HTMLElement>) {}
 
-  @HostListener('input', ['$event.target'])
-  onInput(_?: HTMLTextAreaElement): void {
-    const height = this.element.nativeElement.scrollHeight + 'px';
-    this.element.nativeElement.style.height = height;
+  onInput() {
+    if (this._enabled) {
+      const height = this.element.nativeElement.scrollHeight + 'px';
+      const width = this.element.nativeElement.scrollWidth + 'px';
+
+      if (this.nodeName === 'TEXTAREA') {
+        this.element.nativeElement.style.height = height;
+      } else {
+        this.element.nativeElement.style.width = width;
+      }
+    }
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.fixture.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.fixture.ts
@@ -20,12 +20,14 @@ import { InputTypes } from './input-types.enum';
       [spellcheck]="spellcheck$ | async"
       [min]="min$ | async"
       [max]="max$ | async"
+      [autosize]="autosize$ | async"
     ></ngx-input>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class InputComponentFixture {
   value: string | number = 'test';
+
   readonly type$ = new BehaviorSubject(InputTypes.text);
   readonly disabled$ = new BehaviorSubject(false);
   readonly passwordTextVisible$ = new BehaviorSubject(false);
@@ -37,6 +39,7 @@ export class InputComponentFixture {
   readonly spellcheck$ = new BehaviorSubject(true);
   readonly min$ = new BehaviorSubject<number>(undefined);
   readonly max$ = new BehaviorSubject<number>(undefined);
+  readonly autosize$ = new BehaviorSubject<boolean>(false);
 
   @ViewChild(InputComponent, { static: false })
   readonly input: InputComponent;

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
@@ -38,8 +38,8 @@
           [placeholder]="placeholder"
           [disabled]="disabled"
           [type]="type$ | async"
-          [min]="'' + min"
-          [max]="'' + max"
+          [min]="min"
+          [max]="max"
           [minlength]="minlength"
           [maxlength]="maxlength"
           [attr.tabindex]="tabindex"
@@ -64,7 +64,8 @@
         </span>
       </div>
       <span class="ngx-input-label" [@labelState]="labelState">
-        <span [innerHTML]="label"></span> <span [innerHTML]="requiredIndicatorView"></span>
+        <span [innerHTML]="label"></span>&nbsp;
+        <span *ngIf="required && requiredIndicator" [innerHTML]="requiredIndicator"></span>
       </span>
     </div>
     <ng-content select="ngx-input-suffix"></ng-content>

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
@@ -32,6 +32,7 @@
         <input
           *ngIf="type !== 'textarea'"
           class="ngx-input-box"
+          [autosize]="autosize"
           [(ngModel)]="value"
           [id]="id"
           [name]="name"

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -10,6 +10,7 @@ $input-placeholder-color: $color-blue-grey-350;
 
 .ngx-input {
   display: block;
+  max-width: 100%;
   margin-top: 16px;
   margin-bottom: 8px;
   padding-top: 20px;
@@ -73,6 +74,10 @@ $input-placeholder-color: $color-blue-grey-350;
     }
   }
 
+  &.autosize {
+    display: inline-block;
+  }
+
   // override chrome autofill styles
   input:-webkit-autofill,
   input:-webkit-autofill:hover,
@@ -89,6 +94,7 @@ $input-placeholder-color: $color-blue-grey-350;
     .ngx-input-flex-wrap-inner {
       display: flex;
       flex: 1;
+      max-width: 100%;
     }
 
     ngx-input-suffix,
@@ -136,6 +142,7 @@ $input-placeholder-color: $color-blue-grey-350;
         margin-bottom: 0px;
         padding-left: 0px;
         width: 100%;
+        max-width: 100%;
         color: $color-blue-grey-100;
         font-size: 16px;
         line-height: 20px;

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -1,7 +1,7 @@
 @import 'colors/variables';
 @import 'forms/inputs';
 
-$input-hint-color: $color-blue-grey-300;
+$input-hint-color: $color-blue-grey-350;
 $input-invalid-color: $color-red;
 $input-active-underline-fill: $color-blue;
 $input-inactive-underline-fill: $color-blue-grey-500;
@@ -130,13 +130,15 @@ $input-placeholder-color: $color-blue-grey-350;
       .ngx-input-box,
       .ngx-input-textarea {
         flex: auto;
+        display: block;
         background: transparent;
         border: none;
         margin-bottom: 0px;
         padding-left: 0px;
         width: 100%;
         color: $color-blue-grey-100;
-        font-size: 1em;
+        font-size: 16px;
+        line-height: 20px;
         min-height: 0px;
         font-family: inherit;
         caret-color: $input-active-underline-fill;
@@ -184,8 +186,9 @@ $input-placeholder-color: $color-blue-grey-350;
     .ngx-input-label {
       pointer-events: none;
       position: absolute;
-      font-size: 14px;
+      font-size: 13px;
       font-weight: 600;
+      line-height: 16px;
       transition: color 0.2s ease-in-out;
       color: $color-blue-grey-350;
     }
@@ -208,6 +211,8 @@ $input-placeholder-color: $color-blue-grey-350;
       color: $input-hint-color;
       margin-top: 2px;
       min-height: 1em;
+      line-height: 14px;
+      transition: color 0.2s ease-in-out;
     }
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -22,21 +22,21 @@ $input-placeholder-color: $color-blue-grey-350;
     .ngx-input-textarea {
       margin: 0 !important;
       padding: 6px 10px !important;
-    }
-    input,
-    textarea {
       position: relative;
       z-index: 1;
     }
-    .ngx-input-box-wrap::after {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      background-color: $color-blue-grey-875;
-      mix-blend-mode: exclusion;
-      content: '';
+
+    .ngx-input-box-wrap {
+      &:after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        background-color: $color-blue-grey-875;
+        mix-blend-mode: exclusion;
+        content: '';
+      }
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -43,7 +43,7 @@ $input-placeholder-color: $color-blue-grey-350;
   &.focused {
     &:not(.ng-invalid) {
       .ngx-input-label {
-        color: $color-blue !important;
+        color: $input-active-underline-fill !important;
       }
     }
   }
@@ -65,6 +65,11 @@ $input-placeholder-color: $color-blue-grey-350;
 
     .ngx-input-hint {
       color: $input-invalid-color;
+    }
+
+    .ngx-input-box,
+    .ngx-input-textarea {
+      caret-color: $input-invalid-color !important;
     }
   }
 
@@ -134,6 +139,7 @@ $input-placeholder-color: $color-blue-grey-350;
         font-size: 1em;
         min-height: 0px;
         font-family: inherit;
+        caret-color: $input-active-underline-fill;
 
         &::placeholder {
           color: $input-placeholder-color;
@@ -180,6 +186,7 @@ $input-placeholder-color: $color-blue-grey-350;
       position: absolute;
       font-size: 14px;
       font-weight: 600;
+      transition: color 0.2s ease-in-out;
       color: $color-blue-grey-350;
     }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -27,7 +27,7 @@ $input-placeholder-color: $color-blue-grey-350;
     }
 
     .ngx-input-box-wrap {
-      &:after {
+      &::after {
         position: absolute;
         top: 0;
         right: 0;

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -4,7 +4,7 @@
 $input-hint-color: $color-blue-grey-350;
 $input-invalid-color: $color-red;
 $input-active-underline-fill: $color-blue;
-$input-inactive-underline-fill: $color-blue-grey-500;
+$input-inactive-underline-fill: $color-blue-grey-600;
 $input-icon-color: $color-grey-300;
 $input-placeholder-color: $color-blue-grey-350;
 
@@ -20,10 +20,23 @@ $input-placeholder-color: $color-blue-grey-350;
   &.fill {
     .ngx-input-box,
     .ngx-input-textarea {
-      background-color: $color-blue-grey-650 !important;
       margin: 0 !important;
       padding: 6px 10px !important;
+    }
+    input,
+    textarea {
+      position: relative;
+      z-index: 1;
+    }
+    .ngx-input-box-wrap::after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background-color: $color-blue-grey-900;
       mix-blend-mode: exclusion;
+      content: '';
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -6,7 +6,7 @@ $input-invalid-color: $color-red;
 $input-active-underline-fill: $color-blue;
 $input-inactive-underline-fill: $color-blue-grey-500;
 $input-icon-color: $color-grey-300;
-$input-placeholder-color: $color-blue-grey-450;
+$input-placeholder-color: $color-blue-grey-350;
 
 .ngx-input {
   display: block;
@@ -15,6 +15,58 @@ $input-placeholder-color: $color-blue-grey-450;
   padding-top: 20px;
   padding-top: calc(0.7em + 8px);
   padding-bottom: 0;
+
+  &.fill {
+    .ngx-input-box,
+    .ngx-input-textarea {
+      background-color: $color-blue-grey-650 !important;
+      margin: 0 !important;
+      padding: 6px 10px !important;
+      mix-blend-mode: exclusion;
+    }
+  }
+
+  &.md {
+    .ngx-input-box,
+    .ngx-input-textarea {
+      font-size: 18px !important;
+    }
+  }
+
+  &.lg {
+    .ngx-input-box,
+    .ngx-input-textarea {
+      font-size: 21px !important;
+    }
+  }
+
+  &.focused {
+    &:not(.ng-invalid) {
+      .ngx-input-label {
+        color: $color-blue !important;
+      }
+    }
+  }
+
+  &.invalid.ng-touched,
+  &.ng-invalid.ng-touched,
+  &.ng-invalid.ng-dirty {
+    .ngx-input-underline {
+      background-color: $input-invalid-color !important;
+
+      .underline-fill {
+        background-color: $input-invalid-color !important;
+      }
+    }
+
+    .ngx-input-label {
+      color: $input-invalid-color;
+    }
+
+    .ngx-input-hint {
+      color: $input-invalid-color;
+    }
+  }
 
   // override chrome autofill styles
   input:-webkit-autofill,
@@ -92,7 +144,7 @@ $input-placeholder-color: $color-blue-grey-450;
           outline: none;
         }
 
-        &[disabled] {
+        &:disabled {
           color: $color-blue-grey-400;
           user-select: none;
         }
@@ -126,7 +178,9 @@ $input-placeholder-color: $color-blue-grey-450;
     .ngx-input-label {
       pointer-events: none;
       position: absolute;
-      font-size: 16px;
+      font-size: 14px;
+      font-weight: 600;
+      color: $color-blue-grey-350;
     }
 
     .ngx-input-underline {
@@ -147,23 +201,6 @@ $input-placeholder-color: $color-blue-grey-450;
       color: $input-hint-color;
       margin-top: 2px;
       min-height: 1em;
-    }
-  }
-
-  &.invalid.ng-touched,
-  &.ng-invalid.ng-touched,
-  &.ng-invalid.ng-dirty {
-    .ngx-input-underline {
-      background-color: $input-invalid-color;
-    }
-
-    .ngx-input-label {
-      font-weight: 600;
-      color: $input-invalid-color;
-    }
-
-    .ngx-input-hint {
-      color: $input-invalid-color;
     }
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -34,7 +34,7 @@ $input-placeholder-color: $color-blue-grey-350;
       right: 0;
       bottom: 0;
       left: 0;
-      background-color: $color-blue-grey-900;
+      background-color: $color-blue-grey-875;
       mix-blend-mode: exclusion;
       content: '';
     }

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.spec.ts
@@ -46,12 +46,6 @@ describe('InputComponent', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should be required', () => {
-    component.required$.next(true);
-    fixture.detectChanges();
-    expect(component.input.requiredIndicatorView).toEqual(component.input.requiredIndicator as string);
-  });
-
   it('should be textarea', () => {
     component.type$.next(InputTypes.textarea);
     fixture.detectChanges();

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -22,13 +22,14 @@ import {
   Validators
 } from '@angular/forms';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
-import { trigger, state, style, transition, animate } from '@angular/animations';
 import { BehaviorSubject } from 'rxjs';
 
+import { Appearance } from '../../mixins/appearance/appearance.enum';
 import { appearanceMixin } from '../../mixins/appearance/appearance.mixin';
 import { sizeMixin } from '../../mixins/size/size.mixin';
 
 import { InputTypes } from './input-types.enum';
+import { INPUT_ANIMATIONS } from './input-animations.constant';
 
 let nextId = 0;
 
@@ -52,46 +53,15 @@ const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
   selector: 'ngx-input',
   templateUrl: './input.component.html',
   styleUrls: ['./input.component.scss'],
-  host: { class: 'ngx-input' },
+  host: {
+    class: 'ngx-input',
+    '[class]': '[appearance, size]',
+    '[class.focused]': 'focused'
+  },
+  animations: INPUT_ANIMATIONS,
   providers: [INPUT_VALUE_ACCESSOR, INPUT_VALIDATORS],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [
-    trigger('labelState', [
-      state(
-        'inside',
-        style({
-          'font-size': '1em',
-          top: '0'
-        })
-      ),
-      state(
-        'outside',
-        style({
-          'font-size': '.7rem',
-          top: '-15px'
-        })
-      ),
-      transition('inside => outside', animate('150ms ease-out')),
-      transition('outside => inside', animate('150ms ease-out'))
-    ]),
-    trigger('underlineState', [
-      state(
-        'collapsed',
-        style({
-          width: '0%'
-        })
-      ),
-      state(
-        'expanded',
-        style({
-          width: '100%'
-        })
-      ),
-      transition('collapsed => expanded', animate('150ms ease-out')),
-      transition('expanded => collapsed', animate('150ms ease-out'))
-    ])
-  ]
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class InputComponent extends _InputMixinBase implements AfterViewInit, ControlValueAccessor, Validator {
   @Input() id: string = `input-${++nextId}`;
@@ -221,7 +191,7 @@ export class InputComponent extends _InputMixinBase implements AfterViewInit, Co
   }
 
   get labelState(): string {
-    return this.placeholder || this.focusedOrDirty ? 'outside' : 'inside';
+    return this.placeholder || this.focusedOrDirty || this.appearance === Appearance.Fill ? 'outside' : 'inside';
   }
 
   get underlineState(): string {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -21,11 +21,14 @@ import {
   FormControl,
   Validators
 } from '@angular/forms';
+import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
+import { trigger, state, style, transition, animate } from '@angular/animations';
 import { BehaviorSubject } from 'rxjs';
 
-import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
+import { appearanceMixin } from '../../mixins/appearance/appearance.mixin';
+import { sizeMixin } from '../../mixins/size/size.mixin';
+
 import { InputTypes } from './input-types.enum';
-import { trigger, state, style, transition, animate } from '@angular/animations';
 
 let nextId = 0;
 
@@ -40,6 +43,9 @@ const INPUT_VALIDATORS = {
   useExisting: forwardRef(() => InputComponent),
   multi: true
 };
+
+class InputBase {}
+const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
 
 @Component({
   exportAs: 'ngxInput',
@@ -87,7 +93,7 @@ const INPUT_VALIDATORS = {
     ])
   ]
 })
-export class InputComponent implements AfterViewInit, ControlValueAccessor, Validator {
+export class InputComponent extends _InputMixinBase implements AfterViewInit, ControlValueAccessor, Validator {
   @Input() id: string = `input-${++nextId}`;
   @Input() name: string;
   @Input() label: string = '';
@@ -244,7 +250,9 @@ export class InputComponent implements AfterViewInit, ControlValueAccessor, Vali
   private _autocorrect: boolean = false;
   private _spellcheck: boolean = false;
 
-  constructor(private readonly cdr: ChangeDetectorRef) {}
+  constructor(private readonly cdr: ChangeDetectorRef) {
+    super();
+  }
 
   ngAfterViewInit(): void {
     if (this.autofocus) {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -198,10 +198,6 @@ export class InputComponent extends _InputMixinBase implements AfterViewInit, Co
     return this.focused ? 'expanded' : 'collapsed';
   }
 
-  get requiredIndicatorView(): string {
-    return !this.requiredIndicator || !this.required ? '' : (this.requiredIndicator as string);
-  }
-
   get element() {
     return this.type === InputTypes.textarea ? this.textareaControl : this.inputControl;
   }
@@ -233,11 +229,11 @@ export class InputComponent extends _InputMixinBase implements AfterViewInit, Co
     setTimeout(() => this.cdr.markForCheck());
   }
 
-  ngOnChanges(changes: any) {
-    if ('max' in changes || 'min' in changes) {
-      this.onChangeCallback(this._value);
-    }
-  }
+  // ngOnChanges(changes: any) {
+  //   if ('max' in changes || 'min' in changes) {
+  //     this.onChangeCallback(this._value);
+  //   }
+  // }
 
   onChange(event: Event): void {
     event.stopPropagation();

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -56,7 +56,8 @@ const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
   host: {
     class: 'ngx-input',
     '[class]': '[appearance, size]',
-    '[class.focused]': 'focused'
+    '[class.focused]': 'focused',
+    '[class.autosize]': 'autosize'
   },
   animations: INPUT_ANIMATIONS,
   providers: [INPUT_VALUE_ACCESSOR, INPUT_VALIDATORS],
@@ -151,6 +152,14 @@ export class InputComponent extends _InputMixinBase implements AfterViewInit, Co
     this.updateInputType();
   }
 
+  @Input()
+  get autosize() {
+    return this._autosize;
+  }
+  set autosize(v: boolean) {
+    this._autosize = coerceBooleanProperty(v);
+  }
+
   @Output() change = new EventEmitter<string | number>();
   @Output() blur = new EventEmitter<Event>();
   @Output() focus = new EventEmitter<FocusEvent>();
@@ -215,6 +224,7 @@ export class InputComponent extends _InputMixinBase implements AfterViewInit, Co
   private _autocomplete: boolean = false;
   private _autocorrect: boolean = false;
   private _spellcheck: boolean = false;
+  private _autosize: boolean = false;
 
   constructor(private readonly cdr: ChangeDetectorRef) {
     super();

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -229,12 +229,6 @@ export class InputComponent extends _InputMixinBase implements AfterViewInit, Co
     setTimeout(() => this.cdr.markForCheck());
   }
 
-  // ngOnChanges(changes: any) {
-  //   if ('max' in changes || 'min' in changes) {
-  //     this.onChangeCallback(this._value);
-  //   }
-  // }
-
   onChange(event: Event): void {
     event.stopPropagation();
     this.change.emit(this.value);

--- a/projects/swimlane/ngx-ui/src/lib/mixins/appearance/appearance.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/mixins/appearance/appearance.enum.ts
@@ -1,0 +1,4 @@
+export enum Appearance {
+  Legacy = 'legacy',
+  Fill = 'fill'
+}

--- a/projects/swimlane/ngx-ui/src/lib/mixins/appearance/appearance.mixin.ts
+++ b/projects/swimlane/ngx-ui/src/lib/mixins/appearance/appearance.mixin.ts
@@ -1,0 +1,13 @@
+import { Input } from '@angular/core';
+
+import { Constructor } from '../constructor.type';
+import { Appearance } from './appearance.enum';
+
+// tslint:disable-next-line: variable-name
+export function appearanceMixin<T extends Constructor<{}>>(Base: T) {
+  class AppearanceBase extends Base {
+    @Input() appearance = Appearance.Legacy;
+  }
+
+  return AppearanceBase;
+}

--- a/projects/swimlane/ngx-ui/src/lib/mixins/constructor.type.ts
+++ b/projects/swimlane/ngx-ui/src/lib/mixins/constructor.type.ts
@@ -1,0 +1,1 @@
+export type Constructor<T> = new (...args: any[]) => T;

--- a/projects/swimlane/ngx-ui/src/lib/mixins/size/size.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/mixins/size/size.enum.ts
@@ -1,0 +1,5 @@
+export enum Size {
+  Small = 'sm',
+  Medium = 'md',
+  Large = 'lg'
+}

--- a/projects/swimlane/ngx-ui/src/lib/mixins/size/size.mixin.ts
+++ b/projects/swimlane/ngx-ui/src/lib/mixins/size/size.mixin.ts
@@ -1,0 +1,13 @@
+import { Input } from '@angular/core';
+
+import { Constructor } from '../constructor.type';
+import { Size } from './size.enum';
+
+// tslint:disable-next-line: variable-name
+export function sizeMixin<T extends Constructor<{}>>(Base: T) {
+  class SizeBase extends Base {
+    @Input() size = Size.Small;
+  }
+
+  return SizeBase;
+}

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -350,6 +350,14 @@
   <br />
 
   <ngx-input size="lg" label="Large" ngModel="Large Input" hint="example of a large input"></ngx-input>
+
+  <br />
+
+  <ngx-codemirror mode="htmlmixed" readOnly="true">
+    <![CDATA[
+      <ngx-input size="lg" label="Large" ngModel="Large Input" hint="example of a large input"></ngx-input>
+    ]]>
+  </ngx-codemirror>
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Appearances">
@@ -362,8 +370,24 @@
   <br />
 
   <ngx-input type="textarea" appearance="fill" label="Fill Textarea" placeholder="enter your text here..." hint="example of a fill textarea"></ngx-input>
+
+  <br />
+
+  <ngx-codemirror mode="htmlmixed" readOnly="true">
+    <![CDATA[
+      <ngx-input label="Fill" appearance="fill" ngModel="Fill Input" placeholder="enter your text here..." hint="example of a fill input"></ngx-input>
+    ]]>
+  </ngx-codemirror>
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Auto Size">
   <ngx-input autosize label="Resize Input" placeholder="enter your text here..." hint="example of a resize input"></ngx-input>
+
+  <br />
+
+  <ngx-codemirror mode="htmlmixed" readOnly="true">
+    <![CDATA[
+      <ngx-input autosize label="Resize Input" placeholder="enter your text here..." hint="example of a resize input"></ngx-input>
+    ]]>
+  </ngx-codemirror>
 </ngx-section>

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -269,7 +269,7 @@
 
   <br />
   <ngx-codemirror mode="htmlmixed" readOnly="true">
-    <![CDATA[ 
+    <![CDATA[
       <ngx-input
         type="text"
         label="Pattern validation"
@@ -277,7 +277,7 @@
         name="patern-input"
         [pattern]="'^\\w+$'"
         hint="Pattern: ^\\w+$">
-      </ngx-input> 
+      </ngx-input>
     ]]>
   </ngx-codemirror>
 </ngx-section>
@@ -342,4 +342,20 @@
       <input type="number" class="form-input" />
     ]]>
   </ngx-codemirror>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Sizes">
+  <ngx-input size="md" label="Medium" ngModel="Medium Input" hint="example of a medium input"></ngx-input>
+
+  <br />
+
+  <ngx-input size="lg" label="Large" ngModel="Large Input" hint="example of a large input"></ngx-input>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Appearances">
+  <ngx-input label="Legacy" ngModel="Legacy Input" placeholder="enter your text here..." hint="example of a legacy input"></ngx-input>
+
+  <br />
+
+  <ngx-input label="Fill" appearance="fill" ngModel="Fill Input" placeholder="enter your text here..." hint="example of a fill input"></ngx-input>
 </ngx-section>

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -236,11 +236,11 @@
       <ngx-input
         type="number"
         label="Age"
-        [ngModel]="numericValue"
+        [(ngModel)]="numericValue"
         name="numeric-input"
         min="0"
         max="122"
-        (change)="numericValue = $event">
+      >
       </ngx-input>
     ]]>
   </ngx-codemirror>
@@ -358,4 +358,8 @@
   <br />
 
   <ngx-input label="Fill" appearance="fill" ngModel="Fill Input" placeholder="enter your text here..." hint="example of a fill input"></ngx-input>
+
+  <br />
+
+  <ngx-input type="textarea" appearance="fill" label="Fill Textarea" placeholder="enter your text here..." hint="example of a fill textarea"></ngx-input>
 </ngx-section>

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -363,3 +363,7 @@
 
   <ngx-input type="textarea" appearance="fill" label="Fill Textarea" placeholder="enter your text here..." hint="example of a fill textarea"></ngx-input>
 </ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Auto Size">
+  <ngx-input autosize label="Resize Input" placeholder="enter your text here..." hint="example of a resize input"></ngx-input>
+</ngx-section>


### PR DESCRIPTION
## Summary

- add reusable mixins for appearance and size (links to other impl examples in commit descriptions)
- enhance autosize directive to work with input (width) as well as textarea (height)
- add input for autosize that enables input resize when type is not textarea
- add fill styles
- add sizing styles (sm, md, lg)
- update all other input styles to match figma
- update unit tests

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_

![Screen Shot 2020-07-14 at 11 47 19 AM](https://user-images.githubusercontent.com/44811138/87446904-e8049680-c5c7-11ea-8e01-ca1636a2c933.png)
![Screen Shot 2020-07-14 at 11 47 29 AM](https://user-images.githubusercontent.com/44811138/87446906-e89d2d00-c5c7-11ea-9d11-276a9c68f2d9.png)
![Screen Shot 2020-07-14 at 11 47 47 AM](https://user-images.githubusercontent.com/44811138/87446907-e89d2d00-c5c7-11ea-8cb3-7876033e1605.png)
