### PR TITLE
don't use faker for no-scroll test because words may be too long

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.spec.ts
@@ -76,7 +76,7 @@ describe('AutosizeDirective', () => {
     });
 
     it('should set width auto when no scroll', () => {
-      component.input.nativeElement.value = 't';
+      component.input.nativeElement.value = '';
       component.input.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
 
@@ -103,7 +103,7 @@ describe('AutosizeDirective', () => {
     });
 
     it('should set height auto when no scroll', () => {
-      component.textarea.nativeElement.value = faker.random.words(3);
+      component.textarea.nativeElement.value = '';
       component.textarea.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
 


### PR DESCRIPTION
## Summary

- use empty string for no scroll tests, faker words are random and could exceed width/height sometimes.

## Checklist

- [x] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
