### PR TITLE
SPT-6967 - select input fill variant

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Feature: sm, md, lg input sizing
 - Bug: make context drawer compatible with components
 - Bug: fix ngx-drawer-content scrolling scss issue
+- Feature: fill select style
+- Enhancement: select dropdown styling
 
 ## 29.1.0 (2020-06-29)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
@@ -1,5 +1,6 @@
 <div>
   <div class="ngx-select-filter" *ngIf="filterable && !tagging">
+    <i class="ngx-icon ngx-search"></i>
     <input
       #filterInput
       type="search"
@@ -11,6 +12,7 @@
       [placeholder]="filterPlaceholder"
       (keyup)="onInputKeyUp($event)"
     />
+    <i [hidden]="!filterInput.value" class="ngx-icon ngx-x" (click)="clearFilter(filterInput)"></i>
   </div>
   <ul class="vertical-list ngx-select-dropdown-options">
     <li *ngFor="let group of groups" class="ngx-select-option-group">
@@ -34,6 +36,10 @@
           >
           </ng-template>
           <span *ngIf="!kv.option.optionTemplate" [innerHTML]="kv.option.name"> </span>
+          <i
+            *ngIf="!kv.option.optionTemplate && isSelected(kv.option)"
+            class="ngx-icon ngx-check ngx-select-dropdown--selected-option"
+          ></i>
         </li>
         <li
           *ngIf="filterQuery && group.options?.length && !filterQueryIsInOptions"

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
@@ -278,4 +278,32 @@ describe('SelectDropdownComponent', () => {
       expect(component.groups).toBeDefined();
     });
   });
+
+  describe('clearFilter', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SelectDropdownComponent);
+      component = fixture.componentInstance;
+
+      component.options = [selectDropdownOptionMock(), selectDropdownOptionMock(), selectDropdownOptionMock()];
+      component.filterable = true;
+      component.tagging = false;
+
+      fixture.detectChanges();
+    });
+
+    it('should clear search', () => {
+      const testVal = 'test';
+      const filter = fixture.nativeElement.querySelector('.ngx-select-filter-input') as HTMLInputElement;
+      filter.value = testVal;
+      fixture.detectChanges();
+
+      expect(filter.value).toEqual(testVal);
+
+      component.clearFilter(filter);
+      fixture.detectChanges();
+
+      expect(component.filterQuery).toEqual('');
+      expect(filter.value).toEqual('');
+    });
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
@@ -174,6 +174,7 @@ describe('SelectDropdownComponent', () => {
     }));
 
     it('should set filterQueryIsInOptions to false if filterQuery does not equal any of the options name property', fakeAsync(() => {
+      event.target.value = 'zzzzzzzzzzzzzzzzzzzz';
       component.onInputKeyUp(event);
       flush();
       fixture.detectChanges();
@@ -186,19 +187,6 @@ describe('SelectDropdownComponent', () => {
       flush();
       fixture.detectChanges();
       expect(component.filterQueryIsInOptions).toBeTruthy();
-    }));
-
-    it('should display Add Value button when allow additions is true and there is at least still one option on dropdown', fakeAsync(() => {
-      event.target.value = component.groups[0].options[0].option.name.substring(0, 2);
-      component.allowAdditions = true;
-      component.filterable = true;
-
-      component.onInputKeyUp(event);
-      flush();
-      fixture.detectChanges();
-      const allowAdditionsButton = fixture.debugElement.queryAll(By.css('.ngx-select-empty-placeholder'));
-      expect(allowAdditionsButton[0].nativeElement).toBeDefined();
-      expect(allowAdditionsButton[0].nativeElement.innerText).toBe('Add Value');
     }));
 
     it('should not display Add Value button when allow additions is false', fakeAsync(() => {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -162,6 +162,7 @@ export class SelectDropdownComponent implements AfterViewInit {
 
     this.filterQuery = '';
     this.updatefilterQueryIsInOptions();
+    this.cdr.markForCheck();
   }
 
   onInputKeyUp(event: KeyboardEvent): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -119,6 +119,7 @@ export class SelectDropdownComponent implements AfterViewInit {
   }
 
   groups: any[];
+  filterQueryIsInOptions: boolean = false;
 
   private _options: SelectDropdownOption[];
   private _groupBy: string;
@@ -128,7 +129,6 @@ export class SelectDropdownComponent implements AfterViewInit {
   private _allowAdditions: boolean;
   private _filterable: boolean;
   private _filterCaseSensitive = false;
-  filterQueryIsInOptions: boolean = false;
 
   constructor(private readonly elementRef: ElementRef, private readonly cdr: ChangeDetectorRef) {}
 
@@ -153,8 +153,15 @@ export class SelectDropdownComponent implements AfterViewInit {
 
   @debounceable(500)
   updatefilterQueryIsInOptions() {
-    this.filterQueryIsInOptions = this.options.some(o => o.name === this.filterQuery);
+    this.filterQueryIsInOptions = this.options.some(o => o.name.toLowerCase().includes(this.filterQuery.toLowerCase()));
     this.cdr.markForCheck();
+  }
+
+  clearFilter(filterInput: HTMLInputElement) {
+    filterInput.value = '';
+
+    this.filterQuery = '';
+    this.updatefilterQueryIsInOptions();
   }
 
   onInputKeyUp(event: KeyboardEvent): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -36,12 +36,13 @@
       <input
         #tagInput
         type="search"
-        class="ng-select-text-box"
+        class="ngx-select-text-box"
         autocomplete="off"
         autocorrect="off"
         spellcheck="off"
         (keyup)="onKeyUp($event)"
       />
+      <i [hidden]="!tagInput.value" class="ngx-icon ngx-x" (click)="tagInput.value = ''"></i>
     </li>
   </ul>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -5,13 +5,16 @@
   class="ngx-select-input-box"
   (click)="onClick($event)"
 >
-  <span *ngIf="label !== undefined" class="ngx-select-label">
+  <span *ngIf="label" class="ngx-select-label">
     <span [innerHTML]="label"></span>
     <span [innerHTML]="requiredIndicator"></span>
   </span>
-  <span *ngIf="!selected?.length && placeholder !== undefined" class="ngx-select-placeholder" [innerHTML]="placeholder">
-  </span>
-  <ul class="horizontal-list ngx-select-input-list">
+  <span *ngIf="!selected?.length && placeholder" class="ngx-select-placeholder" [innerHTML]="placeholder"> </span>
+  <ul
+    *ngIf="tagging || selectedOptions?.length"
+    class="horizontal-list ngx-select-input-list"
+    [class.no-selections]="!selected?.length"
+  >
     <li *ngFor="let option of selectedOptions" class="ngx-select-input-option" [class.disabled]="option.disabled">
       <ng-template
         *ngIf="option.inputTemplate"
@@ -46,7 +49,7 @@
   <div class="underline-fill"></div>
 </div>
 <div class="ngx-select-hint">
-  <span *ngIf="hint !== undefined" [innerHTML]="hint"></span>
+  <span *ngIf="hint" [innerHTML]="hint"></span>
   <ng-content select="ngx-input-hint"></ng-content>
 </div>
 <span

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.fixture.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.fixture.ts
@@ -15,6 +15,7 @@ import { selectDropdownOptionMock } from './select-dropdown-option.mock';
       [minSelections]="minSelections$ | async"
       [maxSelections]="maxSelections$ | async"
       [autofocus]="autofocus$ | async"
+      [autosize]="autosize$ | async"
       [allowClear]="allowClear$ | async"
       [allowAdditions]="allowAdditions$ | async"
       [disableDropdown]="disableDropdown$ | async"
@@ -45,6 +46,7 @@ export class SelectComponentFixture {
   readonly minSelections$ = new BehaviorSubject(0);
   readonly maxSelections$ = new BehaviorSubject(3);
   readonly autofocus$ = new BehaviorSubject(false);
+  readonly autosize$ = new BehaviorSubject(false);
   readonly allowClear$ = new BehaviorSubject(false);
   readonly allowAdditions$ = new BehaviorSubject(false);
   readonly disableDropdown$ = new BehaviorSubject(false);

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -288,7 +288,7 @@ $color-chip-text: #fff;
           }
         }
 
-        .ngx-x {
+        i.ngx-x {
           font-size: 9px;
           top: 50%;
           margin-top: -4.5px;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -276,15 +276,15 @@ $color-chip-text: #fff;
           height: 20px;
           vertical-align: bottom;
 
-          &:focus {
-            outline: none;
-          }
-
           &::-webkit-search-decoration,
           &::-webkit-search-cancel-button,
           &::-webkit-search-results-button,
           &::-webkit-search-results-decoration {
             -webkit-appearance: none !important;
+          }
+
+          &:focus {
+            outline: none;
           }
         }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -262,19 +262,44 @@ $color-chip-text: #fff;
         cursor: text;
       }
 
-      .ng-select-text-box {
-        background-color: transparent;
-        border: none;
-        outline: none;
-        -webkit-appearance: none;
-        color: $color-input-text;
-        line-height: 20px;
-        display: inline-block;
-        height: 20px;
-        vertical-align: bottom;
+      .ngx-select-input-box-wrapper {
+        position: relative;
 
-        &:focus {
+        .ngx-select-text-box {
+          background-color: transparent;
+          border: none;
           outline: none;
+          -webkit-appearance: none;
+          color: $color-input-text;
+          line-height: 20px;
+          display: inline-block;
+          height: 20px;
+          vertical-align: bottom;
+
+          &:focus {
+            outline: none;
+          }
+
+          &::-webkit-search-decoration,
+          &::-webkit-search-cancel-button,
+          &::-webkit-search-results-button,
+          &::-webkit-search-results-decoration {
+            -webkit-appearance: none !important;
+          }
+        }
+
+        .ngx-x {
+          font-size: 9px;
+          top: 50%;
+          margin-top: -4.5px;
+          right: 10px;
+          color: $input-active-underline-fill;
+          z-index: 500;
+          cursor: pointer;
+
+          &:hover {
+            color: $color-blue-400;
+          }
         }
       }
     }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -7,12 +7,12 @@ $color-group-bg: darken($color-blue-grey-700, 5%);
 $color-dropdown-bg: $color-blue-grey-700;
 $color-hover-bg: $color-blue-grey-725;
 $color-placeholder-text: $color-blue-grey-350;
-$color-caret-bg: $color-grey-500;
+$color-caret-bg: $color-blue-grey-350;
 
 // filter
 $color-filter-bg: $color-blue-grey-600;
 $color-filter-text: $color-blue-grey-050;
-$color-empty-text: $color-grey-300;
+$color-empty-text: $color-blue-grey-150;
 
 // chips
 $color-chip-bg: $color-blue-400;
@@ -22,7 +22,7 @@ $color-chip-text: #fff;
 .ngx-select {
   position: relative;
   display: block;
-  min-width: 300px;
+  min-width: 60px;
   line-height: 1.4em;
   margin-top: 16px;
   margin-bottom: 8px;
@@ -30,13 +30,37 @@ $color-chip-text: #fff;
   padding-top: calc(0.7em + 8px);
   padding-bottom: 0;
 
+  &.autosize {
+    .ngx-select-dropdown {
+      width: fit-content;
+      min-width: 190px;
+      max-width: 100%;
+    }
+
+    .ngx-select-flex-wrap {
+      max-width: 100%;
+      width: fit-content;
+    }
+  }
+
+  &.autosize,
+  &.fill {
+    .ngx-select-label {
+      white-space: nowrap;
+      max-width: 100%;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      padding-right: 25px;
+      position: initial !important;
+    }
+  }
+
   &.fill {
     .ngx-select-input-box {
       margin: 0 !important;
       position: relative;
       z-index: 1;
       min-height: 34px !important;
-      min-width: 60px;
       color: $color-blue-grey-050;
     }
 
@@ -49,16 +73,8 @@ $color-chip-text: #fff;
       position: initial !important;
     }
 
-    .ngx-select-dropdown {
-      width: fit-content;
-      min-width: 190px;
-      max-width: 100%;
-    }
-
     .ngx-select-flex-wrap {
       position: relative;
-      max-width: 100%;
-      width: fit-content;
 
       .ngx-select-input-box::after {
         position: absolute;
@@ -98,32 +114,13 @@ $color-chip-text: #fff;
     &.has-placeholder,
     &.active {
       .ngx-select-label {
-        position: absolute !important;
         padding: 0 !important;
       }
     }
 
     .ngx-select-label {
-      top: 6px !important;
-      white-space: nowrap;
-      max-width: 100%;
-      overflow-x: hidden;
-      text-overflow: ellipsis;
+      padding-left: 10px;
       line-height: 34px;
-      padding: 0 25px 0 10px;
-      position: initial !important;
-    }
-
-    &.active:not(.ng-invalid) {
-      .ngx-select-label,
-      .ngx-select-caret,
-      .ngx-select-clear {
-        color: $input-active-underline-fill !important;
-
-        &:hover {
-          color: $color-blue-400 !important;
-        }
-      }
     }
 
     .ngx-select-input-box-wrapper {
@@ -133,6 +130,18 @@ $color-chip-text: #fff;
     &.tagging-selection:not(.active) .ngx-select-input-list.no-selections {
       position: absolute;
       bottom: 0;
+    }
+  }
+
+  &.active:not(.ng-invalid) {
+    .ngx-select-label,
+    .ngx-select-caret,
+    &.single-selection .ngx-select-clear {
+      color: $input-active-underline-fill !important;
+
+      &:hover {
+        color: $color-blue-400 !important;
+      }
     }
   }
 
@@ -198,6 +207,7 @@ $color-chip-text: #fff;
   &.active {
     .ngx-select-input {
       .ngx-select-label {
+        position: absolute !important;
         font-size: 0.8125rem;
         top: -25px !important;
         left: 0;
@@ -213,8 +223,8 @@ $color-chip-text: #fff;
       background: $color-blue-grey-600;
       color: $color-chip-text;
       border-radius: 2px;
-      margin: 6px 5px 0;
-      height: 1.4em;
+      margin: 2px 5px 2px 0;
+      line-height: 1.8;
       white-space: nowrap;
       overflow: visible;
       text-overflow: ellipsis;
@@ -270,10 +280,10 @@ $color-chip-text: #fff;
           border: none;
           outline: none;
           -webkit-appearance: none;
-          color: $color-input-text;
+          color: $color-blue-grey-100;
           line-height: 20px;
           display: inline-block;
-          height: 20px;
+          font-size: 1rem;
           vertical-align: bottom;
 
           &::-webkit-search-decoration,
@@ -293,7 +303,7 @@ $color-chip-text: #fff;
           top: 50%;
           margin-top: -4.5px;
           right: 10px;
-          color: $input-active-underline-fill;
+          color: $color-blue-grey-300;
           z-index: 500;
           cursor: pointer;
 
@@ -352,6 +362,7 @@ $color-chip-text: #fff;
       padding-left: 0;
       width: 100%;
       min-height: 1em;
+      min-width: 60px;
       cursor: pointer;
       display: inline-block;
       vertical-align: bottom;
@@ -373,7 +384,7 @@ $color-chip-text: #fff;
     }
 
     .ngx-select-input-list {
-      padding: 0 40px 0 10px;
+      padding: 1px 40px 1px 10px;
       color: $color-input-text;
       min-height: 1.4em;
       max-width: 100%;
@@ -549,6 +560,10 @@ $color-chip-text: #fff;
         &::-webkit-search-results-button,
         &::-webkit-search-results-decoration {
           -webkit-appearance: none;
+        }
+
+        &::placeholder {
+          color: $color-blue-grey-350;
         }
       }
     }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -395,7 +395,7 @@ $color-chip-text: #fff;
     width: 100%;
     background: $color-dropdown-bg;
     border: 1px solid $color-blue-grey-650;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
     margin-top: 10px;
     opacity: 0;
     display: none;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -30,6 +30,68 @@ $color-chip-text: $color-grey-100;
   padding-top: calc(0.7em + 8px);
   padding-bottom: 0;
 
+  &.fill {
+    .ngx-select-input-box {
+      margin: 0 !important;
+      padding: 6px 10px !important;
+      position: relative;
+      z-index: 1;
+    }
+
+    .ngx-select-wrap {
+      max-width: 100%;
+      width: fit-content;
+    }
+
+    .ngx-select-dropdown {
+      width: fit-content(100%);
+      min-width: 175px;
+      max-width: 100vw;
+
+      li {
+        max-width: 100%;
+        white-space: nowrap;
+      }
+    }
+
+    .ngx-select-flex-wrap {
+      &::after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 18px;
+        left: 0;
+        background-color: $color-blue-grey-875;
+        mix-blend-mode: exclusion;
+        border-radius: 1px 1px 0 0;
+        content: '';
+      }
+    }
+
+    .ngx-select-caret,
+    .ngx-select-clear {
+      top: 50% !important;
+      margin-top: -7.5px !important;
+      z-index: 1000;
+    }
+
+    &.active {
+      .ngx-select-caret {
+        margin-top: -9.5px !important;
+      }
+    }
+
+    .ngx-select-label {
+      top: 6px !important;
+    }
+
+    .ngx-select-input-box:focus:not(.ng-invalid) {
+      .ngx-select-label {
+        color: $input-active-underline-fill !important;
+      }
+    }
+  }
+
   .ngx-select-flex-wrap {
     flex-direction: row;
     display: flex;
@@ -66,7 +128,7 @@ $color-chip-text: $color-grey-100;
       }
 
       .ngx-select-caret {
-        transition: transform 200ms ease-in-out;
+        transition: transform 200ms ease-in-out, margin 200ms ease-in-out;
         transform: rotate(180deg) translateY(50%);
       }
     }
@@ -92,9 +154,9 @@ $color-chip-text: $color-grey-100;
   &.active {
     .ngx-select-input {
       .ngx-select-label {
-        font-size: 0.7rem;
-        top: -25px;
-        transition: 150ms ease-out;
+        font-size: 0.8125rem;
+        top: -25px !important;
+        left: 0;
         line-height: 30px;
       }
     }
@@ -257,12 +319,14 @@ $color-chip-text: $color-grey-100;
       pointer-events: none;
       position: absolute;
       top: 0;
+      transition: 150ms ease-out;
     }
 
     .ngx-select-caret {
       position: absolute;
       top: 1em;
       right: 5px;
+      transition: transform 200ms ease-in-out, margin 200ms ease-in-out;
       transform: translateY(-50%);
       cursor: pointer;
       color: $color-caret-bg;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -5,19 +5,19 @@
 // general
 $color-group-bg: darken($color-blue-grey-700, 5%);
 $color-dropdown-bg: $color-blue-grey-700;
-$color-hover-bg: $color-blue-grey-500;
-$color-placeholder-text: $color-blue-grey-450;
+$color-hover-bg: $color-blue-grey-725;
+$color-placeholder-text: $color-blue-grey-350;
 $color-caret-bg: $color-grey-500;
 
 // filter
 $color-filter-bg: $color-blue-grey-600;
-$color-filter-text: $color-grey-200;
+$color-filter-text: $color-blue-grey-050;
 $color-empty-text: $color-grey-300;
 
 // chips
 $color-chip-bg: $color-blue-400;
 $color-chip-hover-bg: $color-blue;
-$color-chip-text: $color-grey-100;
+$color-chip-text: #fff;
 
 .ngx-select {
   position: relative;
@@ -33,38 +33,51 @@ $color-chip-text: $color-grey-100;
   &.fill {
     .ngx-select-input-box {
       margin: 0 !important;
-      padding: 6px 10px !important;
       position: relative;
       z-index: 1;
+      min-height: 34px !important;
+      min-width: 60px;
+      color: $color-blue-grey-050;
+    }
+
+    &.tagging-selection,
+    &.multi-selection {
+      padding-top: 1px !important;
     }
 
     .ngx-select-wrap {
-      max-width: 100%;
-      width: fit-content;
+      position: initial !important;
     }
 
     .ngx-select-dropdown {
-      width: fit-content(100%);
-      min-width: 175px;
-      max-width: 100vw;
-
-      li {
-        max-width: 100%;
-        white-space: nowrap;
-      }
+      width: fit-content;
+      min-width: 190px;
+      max-width: 100%;
     }
 
     .ngx-select-flex-wrap {
-      &::after {
+      position: relative;
+      max-width: 100%;
+      width: fit-content;
+
+      .ngx-select-input-box::after {
         position: absolute;
         top: 0;
         right: 0;
-        bottom: 18px;
+        bottom: -2px;
         left: 0;
-        background-color: $color-blue-grey-875;
+        z-index: -1;
+        opacity: 0.25;
+        background-color: $color-blue-grey-650;
         mix-blend-mode: exclusion;
         border-radius: 1px 1px 0 0;
         content: '';
+      }
+    }
+
+    &.single-selection {
+      .ngx-select-input-list {
+        line-height: 34px;
       }
     }
 
@@ -72,7 +85,7 @@ $color-chip-text: $color-grey-100;
     .ngx-select-clear {
       top: 50% !important;
       margin-top: -7.5px !important;
-      z-index: 1000;
+      z-index: 500;
     }
 
     &.active {
@@ -81,14 +94,44 @@ $color-chip-text: $color-grey-100;
       }
     }
 
-    .ngx-select-label {
-      top: 6px !important;
+    &.active-selections,
+    &.has-placeholder,
+    &.active {
+      .ngx-select-label {
+        position: absolute !important;
+        padding: 0 !important;
+      }
     }
 
-    .ngx-select-input-box:focus:not(.ng-invalid) {
-      .ngx-select-label {
+    .ngx-select-label {
+      top: 6px !important;
+      white-space: nowrap;
+      max-width: 100%;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      line-height: 34px;
+      padding: 0 25px 0 10px;
+      position: initial !important;
+    }
+
+    &.active:not(.ng-invalid) {
+      .ngx-select-label,
+      .ngx-select-caret,
+      .ngx-select-clear {
         color: $input-active-underline-fill !important;
+
+        &:hover {
+          color: $color-blue-400 !important;
+        }
       }
+    }
+
+    .ngx-select-input-box-wrapper {
+      margin-top: 6px;
+    }
+
+    &.tagging-selection:not(.active) .ngx-select-input-list.no-selections {
+      position: absolute;
     }
   }
 
@@ -168,8 +211,8 @@ $color-chip-text: $color-grey-100;
     .ngx-select-input-option {
       background: $color-blue-grey-600;
       color: $color-chip-text;
-      border-radius: 0.7em;
-      margin: 0 5px;
+      border-radius: 2px;
+      margin: 6px 5px 0;
       height: 1.4em;
       white-space: nowrap;
       overflow: visible;
@@ -178,12 +221,8 @@ $color-chip-text: $color-grey-100;
       transition: background 100ms ease-in;
       position: relative;
       top: 0;
-      padding: 0 0.7em;
-      font-size: 0.95em;
-
-      &:hover {
-        background: $color-chip-hover-bg;
-      }
+      padding: 0 8px;
+      font-size: 1rem;
 
       .ngx-select-input-name {
         text-shadow: 2px 4px 2px rgba(0, 0, 0, 0.1);
@@ -199,13 +238,13 @@ $color-chip-text: $color-grey-100;
         display: inline;
         vertical-align: middle;
         font-size: 0.8em;
-        color: $color-grey-100;
+        color: $color-blue-grey-300;
         transition: color 100ms ease-in;
         cursor: pointer;
         line-height: 1.4em;
 
         &:hover {
-          color: $color-blue-grey-800;
+          color: $color-blue-400;
         }
       }
 
@@ -232,7 +271,6 @@ $color-chip-text: $color-grey-100;
         display: inline-block;
         height: 20px;
         vertical-align: bottom;
-        margin-bottom: 6px;
 
         &:focus {
           outline: none;
@@ -259,7 +297,7 @@ $color-chip-text: $color-grey-100;
       .ngx-select-clear {
         position: absolute;
         top: 1em;
-        right: 25px;
+        right: 20px;
         transform: translateY(-50%);
         cursor: pointer;
         color: $color-caret-bg;
@@ -309,10 +347,10 @@ $color-chip-text: $color-grey-100;
     }
 
     .ngx-select-input-list {
-      margin-right: 40px;
-      padding-top: 0;
+      padding: 0 40px 0 10px;
       color: $color-input-text;
       min-height: 1.4em;
+      max-width: 100%;
     }
 
     .ngx-select-label {
@@ -334,11 +372,15 @@ $color-chip-text: $color-grey-100;
     }
 
     .ngx-select-placeholder {
-      position: absolute;
-      top: 0;
-      left: 0;
+      display: block;
       cursor: pointer;
       color: $color-placeholder-text;
+      padding: 0 25px 0 10px;
+      overflow-x: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      max-width: 100%;
+      line-height: 34px;
     }
   }
 
@@ -351,22 +393,46 @@ $color-chip-text: $color-grey-100;
     z-index: 1000;
     width: 100%;
     background: $color-dropdown-bg;
-    box-shadow: $shadow-3;
+    border: 1px solid $color-blue-grey-650;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     margin-top: 10px;
     opacity: 0;
     display: none;
     transition: visibility 0s, opacity 0.25s ease-out;
+
+    li {
+      max-width: 100%;
+      white-space: nowrap;
+      position: relative;
+
+      &:not(:last-child) {
+        border-bottom: 1px solid $color-blue-grey-650;
+      }
+
+      .ngx-check {
+        color: $color-blue-400;
+        position: absolute;
+        right: 15px;
+        top: 50%;
+        margin-top: -7.5px;
+      }
+    }
 
     .ngx-select-dropdown-options {
       max-height: 300px;
       overflow-y: auto;
 
       .ngx-select-dropdown-option {
-        padding: 7px 15px;
+        padding: 7px 35px 7px 15px;
         font-size: 15px;
         overflow-x: hidden;
         overflow-y: visible;
         text-overflow: ellipsis;
+
+        &.disabled {
+          color: $color-blue-grey-450;
+          opacity: 1;
+        }
 
         &:not(.disabled) {
           cursor: pointer;
@@ -380,13 +446,12 @@ $color-chip-text: $color-grey-100;
         }
 
         &.selected {
-          background: $color-blue-400;
-          color: $color-grey-100;
+          background: $color-blue-grey-750;
 
           &:not(.disabled) {
             &.active,
             &:hover {
-              background: $color-blue;
+              background: $color-hover-bg;
             }
           }
         }
@@ -397,20 +462,19 @@ $color-chip-text: $color-grey-100;
       .ngx-select-option-group {
         .ngx-select-option-group-name {
           padding: 7px 15px;
-          font-size: 18px;
+          font-size: 1rem;
           display: block;
-          background: $color-group-bg;
-          font-weight: bold;
+          font-weight: 600;
+          line-height: 20px;
+          color: $color-blue-grey-300;
+          overflow-x: hidden;
+          text-overflow: ellipsis;
         }
       }
 
       .ngx-select-dropdown-options {
         .ngx-select-dropdown-option {
-          padding: 7px 25px;
-
-          &:last-child {
-            margin-bottom: 10px;
-          }
+          padding: 7px 35px 7px 25px;
         }
       }
     }
@@ -418,6 +482,31 @@ $color-chip-text: $color-grey-100;
     .ngx-select-filter {
       padding: 10px;
       background: $color-filter-bg;
+      position: relative;
+
+      .ngx-search,
+      .ngx-x {
+        position: absolute;
+        top: 50%;
+        color: $color-blue-grey-350;
+      }
+
+      .ngx-search {
+        left: 10px;
+        font-size: 0.75rem;
+        margin-top: -6px;
+      }
+
+      .ngx-x {
+        right: 11px;
+        font-size: 0.5625rem;
+        margin-top: -4.5px;
+        cursor: pointer;
+
+        &:hover {
+          color: $color-blue-grey-300;
+        }
+      }
 
       .ngx-select-filter-input {
         color: $color-filter-text;
@@ -427,6 +516,14 @@ $color-chip-text: $color-grey-100;
         display: block;
         font-size: 15px;
         width: 100%;
+        padding-left: 19px;
+
+        &::-webkit-search-decoration,
+        &::-webkit-search-cancel-button,
+        &::-webkit-search-results-button,
+        &::-webkit-search-results-decoration {
+          -webkit-appearance: none;
+        }
       }
     }
 
@@ -440,6 +537,7 @@ $color-chip-text: $color-grey-100;
         font-style: normal;
         float: right;
       }
+
       .ngx-select-add-current-value {
         font-style: normal;
         span {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -114,18 +114,18 @@ $color-chip-text: #fff;
       }
     }
 
+    .ngx-select-label,
+    .ngx-select-placeholder {
+      padding-left: 10px !important;
+      line-height: 34px;
+    }
+
     &.active-selections,
     &.has-placeholder,
     &.active {
       .ngx-select-label {
         padding: 0 !important;
       }
-    }
-
-    .ngx-select-label,
-    .ngx-select-placeholder {
-      padding-left: 10px !important;
-      line-height: 34px;
     }
 
     .ngx-select-input-box-wrapper {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -64,7 +64,8 @@ $color-chip-text: #fff;
       color: $color-blue-grey-050;
     }
 
-    .ngx-select-input-list {
+    .ngx-select-input-list,
+    .ngx-select-placeholder {
       padding-left: 10px !important;
     }
 
@@ -416,7 +417,7 @@ $color-chip-text: #fff;
       display: block;
       cursor: pointer;
       color: $color-placeholder-text;
-      padding: 0 25px 0 10px;
+      padding: 0 25px 0 0;
       overflow-x: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -64,6 +64,10 @@ $color-chip-text: #fff;
       color: $color-blue-grey-050;
     }
 
+    .ngx-select-input-list {
+      padding-left: 10px !important;
+    }
+
     &.tagging-selection,
     &.multi-selection {
       padding-top: 1px !important;
@@ -384,7 +388,7 @@ $color-chip-text: #fff;
     }
 
     .ngx-select-input-list {
-      padding: 1px 40px 1px 10px;
+      padding: 0 40px 0 0;
       color: $color-input-text;
       min-height: 1.4em;
       max-width: 100%;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -64,8 +64,7 @@ $color-chip-text: #fff;
       color: $color-blue-grey-050;
     }
 
-    .ngx-select-input-list,
-    .ngx-select-placeholder {
+    .ngx-select-input-list {
       padding-left: 10px !important;
     }
 
@@ -123,8 +122,9 @@ $color-chip-text: #fff;
       }
     }
 
-    .ngx-select-label {
-      padding-left: 10px;
+    .ngx-select-label,
+    .ngx-select-placeholder {
+      padding-left: 10px !important;
       line-height: 34px;
     }
 
@@ -422,7 +422,6 @@ $color-chip-text: #fff;
       white-space: nowrap;
       text-overflow: ellipsis;
       max-width: 100%;
-      line-height: 34px;
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -132,6 +132,7 @@ $color-chip-text: #fff;
 
     &.tagging-selection:not(.active) .ngx-select-input-list.no-selections {
       position: absolute;
+      bottom: 0;
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
@@ -348,4 +348,13 @@ describe('SelectComponent', () => {
       expect(component.select.options.length).toBe(1);
     });
   });
+
+  describe('autosize', () => {
+    it('setting autosize adds class to component', () => {
+      component.autosize$.next(true);
+      fixture.detectChanges();
+      const select = fixture.nativeElement.querySelector('.ngx-select');
+      expect(select).toHaveClass('autosize');
+    });
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -52,7 +52,8 @@ const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
     '[class.disabled]': 'disabled',
     '[class.active]': 'dropdownActive',
     '[class.active-selections]': 'hasSelections',
-    '[class.has-placeholder]': 'hasPlaceholder'
+    '[class.has-placeholder]': 'hasPlaceholder',
+    '[class.autosize]': 'autosize'
   },
   providers: [SELECT_VALUE_ACCESSOR],
   encapsulation: ViewEncapsulation.None,
@@ -97,6 +98,14 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   }
   set autofocus(autofocus) {
     this._autofocus = coerceBooleanProperty(autofocus);
+  }
+
+  @Input()
+  get autosize() {
+    return this._autosize;
+  }
+  set autosize(autosize) {
+    this._autosize = coerceBooleanProperty(autosize);
   }
 
   @Input()
@@ -272,6 +281,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   private _maxSelections?: number;
 
   private _autofocus: boolean = false;
+  private _autosize: boolean = false;
   private _allowClear: boolean = true;
   private _allowAdditions: boolean = false;
   private _disableDropdown: boolean = false;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -21,6 +21,8 @@ import { SelectOptionDirective } from './select-option.directive';
 import { SelectInputComponent } from './select-input.component';
 import { SelectDropdownOption } from './select-dropdown-option.interface';
 import { KeyboardKeys } from '../../enums/keyboard-keys.enum';
+import { appearanceMixin } from '../../mixins/appearance/appearance.mixin';
+import { sizeMixin } from '../../mixins/size/size.mixin';
 
 let nextId = 0;
 
@@ -29,6 +31,9 @@ const SELECT_VALUE_ACCESSOR = {
   useExisting: forwardRef(() => SelectComponent),
   multi: true
 };
+
+class InputBase {}
+const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
 
 @Component({
   exportAs: 'ngxSelect',
@@ -39,6 +44,7 @@ const SELECT_VALUE_ACCESSOR = {
     class: 'ngx-select',
     '[id]': 'id',
     '[attr.name]': 'name',
+    '[class]': '[appearance, size]',
     '[class.invalid]': 'invalid && touched',
     '[class.tagging-selection]': 'tagging',
     '[class.multi-selection]': 'multiple',
@@ -52,7 +58,7 @@ const SELECT_VALUE_ACCESSOR = {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SelectComponent implements ControlValueAccessor, OnDestroy {
+export class SelectComponent extends _InputMixinBase implements ControlValueAccessor, OnDestroy {
   @Input() id: string = `select-${++nextId}`;
   @Input() name: string;
   @Input() label: string;
@@ -282,7 +288,9 @@ export class SelectComponent implements ControlValueAccessor, OnDestroy {
     private readonly _element: ElementRef,
     private readonly _renderer: Renderer2,
     private readonly _cdr: ChangeDetectorRef
-  ) {}
+  ) {
+    super();
+  }
 
   ngOnDestroy(): void {
     this.toggleDropdown(false);

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -558,3 +558,39 @@
     ></ngx-select-option>
   </ngx-select>
 </ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Appearances">
+  <ngx-select [filterable]="false" appearance="legacy">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" appearance="fill" label="Fill" hint="im a hint">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <br />
+
+  <ngx-codemirror mode="htmlmixed" readOnly="true">
+    <![CDATA[
+    <ngx-select [filterable]="false" appearance="legacy">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+
+    <ngx-select [filterable]="false" appearance="fill">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
+  </ngx-codemirror>
+</ngx-section>

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -560,7 +560,7 @@
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Appearances">
-  <ngx-select [filterable]="false" appearance="legacy">
+  <ngx-select [filterable]="false" appearance="legacy" label="Legacy input">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
@@ -568,10 +568,47 @@
 
   <br />
 
-  <ngx-select [filterable]="false" appearance="fill" label="Fill" hint="im a hint">
+  <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint" placeholder="Select a value...">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-    <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="true" appearance="fill" label="Fill With Search">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options">
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type">
+    <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+    <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+    <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
   </ngx-select>
 
   <br />
@@ -590,6 +627,33 @@
       <ngx-select-option name="Breach" value="breach"></ngx-select-option>
       <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
       <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+
+    <ngx-select [filterable]="true" appearance="fill" label="Fill With Search">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+  
+    <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+  
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+  
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options">
+    </ngx-select>
+  
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type">
+      <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
     </ngx-select>
     ]]>
   </ngx-codemirror>

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -568,6 +568,15 @@
 
   <br />
 
+  <ngx-select [filterable]="false" appearance="legacy" label="Legacy input with autosize" autosize="true">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    <ngx-select-option name="Really long option to show autosize of the component when autosize is selected" value="Really long option to show autosize of the component when autosize is selected"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
   <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint" placeholder="Select a value...">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
@@ -613,6 +622,53 @@
 
   <br />
 
+  <h4>Autosize</h4>
+
+  <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint" placeholder="Select a value..." autosize="true">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="true" appearance="fill" label="Fill With Search" autosize="true">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections" autosize="true">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging" autosize="true">
+    <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+    <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+    <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options" autosize="true">
+  </ngx-select>
+
+  <br />
+
+  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type" autosize="true">
+    <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+    <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+    <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+  </ngx-select>
+
+  <br />
+
   <br />
 
   <ngx-codemirror mode="htmlmixed" readOnly="true">
@@ -623,6 +679,13 @@
       <ngx-select-option name="Physical" value="physical"></ngx-select-option>
     </ngx-select>
 
+    <ngx-select [filterable]="false" appearance="legacy" label="Legacy input with autosize" autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+      <ngx-select-option name="Really long option to show autosize of the component when autosize is selected" value="Really long option to show autosize of the component when autosize is selected"></ngx-select-option>
+    </ngx-select>
+    
     <ngx-select [filterable]="false" appearance="fill">
       <ngx-select-option name="Breach" value="breach"></ngx-select-option>
       <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
@@ -651,6 +714,41 @@
     </ngx-select>
   
     <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type">
+      <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+    </ngx-select>
+
+    <h4>Autosize</h4>
+
+    <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint" placeholder="Select a value..." autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
+    </ngx-select>
+
+    <ngx-select [filterable]="true" appearance="fill" label="Fill With Search" autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+
+    <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections" autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging" autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options" autosize="true">
+    </ngx-select>
+
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type" autosize="true">
       <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
       <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
       <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>


### PR DESCRIPTION
## Summary

Updated the select component to include a "fill" appearance variant, as shown in the screenshot. This also included an updating of the dropdown styling that applies to both the fill and legacy variants, based on latest designs from UX. For the fill variant, the select will automatically fit to its contents up to the max width of its parent container. If no choice is selected, the select will initialize to the width of either the placeholder or the label if defined.

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_

<img width="954" alt="Screen Shot 2020-07-22 at 9 32 44 AM" src="https://user-images.githubusercontent.com/5652524/88189547-ca09e800-cbfe-11ea-8a0c-7622c605e1fa.png">
<img width="234" alt="Screen Shot 2020-07-22 at 9 33 42 AM" src="https://user-images.githubusercontent.com/5652524/88189548-ca09e800-cbfe-11ea-862d-563a9ba3c91d.png">
<img width="237" alt="Screen Shot 2020-07-22 at 9 33 30 AM" src="https://user-images.githubusercontent.com/5652524/88189549-ca09e800-cbfe-11ea-9c4d-e8a8afc33154.png">
<img width="324" alt="Screen Shot 2020-07-22 at 9 33 20 AM" src="https://user-images.githubusercontent.com/5652524/88189551-caa27e80-cbfe-11ea-8a7a-095b7e7781cd.png">
<img width="342" alt="Screen Shot 2020-07-22 at 9 33 05 AM" src="https://user-images.githubusercontent.com/5652524/88189555-cb3b1500-cbfe-11ea-88f0-5b2b02673880.png">
<img width="339" alt="Screen Shot 2020-07-22 at 9 33 00 AM" src="https://user-images.githubusercontent.com/5652524/88189556-cb3b1500-cbfe-11ea-8e1c-8fbcc6cf7ac9.png">

