### PR TITLE
Update UpdateFilterQueryIsInOptions method

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
@@ -189,6 +189,19 @@ describe('SelectDropdownComponent', () => {
       expect(component.filterQueryIsInOptions).toBeTruthy();
     }));
 
+    it('should display Add Value button when allow additions is true and there is at least still one option on dropdown', fakeAsync(() => {
+      event.target.value = component.groups[0].options[0].option.name.substring(0, 2);
+      component.allowAdditions = true;
+      component.filterable = true;
+
+      component.onInputKeyUp(event);
+      flush();
+      fixture.detectChanges();
+      const allowAdditionsButton = fixture.debugElement.queryAll(By.css('.ngx-select-empty-placeholder'));
+      expect(allowAdditionsButton[0].nativeElement).toBeDefined();
+      expect(allowAdditionsButton[0].nativeElement.innerText).toBe('Add Value');
+    }));
+
     it('should not display Add Value button when allow additions is false', fakeAsync(() => {
       event.target.value = component.groups[0].options[0].option.name.substring(0, 2);
       component.allowAdditions = false;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -153,7 +153,7 @@ export class SelectDropdownComponent implements AfterViewInit {
 
   @debounceable(500)
   updatefilterQueryIsInOptions() {
-    this.filterQueryIsInOptions = this.options.some(o => o.name.toLowerCase().includes(this.filterQuery.toLowerCase()));
+    this.filterQueryIsInOptions = this.options.some(o => o.name.toLowerCase() === this.filterQuery.toLowerCase());
     this.cdr.markForCheck();
   }
 


### PR DESCRIPTION
## Summary

Adding the check back to be a match rather than partial. Looking back into it, what we are checking there is if the filterQuery exactly matches one of the options, we want the add value button to be removed since it is available as an option and we don't want to add a new value with the exact same name(which might cause bugs as well). If we have partial matches, we do want the add value button displayed, to enable the user to add a new value.


![image](https://user-images.githubusercontent.com/62297014/88424160-4c82db00-cdaa-11ea-8aac-43a992c92272.png)
![image](https://user-images.githubusercontent.com/62297014/88424174-560c4300-cdaa-11ea-9723-bc259d552d9b.png)




## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
