### PR TITLE
Promise button bug fix

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.spec.ts
@@ -59,7 +59,7 @@ describe('ButtonComponent', () => {
 
       component.updatePromise().finally(() => {
         expect(component.state).toBe(ButtonState.Success);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(1);
         done();
       });
     });
@@ -72,7 +72,7 @@ describe('ButtonComponent', () => {
 
       component.updatePromise().finally(() => {
         expect(component.state).toBe(ButtonState.Fail);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(1);
         done();
       });
     });

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
@@ -73,7 +73,7 @@ export class ButtonComponent implements OnInit, OnChanges {
   updatePromise() {
     if (this.promise) {
       this.state = ButtonState.InProgress;
-      this.updateState();
+
       return this.promise
         .then(() => {
           this.state = ButtonState.Success;


### PR DESCRIPTION
## Summary

The promise input on the ngx-button had a bug where responses of promises that took longer than 3 seconds, would correctly go into `inProgress` state, then into active state after 3 sec and then properly update the state (success, fail) rather than remaining in the `inProgress` state until the promise resolved/rejected. This was happening because inside the `updatePromise` method, the `updateState` method was being called, which would set the state to `active` after the timer would end, which is set to 3 seconds. Removing this call allows the state to remain `inProgress` up until the Promise is resolved/rejected, which is the desired behavior. This wasn't happening in promises in that took less than 3 seconds to resolve/reject because the timer would be cleared in time before changing states.

Also, we didn't catch this one on the doc pages because the mock promise created is set to 3 sec, same time defined on the timer.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
