### PR TITLE
update ngx-select component to fix focus underline and caret bug

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- enhancement: update ngx-select focus underline to be clearer. clicking the input box now also toggles dropdown
+- Bug: fix ngx-select so that clicking the caret closes the dropdown
+
 ## 29.2.3 (2020-08-14)
 
 - Fix: refactor ngx-select fill css to use proper css ordering and not rely on important keyword

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -56,7 +56,7 @@
     *ngIf="caretVisible"
     class="ngx-select-caret icon-arrow-down"
     [class.icon-arrow-down]="!selectCaret"
-    (click)="toggle.emit()"
+    (click)="onToggle($event)"
   >
     <span *ngIf="isNotTemplate; else tpl" [innerHTML]="selectCaret"> </span>
     <ng-template #tpl>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
@@ -180,6 +180,11 @@ export class SelectInputComponent implements AfterViewInit {
     }
   }
 
+  onToggle(event: Event): void {
+    event.stopPropagation();
+    this.toggle.emit();
+  }
+
   onOptionRemove(event: Event, option: SelectDropdownOption): void {
     event.stopPropagation();
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -240,7 +240,7 @@ $color-chip-text: #fff;
 
     .ngx-select-input-box {
       background: transparent;
-      border: none;
+      outline: none;
       margin-bottom: 0;
       padding-left: 0;
       width: 100%;
@@ -263,6 +263,12 @@ $color-chip-text: #fff;
         width: 0;
         height: 2px;
         margin: 0 auto;
+      }
+    }
+
+    .ngx-select-input-box:focus + .ngx-select-input-underline {
+      .underline-fill {
+        width: 100%;
       }
     }
 
@@ -566,6 +572,7 @@ $color-chip-text: #fff;
 
     .ngx-select-label {
       padding-left: 10px;
+      line-height: 0;
     }
 
     .ngx-select-placeholder {
@@ -577,6 +584,7 @@ $color-chip-text: #fff;
     &.active {
       .ngx-select-label {
         padding: 0;
+        line-height: 30px;
       }
     }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -345,7 +345,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   onFocus(): void {
     if (this.disabled) return;
 
-    this.toggleDropdown(true);
+    this.toggleDropdown(!this.dropdownActive);
     this.onTouchedCallback();
   }
 


### PR DESCRIPTION
## Summary

- Fixed ngx-select caret so that it properly toggles the dropdown. 
- Made the entire input box a toggle, as before it only opened the dropdown.
- Updated the border on the ngx-select to remove the chrome accessibility outline and use our underline on focus

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_

<img width="832" alt="Screen Shot 2020-08-17 at 11 34 03 AM" src="https://user-images.githubusercontent.com/5652524/90420448-95fad900-e07d-11ea-969f-f0015bfde9b6.png">

