### PR TITLE
Spt-7598 - datetime fill autosize

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -5,12 +5,12 @@
 - Chore: Removed ngx-datatable from demo page
 - Enhancement: Added icons; update icon style for `calendar-clock` and `calendar` icons (#491)
 - Breaking: Upgrade to Angular 10
-
-## HEAD (Unreleased)
-
 - Enhancement: replace the default chrome accessibility number spinner with a styled one for number type ngx-inputs
 - Enhancement: added a minWidth input property to ngx-input
 - Fix: rework the way autosize works on ngx-input so that it sizes to its content correctly. Now using ngx-autosize-input library.
+- Enhancement: Updated ngx-date-time component to have fill variants and autosize option
+
+## HEAD (Unreleased)
 
 ## 29.3.0 (2020-08-17)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -105,8 +105,8 @@
   (blur)="onBlur()"
 >
   <ngx-input-hint class="date-time-hint">
-    <div *ngIf="hint" class="text-left">{{ hint }}</div>
-    <div *ngIf="errorMsg" class="text-right input-error">{{ errorMsg }}</div>
+    <div *ngIf="hint">{{ hint }}</div>
+    <div *ngIf="errorMsg" class="input-error">{{ errorMsg }}</div>
   </ngx-input-hint>
 </ngx-input>
 <button

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -28,10 +28,6 @@
   <div class="time-row" *ngIf="inputType === 'time' || inputType === 'datetime'">
     <div>
       <ngx-input
-      [minWidth]="minWidth"
-        [autosize]="autosize"
-        [size]="size"
-        [appearance]="appearance"
         type="number"
         hint="Hour"
         [id]="id + '-hour'"
@@ -45,10 +41,6 @@
     </div>
     <div>
       <ngx-input
-      [minWidth]="minWidth"
-        [autosize]="autosize"
-        [size]="size"
-        [appearance]="appearance"
         type="number"
         hint="Minute"
         [id]="id + '-minute'"

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -1,121 +1,128 @@
-<div class="ngx-date-time">
-  <ng-template #dialogTpl>
-    <div class="selected-header text-center">
-      <h1>
-        <span *ngIf="dialogModel && (inputType === 'datetime' || inputType === 'date')">
-          {{ dialogModel | amTimeZone: timezone | amDateFormat: 'ddd, MMM D YYYY' }}
-          <small *ngIf="inputType === 'datetime'">
-            {{ dialogModel | amTimeZone: timezone | amDateFormat: 'h:mm a' }}
-          </small>
-        </span>
-        <span *ngIf="dialogModel && inputType === 'time'">
+<ng-template #dialogTpl>
+  <div class="selected-header text-center">
+    <h1>
+      <span *ngIf="dialogModel && (inputType === 'datetime' || inputType === 'date')">
+        {{ dialogModel | amTimeZone: timezone | amDateFormat: 'ddd, MMM D YYYY' }}
+        <small *ngIf="inputType === 'datetime'">
           {{ dialogModel | amTimeZone: timezone | amDateFormat: 'h:mm a' }}
-        </span>
-        <span *ngIf="!dialogModel">No value</span>
-      </h1>
-    </div>
-    <ngx-calendar
-      [id]="id + '-cal'"
-      *ngIf="inputType === 'date' || inputType === 'datetime'"
-      (change)="setDialogDate($event)"
-      [minDate]="minDate"
-      [maxDate]="maxDate"
-      [ngModel]="dialogModel"
-      [timezone]="timezone"
-      [minView]="precision"
-      name="calendar"
-    >
-    </ngx-calendar>
-    <div class="time-row" *ngIf="inputType === 'time' || inputType === 'datetime'">
-      <div>
-        <ngx-input
-          type="number"
-          hint="Hour"
-          [id]="id + '-hour'"
-          [ngModel]="hour"
-          min="1"
-          max="12"
-          (change)="hourChanged($event)"
-          [disabled]="isTimeDisabled('hour')"
-        >
-        </ngx-input>
-      </div>
-      <div>
-        <ngx-input
-          type="number"
-          hint="Minute"
-          [id]="id + '-minute'"
-          [ngModel]="minute"
-          min="0"
-          max="59"
-          (change)="minuteChanged($event)"
-          [disabled]="isTimeDisabled('minute')"
-        >
-        </ngx-input>
-      </div>
-      <div>
-        <button
-          class="ampm"
-          type="button"
-          [class.selected]="amPmVal === 'AM'"
-          (click)="onAmPmChange('AM')"
-          [disabled]="isTimeDisabled('hour')"
-        >
-          AM
-        </button>
-        <button
-          class="ampm"
-          type="button"
-          [class.selected]="amPmVal === 'PM'"
-          (click)="onAmPmChange('PM')"
-          [disabled]="isTimeDisabled('hour')"
-        >
-          PM
-        </button>
-      </div>
-    </div>
-    <nav role="navigation" class="ngx-dialog-footer">
-      <div class="text-left">
-        <button type="button" class="btn btn-link today-btn" (click)="selectCurrent()" [hidden]="isCurrent()">
-          Current
-        </button>
-      </div>
-      <div class="text-right">
-        <button type="button" class="btn btn-link clear-btn" (click)="clear()">Clear</button>
-        <button type="button" class="btn btn-link apply-btn" (click)="apply()">Apply</button>
-      </div>
-    </nav>
-  </ng-template>
-  <ngx-input
-    #input
-    [id]="id + '-input'"
-    [autocorrect]="false"
-    [autocomplete]="false"
-    [spellcheck]="false"
-    [disabled]="disabled"
-    [placeholder]="placeholder"
-    [autofocus]="autofocus"
-    [tabindex]="tabindex"
-    [label]="label"
-    [ngModel]="displayValue"
-    (ngModelChange)="inputChanged($event)"
-    (blur)="onBlur()"
+        </small>
+      </span>
+      <span *ngIf="dialogModel && inputType === 'time'">
+        {{ dialogModel | amTimeZone: timezone | amDateFormat: 'h:mm a' }}
+      </span>
+      <span *ngIf="!dialogModel">No value</span>
+    </h1>
+  </div>
+  <ngx-calendar
+    [id]="id + '-cal'"
+    *ngIf="inputType === 'date' || inputType === 'datetime'"
+    (change)="setDialogDate($event)"
+    [minDate]="minDate"
+    [maxDate]="maxDate"
+    [ngModel]="dialogModel"
+    [timezone]="timezone"
+    [minView]="precision"
+    name="calendar"
   >
-    <ngx-input-hint class="date-time-hint">
-      <div *ngIf="hint" class="text-left">{{ hint }}</div>
-      <div *ngIf="errorMsg" class="text-right input-error">{{ errorMsg }}</div>
-    </ngx-input-hint>
-  </ngx-input>
-  <button
-    title="Show date/time selector"
-    type="button"
-    [disabled]="disabled"
-    (click)="open()"
-    [ngClass]="{
-      'icon-calendar': inputType === 'date',
-      'icon-calendar-clock': inputType === 'datetime',
-      'icon-clock': inputType === 'time'
-    }"
-    class="calendar-dialog-btn"
-  ></button>
-</div>
+  </ngx-calendar>
+  <div class="time-row" *ngIf="inputType === 'time' || inputType === 'datetime'">
+    <div>
+      <ngx-input
+        [autosize]="autosize"
+        [size]="size"
+        [appearance]="appearance"
+        type="number"
+        hint="Hour"
+        [id]="id + '-hour'"
+        [ngModel]="hour"
+        min="1"
+        max="12"
+        (change)="hourChanged($event)"
+        [disabled]="isTimeDisabled('hour')"
+      >
+      </ngx-input>
+    </div>
+    <div>
+      <ngx-input
+        [autosize]="autosize"
+        [size]="size"
+        [appearance]="appearance"
+        type="number"
+        hint="Minute"
+        [id]="id + '-minute'"
+        [ngModel]="minute"
+        min="0"
+        max="59"
+        (change)="minuteChanged($event)"
+        [disabled]="isTimeDisabled('minute')"
+      >
+      </ngx-input>
+    </div>
+    <div>
+      <button
+        class="ampm"
+        type="button"
+        [class.selected]="amPmVal === 'AM'"
+        (click)="onAmPmChange('AM')"
+        [disabled]="isTimeDisabled('hour')"
+      >
+        AM
+      </button>
+      <button
+        class="ampm"
+        type="button"
+        [class.selected]="amPmVal === 'PM'"
+        (click)="onAmPmChange('PM')"
+        [disabled]="isTimeDisabled('hour')"
+      >
+        PM
+      </button>
+    </div>
+  </div>
+  <nav role="navigation" class="ngx-dialog-footer">
+    <div class="text-left">
+      <button type="button" class="btn btn-link today-btn" (click)="selectCurrent()" [hidden]="isCurrent()">
+        Current
+      </button>
+    </div>
+    <div class="text-right">
+      <button type="button" class="btn btn-link clear-btn" (click)="clear()">Clear</button>
+      <button type="button" class="btn btn-link apply-btn" (click)="apply()">Apply</button>
+    </div>
+  </nav>
+</ng-template>
+<ngx-input
+  #input
+  [id]="id + '-input'"
+  [autosize]="autosize"
+  [size]="size"
+  [appearance]="appearance"
+  [autocorrect]="false"
+  [autocomplete]="false"
+  [spellcheck]="false"
+  [disabled]="disabled"
+  [placeholder]="placeholder"
+  [autofocus]="autofocus"
+  [tabindex]="tabindex"
+  [label]="label"
+  [ngModel]="displayValue"
+  (ngModelChange)="inputChanged($event)"
+  (blur)="onBlur()"
+>
+  <ngx-input-hint class="date-time-hint">
+    <div *ngIf="hint" class="text-left">{{ hint }}</div>
+    <div *ngIf="errorMsg" class="text-right input-error">{{ errorMsg }}</div>
+  </ngx-input-hint>
+</ngx-input>
+<button
+  title="Show date/time selector"
+  type="button"
+  [disabled]="disabled"
+  (click)="open()"
+  [ngClass]="{
+    'icon-calendar': inputType === 'date',
+    'icon-calendar-clock': inputType === 'datetime',
+    'icon-clock': inputType === 'time'
+  }"
+  class="calendar-dialog-btn"
+></button>

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -28,6 +28,7 @@
   <div class="time-row" *ngIf="inputType === 'time' || inputType === 'datetime'">
     <div>
       <ngx-input
+      [minWidth]="minWidth"
         [autosize]="autosize"
         [size]="size"
         [appearance]="appearance"
@@ -44,6 +45,7 @@
     </div>
     <div>
       <ngx-input
+      [minWidth]="minWidth"
         [autosize]="autosize"
         [size]="size"
         [appearance]="appearance"
@@ -93,6 +95,7 @@
 </ng-template>
 <ngx-input
   #input
+  [minWidth]="minWidth"
   [id]="id + '-input'"
   [autosize]="autosize"
   [size]="size"

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
@@ -43,6 +43,17 @@ $animation-timing: 200ms;
     }
   }
 
+  .date-time-hint {
+    display: flex;
+    justify-content: space-between;
+
+    .input-error {
+      color: $color-red;
+      margin-left: auto;
+      padding-left: 5px;
+    }
+  }
+
   &.autosize {
     display: inline-block;
 
@@ -53,17 +64,23 @@ $animation-timing: 200ms;
     &.fill .calendar-dialog-btn {
       transform: translateY(-15%);
     }
-  }
 
-  .date-time-hint {
-    display: flex;
+    .ngx-input-hint {
+      position: relative;
 
-    > * {
-      flex: 1 1 50%;
-    }
+      .date-time-hint {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        max-width: 100%;
+        white-space: nowrap;
 
-    .input-error {
-      color: $color-red;
+        > * {
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
     }
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
@@ -22,36 +22,36 @@ $animation-timing: 200ms;
     }
   }
 
-  &.autosize {
-    display: inline-block;
-  }
-
   .calendar-dialog-btn {
     position: absolute;
-    right: 5px;
-    height: 30px;
-    line-height: 30px;
-    top: -5px;
-    color: $color-blue-grey-200;
     padding: 0;
-    padding-top: 20px;
-    padding-top: calc(0.7em + 8px);
-    padding-bottom: 20px;
-    padding-bottom: calc(0.7em + 8px);
+    right: 5px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: $color-blue-grey-200;
     z-index: 2;
+  }
+
+  .ngx-input-box-wrap {
+    padding-right: 25px;
   }
 
   &.fill {
     .calendar-dialog-btn {
-      top: 50%;
+      transform: translateY(-35%);
       right: 10px;
-      transform: translateY(-45%);
-      height: initial;
-      line-height: initial;
+    }
+  }
+
+  &.autosize {
+    display: inline-block;
+
+    .calendar-dialog-btn {
+      transform: translateY(-25%);
     }
 
-    .ngx-input-box-wrap {
-      padding-right: 20px;
+    &.fill .calendar-dialog-btn {
+      transform: translateY(-15%);
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
@@ -7,6 +7,24 @@ $animation-timing: 200ms;
 
 .ngx-date-time {
   position: relative;
+  display: block;
+  max-width: 100%;
+
+  &.md {
+    .ngx-input {
+      font-size: 18px !important;
+    }
+  }
+
+  &.lg {
+    .ngx-input {
+      font-size: 21px !important;
+    }
+  }
+
+  &.autosize {
+    display: inline-block;
+  }
 
   .calendar-dialog-btn {
     position: absolute;
@@ -20,6 +38,21 @@ $animation-timing: 200ms;
     padding-top: calc(0.7em + 8px);
     padding-bottom: 20px;
     padding-bottom: calc(0.7em + 8px);
+    z-index: 2;
+  }
+
+  &.fill {
+    .calendar-dialog-btn {
+      top: 50%;
+      right: 10px;
+      transform: translateY(-45%);
+      height: initial;
+      line-height: initial;
+    }
+
+    .ngx-input-box-wrap {
+      padding-right: 20px;
+    }
   }
 
   .date-time-hint {

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -25,6 +25,8 @@ import { sizeMixin } from '../../mixins/size/size.mixin';
 
 let nextId = 0;
 
+const MIN_WIDTH = 60;
+
 const DATE_TIME_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => DateTimeComponent),
@@ -72,6 +74,14 @@ export class DateTimeComponent extends _InputMixinBase implements OnDestroy, Con
   }
   set disabled(disabled) {
     this._disabled = coerceBooleanProperty(disabled);
+  }
+
+  @Input()
+  get minWidth(): number {
+    return this._minWidth;
+  }
+  set minWidth(minWidth) {
+    this._minWidth = coerceNumberProperty(minWidth);
   }
 
   @Input()
@@ -188,6 +198,7 @@ export class DateTimeComponent extends _InputMixinBase implements OnDestroy, Con
   private _autofocus: boolean = false;
   private _tabindex: number;
   private _autosize: boolean = false;
+  private _minWidth: number = MIN_WIDTH;
 
   constructor(private readonly dialogService: DialogService) {
     super();

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -20,8 +20,8 @@ import { DialogService } from '../dialog/dialog.service';
 import { DateTimeType } from './date-time-type.enum';
 import { Datelike } from './date-like.type';
 import { InputComponent } from '../input/input.component';
-import { appearanceMixin } from '../../mixins/appearance/appearance.mixin';
-import { sizeMixin } from '../../mixins/size/size.mixin';
+import { Size } from '../../mixins/size/size.enum';
+import { Appearance } from '../../mixins/appearance/appearance.enum';
 
 let nextId = 0;
 
@@ -32,9 +32,6 @@ const DATE_TIME_VALUE_ACCESSOR = {
   useExisting: forwardRef(() => DateTimeComponent),
   multi: true
 };
-
-class InputBase {}
-const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
 
 @Component({
   exportAs: 'ngxDateTime',
@@ -54,12 +51,14 @@ const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
     '[class.autosize]': 'autosize'
   }
 })
-export class DateTimeComponent extends _InputMixinBase implements OnDestroy, ControlValueAccessor {
+export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   @Input() id: string = `datetime-${++nextId}`;
   @Input() name: string;
   @Input() label: string;
   @Input() hint: string;
   @Input() placeholder: string = '';
+  @Input() size: Size = Size.Small;
+  @Input() appearance: Appearance = Appearance.Legacy;
 
   @Input() minDate: string | Date;
   @Input() maxDate: string | Date;
@@ -200,9 +199,7 @@ export class DateTimeComponent extends _InputMixinBase implements OnDestroy, Con
   private _autosize: boolean = false;
   private _minWidth: number = MIN_WIDTH;
 
-  constructor(private readonly dialogService: DialogService) {
-    super();
-  }
+  constructor(private readonly dialogService: DialogService) {}
 
   ngOnDestroy(): void {
     this.close();

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -20,6 +20,8 @@ import { DialogService } from '../dialog/dialog.service';
 import { DateTimeType } from './date-time-type.enum';
 import { Datelike } from './date-like.type';
 import { InputComponent } from '../input/input.component';
+import { appearanceMixin } from '../../mixins/appearance/appearance.mixin';
+import { sizeMixin } from '../../mixins/size/size.mixin';
 
 let nextId = 0;
 
@@ -29,6 +31,9 @@ const DATE_TIME_VALUE_ACCESSOR = {
   multi: true
 };
 
+class InputBase {}
+const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
+
 @Component({
   exportAs: 'ngxDateTime',
   selector: 'ngx-date-time',
@@ -36,9 +41,18 @@ const DATE_TIME_VALUE_ACCESSOR = {
   styleUrls: ['./date-time.component.scss'],
   providers: [DATE_TIME_VALUE_ACCESSOR],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'ngx-date-time',
+    '[class.legacy]': 'appearance === "legacy"',
+    '[class.fill]': 'appearance === "fill"',
+    '[class.sm]': 'size === "sm"',
+    '[class.md]': 'size === "md"',
+    '[class.lg]': 'size === "lg"',
+    '[class.autosize]': 'autosize'
+  }
 })
-export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
+export class DateTimeComponent extends _InputMixinBase implements OnDestroy, ControlValueAccessor {
   @Input() id: string = `datetime-${++nextId}`;
   @Input() name: string;
   @Input() label: string;
@@ -142,6 +156,14 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     }
   }
 
+  @Input()
+  get autosize() {
+    return this._autosize;
+  }
+  set autosize(v: boolean) {
+    this._autosize = coerceBooleanProperty(v);
+  }
+
   @Output() change = new EventEmitter<string | Date>();
 
   @ViewChild('dialogTpl', { static: true })
@@ -165,8 +187,11 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   private _disabled: boolean = false;
   private _autofocus: boolean = false;
   private _tabindex: number;
+  private _autosize: boolean = false;
 
-  constructor(private readonly dialogService: DialogService) {}
+  constructor(private readonly dialogService: DialogService) {
+    super();
+  }
 
   ngOnDestroy(): void {
     this.close();

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
@@ -78,6 +78,7 @@
     [minWidth]="minWidth"
     [includePadding]="true"
     [(ngModel)]="value"
+    [value]="value"
     [id]="id"
     [name]="name"
     [placeholder]="placeholder"

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -66,7 +66,6 @@ $input-placeholder-color: $color-blue-grey-350;
 
   &.autosize {
     display: inline-block;
-    width: fit-content;
   }
 
   // override chrome autofill styles

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -83,7 +83,6 @@ export class InputComponent extends _InputMixinBase
   @Input() max: number;
   @Input() minlength: number;
   @Input() maxlength: number;
-  @Input() minWidth: number = MIN_WIDTH;
 
   @Input()
   get disabled() {
@@ -91,6 +90,14 @@ export class InputComponent extends _InputMixinBase
   }
   set disabled(disabled: boolean) {
     this._disabled = coerceBooleanProperty(disabled);
+  }
+
+  @Input()
+  get minWidth(): number {
+    return this._minWidth;
+  }
+  set minWidth(minWidth) {
+    this._minWidth = coerceNumberProperty(minWidth);
   }
 
   @Input() requiredIndicator: string | boolean = '*';
@@ -237,6 +244,7 @@ export class InputComponent extends _InputMixinBase
   private _autosize: boolean = false;
   private _spinnerInterval;
   private _spinnerTimeout;
+  private _minWidth: number = MIN_WIDTH;
 
   constructor(private readonly cdr: ChangeDetectorRef) {
     super();

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -26,11 +26,10 @@ import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coerci
 import { BehaviorSubject } from 'rxjs';
 
 import { Appearance } from '../../mixins/appearance/appearance.enum';
-import { appearanceMixin } from '../../mixins/appearance/appearance.mixin';
-import { sizeMixin } from '../../mixins/size/size.mixin';
 
 import { InputTypes } from './input-types.enum';
 import { INPUT_ANIMATIONS } from './input-animations.constant';
+import { Size } from '../../mixins/size/size.enum';
 
 let nextId = 0;
 
@@ -47,9 +46,6 @@ const INPUT_VALIDATORS = {
 };
 
 const MIN_WIDTH = 60;
-
-class InputBase {}
-const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
 
 @Component({
   exportAs: 'ngxInput',
@@ -71,8 +67,7 @@ const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class InputComponent extends _InputMixinBase
-  implements AfterViewInit, OnDestroy, ControlValueAccessor, Validator {
+export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAccessor, Validator {
   @Input() id: string = `input-${++nextId}`;
   @Input() name: string;
   @Input() label: string = '';
@@ -83,6 +78,8 @@ export class InputComponent extends _InputMixinBase
   @Input() max: number;
   @Input() minlength: number;
   @Input() maxlength: number;
+  @Input() size: Size = Size.Small;
+  @Input() appearance: Appearance = Appearance.Legacy;
 
   @Input()
   get disabled() {
@@ -246,9 +243,7 @@ export class InputComponent extends _InputMixinBase
   private _spinnerTimeout;
   private _minWidth: number = MIN_WIDTH;
 
-  constructor(private readonly cdr: ChangeDetectorRef) {
-    super();
-  }
+  constructor(private readonly cdr: ChangeDetectorRef) {}
 
   ngAfterViewInit(): void {
     if (this.autofocus) {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -385,6 +385,7 @@ export class InputComponent extends _InputMixinBase
 
       el.value = el.value ? (+el.value + 1).toString() : '1';
       this.value = el.value;
+      this.change.emit(this._value);
       if (document.activeElement !== this.inputControl.nativeElement) {
         this.inputControl.nativeElement.focus();
       }
@@ -401,6 +402,7 @@ export class InputComponent extends _InputMixinBase
         if (min === 0 && !el.value) {
           el.value = '0';
           this.value = el.value;
+          this.change.emit(this._value);
           this.inputControl.nativeElement.focus();
           return;
         } else if (+el.value <= min) {
@@ -410,6 +412,7 @@ export class InputComponent extends _InputMixinBase
 
       el.value = el.value ? (+el.value - 1).toString() : '-1';
       this.value = el.value;
+      this.change.emit(this._value);
       if (document.activeElement !== this.inputControl.nativeElement) {
         this.inputControl.nativeElement.focus();
       }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
@@ -1,5 +1,5 @@
 <div class="ngx-select-wrap">
-  <div class="ngx-select-flex-wrap">
+  <div class="ngx-select-flex-wrap" [style.min-width]="autosize ? autosizeMinWidth : undefined">
     <div class="ngx-select-flex-wrap-inner">
       <ngx-select-input
         [autofocus]="autofocus"

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -18,7 +18,6 @@ $color-empty-text: $color-blue-grey-150;
 $color-chip-bg: $color-blue-400;
 $color-chip-hover-bg: $color-blue;
 $color-chip-text: #fff;
-$autosize-min-width: var(--autosize-min-width);
 
 .ngx-select {
   position: relative;
@@ -32,8 +31,6 @@ $autosize-min-width: var(--autosize-min-width);
   padding-bottom: 0;
 
   &.autosize {
-    min-width: $autosize-min-width;
-
     .ngx-select-dropdown {
       width: fit-content;
       min-width: 190px;
@@ -43,7 +40,6 @@ $autosize-min-width: var(--autosize-min-width);
     .ngx-select-flex-wrap {
       max-width: 100%;
       width: fit-content;
-      min-width: $autosize-min-width;
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -32,6 +32,8 @@ $autosize-min-width: var(--autosize-min-width);
   padding-bottom: 0;
 
   &.autosize {
+    min-width: $autosize-min-width;
+
     .ngx-select-dropdown {
       width: fit-content;
       min-width: 190px;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -18,11 +18,12 @@ $color-empty-text: $color-blue-grey-150;
 $color-chip-bg: $color-blue-400;
 $color-chip-hover-bg: $color-blue;
 $color-chip-text: #fff;
+$autosize-min-width: var(--autosize-min-width);
 
 .ngx-select {
   position: relative;
   display: block;
-  min-width: 60px;
+  min-width: 300px;
   line-height: 1.4em;
   margin-top: 16px;
   margin-bottom: 8px;
@@ -40,6 +41,7 @@ $color-chip-text: #fff;
     .ngx-select-flex-wrap {
       max-width: 100%;
       width: fit-content;
+      min-width: $autosize-min-width;
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -12,8 +12,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  OnInit
+  ChangeDetectorRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
@@ -58,13 +57,14 @@ const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
     '[class.active]': 'dropdownActive',
     '[class.active-selections]': 'hasSelections',
     '[class.has-placeholder]': 'hasPlaceholder',
-    '[class.autosize]': 'autosize'
+    '[class.autosize]': 'autosize',
+    '[style.min-width]': 'autosize ? autosizeMinWidth : undefined'
   },
   providers: [SELECT_VALUE_ACCESSOR],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SelectComponent extends _InputMixinBase implements ControlValueAccessor, OnInit, OnDestroy {
+export class SelectComponent extends _InputMixinBase implements ControlValueAccessor, OnDestroy {
   @Input() id: string = `select-${++nextId}`;
   @Input() name: string;
   @Input() label: string;
@@ -318,12 +318,6 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     private readonly _cdr: ChangeDetectorRef
   ) {
     super();
-  }
-
-  ngOnInit() {
-    if (this.autosize) {
-      this._element.nativeElement.style.setProperty('--autosize-min-width', this.autosizeMinWidth);
-    }
   }
 
   ngOnDestroy(): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -12,7 +12,8 @@ import {
   ViewChild,
   ViewEncapsulation,
   ChangeDetectionStrategy,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  OnInit
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
@@ -63,7 +64,7 @@ const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SelectComponent extends _InputMixinBase implements ControlValueAccessor, OnDestroy {
+export class SelectComponent extends _InputMixinBase implements ControlValueAccessor, OnInit, OnDestroy {
   @Input() id: string = `select-${++nextId}`;
   @Input() name: string;
   @Input() label: string;
@@ -86,6 +87,18 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   }
   set minSelections(minSelections) {
     this._minSelections = coerceNumberProperty(minSelections, undefined);
+  }
+
+  @Input()
+  get autosizeMinWidth(): number | string {
+    return this._autosizeMinWidth;
+  }
+  set autosizeMinWidth(autosizeMinWidth) {
+    if (!isNaN(+autosizeMinWidth)) {
+      this._autosizeMinWidth = `${autosizeMinWidth}px`;
+    } else if (typeof autosizeMinWidth === 'string') {
+      this._autosizeMinWidth = autosizeMinWidth;
+    }
   }
 
   @Input()
@@ -297,6 +310,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   private _tagging: boolean = false;
   private _multiple: boolean = false;
   private _disabled: boolean = false;
+  private _autosizeMinWidth: string = '60px';
 
   constructor(
     private readonly _element: ElementRef,
@@ -304,6 +318,12 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     private readonly _cdr: ChangeDetectorRef
   ) {
     super();
+  }
+
+  ngOnInit() {
+    if (this.autosize) {
+      this._element.nativeElement.style.setProperty('--autosize-min-width', this.autosizeMinWidth);
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -202,3 +202,108 @@
     (change)="dateChanged($event)"> </ngx-date-time> ]]>
   </ngx-codemirror>
 </ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Fill">
+  Current Value: {{ curDate2 | json }}
+  <ngx-date-time
+    appearance="fill"
+    inputType="date"
+    label="Year"
+    precision="year"
+    [(ngModel)]="curDate2"
+    format="YYYY"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+
+  <ngx-date-time
+    appearance="fill"
+    inputType="date"
+    label="Month"
+    precision="month"
+    [(ngModel)]="curDate2"
+    format="MMM YYYY"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+
+  <ngx-date-time
+    appearance="fill"
+    inputType="datetime"
+    label="Hour"
+    precision="hour"
+    [(ngModel)]="curDate2"
+    format="MMM DD, YYYY, hh:mm"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+
+  <ngx-date-time
+    appearance="fill"
+    inputType="datetime"
+    label="Minutes"
+    precision="minute"
+    [(ngModel)]="curDate2"
+    format="MMM DD, YYYY, hh:mm:ss"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Autosize">
+  Current Value: {{ curDate2 | json }}
+  
+  <br />
+
+  <ngx-date-time
+    autosize="true"
+    inputType="date"
+    label="Year"
+    precision="year"
+    [(ngModel)]="curDate2"
+    format="YYYY"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+
+  <br />
+
+  <ngx-date-time
+    autosize="true"
+    inputType="date"
+    label="Month"
+    precision="month"
+    [(ngModel)]="curDate2"
+    format="MMM YYYY"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+
+  <br />
+
+  <ngx-date-time
+    autosize="true"
+    appearance="fill"
+    inputType="datetime"
+    label="Hour"
+    precision="hour"
+    [(ngModel)]="curDate2"
+    format="MMM DD, YYYY, hh:mm"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+
+  <br />
+
+  <ngx-date-time
+    autosize="true"
+    appearance="fill"
+    inputType="datetime"
+    label="Minutes"
+    precision="minute"
+    [(ngModel)]="curDate2"
+    format="MMM DD, YYYY, hh:mm:ss"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+</ngx-section>

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -385,7 +385,7 @@
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Auto Size">
-  <ngx-input autosize label="Resize Input"></ngx-input>
+  <ngx-input [(ngModel)]="inputValue" autosize label="Resize Input"></ngx-input>
 
   <br />
 


### PR DESCRIPTION
## Summary

Updated the `ngx-date-time` component to have a fill appearance variant and support autosizing.

as part of this, also fixed the following bugs I found in ngx-input:
- when autosize is set with an initial value, the component will now properly autosize to that value on init
- The numeric spinners now emit a change event on press

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_

<img width="961" alt="Screen Shot 2020-09-16 at 11 40 43 AM" src="https://user-images.githubusercontent.com/5652524/93368188-3e35c600-f813-11ea-854e-f6ebb2102bc1.png">
<img width="962" alt="Screen Shot 2020-09-16 at 11 40 49 AM" src="https://user-images.githubusercontent.com/5652524/93368189-3ece5c80-f813-11ea-9119-69bbca791a38.png">

