### PR TITLE
Fix displayValue for DateTimeComponent

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -9,7 +9,8 @@ import {
   TemplateRef,
   OnDestroy,
   ElementRef,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  ChangeDetectorRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
@@ -165,6 +166,15 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     }
   }
 
+  get displayValue(): string {
+    return this._displayValue;
+  }
+
+  set displayValue(value: string) {
+    this._displayValue = value;
+    this.cdr.markForCheck();
+  }
+
   @Input()
   get autosize() {
     return this._autosize;
@@ -187,10 +197,10 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   hour: number;
   minute: string;
   amPmVal: string;
-  displayValue = '';
   modes = ['millisecond', 'second', 'minute', 'hour', 'date', 'month', 'year'];
 
   private _value: Date | string;
+  private _displayValue: string = '';
   private _format: string;
   private _inputType: string;
   private _disabled: boolean = false;
@@ -199,7 +209,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   private _autosize: boolean = false;
   private _minWidth: number = MIN_WIDTH;
 
-  constructor(private readonly dialogService: DialogService) {}
+  constructor(private readonly dialogService: DialogService, private readonly cdr: ChangeDetectorRef) {}
 
   ngOnDestroy(): void {
     this.close();


### PR DESCRIPTION
## Summary

Display value for `<ngx-date-time />` not updated when used as part of a reactive form. Steps to reproduce:
```html
<div [formGroup]="form">
  <ngx-date-time formControlName="date"> </ngx-date-time>
</div>
```
After selecting the date and clicking the `Apply` button the input field is not updated.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
