### PR TITLE
fix: select not auto-collapse when click on caret

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -26,10 +26,20 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.app.json",
-            "assets": ["src/favicon.ico", "src/favicon-16x16.png", "src/assets", "src/.nojekyll"],
-            "styles": ["src/styles.scss"],
+            "assets": [
+              "src/favicon.ico",
+              "src/favicon-16x16.png",
+              "src/assets",
+              "src/.nojekyll"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
             "stylePreprocessorOptions": {
-              "includePaths": ["dist/swimlane/ngx-ui/lib/styles", "dist/swimlane/ngx-ui/lib/assets"]
+              "includePaths": [
+                "dist/swimlane/ngx-ui/lib/styles",
+                "dist/swimlane/ngx-ui/lib/assets"
+              ]
             },
             "scripts": []
           },
@@ -92,16 +102,26 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.spec.json",
             "karmaConfig": "src/karma.conf.js",
-            "styles": ["src/styles.scss"],
+            "styles": [
+              "src/styles.scss"
+            ],
             "scripts": [],
-            "assets": ["src/favicon.ico", "src/assets"]
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ]
           }
         },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": ["src/tsconfig.app.json", "src/tsconfig.spec.json"],
-            "exclude": ["**/node_modules/**"]
+            "tsConfig": [
+              "src/tsconfig.app.json",
+              "src/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
           }
         }
       }
@@ -154,12 +174,20 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": ["projects/swimlane/ngx-ui/tsconfig.lib.json", "projects/swimlane/ngx-ui/tsconfig.spec.json"],
-            "exclude": ["**/node_modules/**"]
+            "tsConfig": [
+              "projects/swimlane/ngx-ui/tsconfig.lib.json",
+              "projects/swimlane/ngx-ui/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
           }
         }
       }
     }
   },
-  "defaultProject": "ngx-ui"
+  "defaultProject": "ngx-ui",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/cypress/integration/forms/selects-spec.js
+++ b/cypress/integration/forms/selects-spec.js
@@ -1,0 +1,38 @@
+describe('Selects', () => {
+  before(() => {
+    cy.visit('/selects');
+    cy.get('.page-loader').should('not.be.visible', { timeout: 20000 });
+  });
+
+  describe('Close on body click', () => {
+    beforeEach(() => {
+      cy.asAllDataCy();
+    });
+
+    it('should close on input click', () => {
+      cy.get('@attackType').find('.ngx-select-dropdown-options').should('not.be.visible');
+      cy.get('@attackType').find('.ngx-select-input-box').click();
+      cy.get('@attackType').find('.ngx-select-dropdown-options').should('be.visible');
+
+      cy.get('@attackTypeRequired').find('.ngx-select-dropdown-options').should('not.be.visible');
+      cy.get('@attackTypeRequired').find('.ngx-select-input-box').click();
+      cy.get('@attackTypeRequired').find('.ngx-select-dropdown-options').should('be.visible');
+
+      // the current opened select should be closed
+      cy.get('@attackType').find('.ngx-select-dropdown-options').should('not.be.visible');
+    });
+
+    it('should close on caret down click', () => {
+      cy.get('@attackType').find('.ngx-select-dropdown-options').should('not.be.visible');
+      cy.get('@attackType').find('.ngx-select-caret').click();
+      cy.get('@attackType').find('.ngx-select-dropdown-options').should('be.visible');
+
+      cy.get('@attackTypeRequired').find('.ngx-select-dropdown-options').should('not.be.visible');
+      cy.get('@attackTypeRequired').find('.ngx-select-caret').click();
+      cy.get('@attackTypeRequired').find('.ngx-select-dropdown-options').should('be.visible');
+
+      // the current opened select should be closed
+      cy.get('@attackType').find('.ngx-select-dropdown-options').should('not.be.visible');
+    });
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,40 +25,46 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('navigate', (url, options = {}) => {
-    return cy.window().then($win => {
-      // No page loaded, visit
-      if (options.forceReload || !$win.location.href.startsWith(Cypress.config('baseUrl'))) {
-        cy.log('Visit');
-        cy.visit(url, options);
-        return cy.get('.page-loader').should('not.be.visible', { timeout: 20000 });
-      }
-  
-      if (!url || url === '') {
-        cy.log('Reload');
-        cy.reload();
-        return cy.get('.page-loader').should('not.be.visible', { timeout: 20000 });
-      }
-  
-      // Already on this page, navigate away then back, fater than visit or reload
-      if ($win.location.href === Cypress.config('baseUrl') + url) {
-        cy.log('Refresh');
-        return navByLink('/').then(() => {
-          return navByLink(url);
-        });
-      }
-  
-      return navByLink(url);
-  
-      // Equivalent to navigating by link
-      function navByLink(url) {
-        cy.log('navByLink');
-        return cy.document().then($doc => {
-          var a = $doc.createElement('a');
-          a.href = url;
-          $doc.body.appendChild(a);
-          a.click();
-          $doc.body.removeChild(a);
-        });
-      }
-    });
+  return cy.window().then($win => {
+    // No page loaded, visit
+    if (options.forceReload || !$win.location.href.startsWith(Cypress.config('baseUrl'))) {
+      cy.log('Visit');
+      cy.visit(url, options);
+      return cy.get('.page-loader').should('not.be.visible', { timeout: 20000 });
+    }
+
+    if (!url || url === '') {
+      cy.log('Reload');
+      cy.reload();
+      return cy.get('.page-loader').should('not.be.visible', { timeout: 20000 });
+    }
+
+    // Already on this page, navigate away then back, fater than visit or reload
+    if ($win.location.href === Cypress.config('baseUrl') + url) {
+      cy.log('Refresh');
+      return navByLink('/').then(() => {
+        return navByLink(url);
+      });
+    }
+
+    return navByLink(url);
+
+    // Equivalent to navigating by link
+    function navByLink(url) {
+      cy.log('navByLink');
+      return cy.document().then($doc => {
+        var a = $doc.createElement('a');
+        a.href = url;
+        $doc.body.appendChild(a);
+        a.click();
+        $doc.body.removeChild(a);
+      });
+    }
   });
+});
+
+Cypress.Commands.add('asAllDataCy', () =>
+  cy.get('[data-cy]').then(list => {
+    list.each((i, { dataset: { cy: name } }) => cy.get(`[data-cy=${name}]`).as(name));
+  })
+);

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,0 +1,6 @@
+// tslint:disable-next-line:no-namespace
+declare namespace Cypress {
+  interface Chainable<T = unknown> {
+    asAllDataCy(): Chainable<void>;
+  }
+}

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,6 +1,19 @@
 // tslint:disable-next-line:no-namespace
 declare namespace Cypress {
   interface Chainable<T = unknown> {
+    /**
+     * Get and alias all elements with `[data-cy]` attr on the current page.
+     * @see https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements
+     *
+     * @example
+     *    <div data-cy="firstDiv"></div>
+     *    <div data-cy="secondDiv"></div>
+     *
+     *    cy.asAllDataCy();
+     *    // equivalent to:
+     *    cy.get('[data-cy=firstDiv]').as('firstDiv');
+     *    cy.get('[data-cy=secondDiv]').as('secondDiv');
+     */
     asAllDataCy(): Chainable<void>;
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -52,18 +52,18 @@
     (click)="selection.emit([])"
   >
   </span>
-  <span
-    *ngIf="caretVisible"
-    class="ngx-select-caret icon-arrow-down"
-    [class.icon-arrow-down]="!selectCaret"
-    (click)="onToggle($event)"
-  >
-    <span *ngIf="isNotTemplate; else tpl" [innerHTML]="selectCaret"> </span>
-    <ng-template #tpl>
-      <ng-container *ngTemplateOutlet="selectCaret"></ng-container>
-    </ng-template>
-  </span>
 </div>
+<span
+  *ngIf="caretVisible"
+  class="ngx-select-caret icon-arrow-down"
+  [class.icon-arrow-down]="!selectCaret"
+  (click)="onToggle()"
+>
+  <span *ngIf="isNotTemplate; else tpl" [innerHTML]="selectCaret"> </span>
+  <ng-template #tpl>
+    <ng-container *ngTemplateOutlet="selectCaret"></ng-container>
+  </ng-template>
+</span>
 <div class="ngx-select-input-underline">
   <div class="underline-fill"></div>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
@@ -1,13 +1,13 @@
 import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
+  ElementRef,
+  EventEmitter,
   Input,
   Output,
-  EventEmitter,
-  ViewChild,
-  AfterViewInit,
   TemplateRef,
-  ElementRef,
-  ChangeDetectionStrategy
+  ViewChild
 } from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
@@ -35,6 +35,7 @@ export class SelectInputComponent implements AfterViewInit {
   get autofocus() {
     return this._autofocus;
   }
+
   set autofocus(autofocus) {
     this._autofocus = coerceBooleanProperty(autofocus);
   }
@@ -43,6 +44,7 @@ export class SelectInputComponent implements AfterViewInit {
   get allowClear() {
     return this._allowClear;
   }
+
   set allowClear(allowClear) {
     this._allowClear = coerceBooleanProperty(allowClear);
   }
@@ -51,6 +53,7 @@ export class SelectInputComponent implements AfterViewInit {
   get multiple() {
     return this._multiple;
   }
+
   set multiple(multiple) {
     this._multiple = coerceBooleanProperty(multiple);
   }
@@ -59,6 +62,7 @@ export class SelectInputComponent implements AfterViewInit {
   get tagging() {
     return this._tagging;
   }
+
   set tagging(tagging) {
     this._tagging = coerceBooleanProperty(tagging);
   }
@@ -67,6 +71,7 @@ export class SelectInputComponent implements AfterViewInit {
   get allowAdditions() {
     return this._allowAdditions;
   }
+
   set allowAdditions(allowAdditions) {
     this._allowAdditions = coerceBooleanProperty(allowAdditions);
   }
@@ -75,6 +80,7 @@ export class SelectInputComponent implements AfterViewInit {
   get disableDropdown() {
     return this._disableDropdown;
   }
+
   set disableDropdown(disableDropdown) {
     this._disableDropdown = coerceBooleanProperty(disableDropdown);
   }
@@ -83,6 +89,7 @@ export class SelectInputComponent implements AfterViewInit {
   get selected() {
     return this._selected;
   }
+
   set selected(val: any[]) {
     this._selected = val;
     this.selectedOptions = this.calcSelectedOptions(val);
@@ -98,8 +105,7 @@ export class SelectInputComponent implements AfterViewInit {
 
   get caretVisible(): boolean {
     if (this.disableDropdown) return false;
-    if (this.tagging && (!this.options || !this.options.length)) return false;
-    return true;
+    return !(this.tagging && (!this.options || !this.options.length));
   }
 
   get isNotTemplate() {
@@ -180,8 +186,7 @@ export class SelectInputComponent implements AfterViewInit {
     }
   }
 
-  onToggle(event: Event): void {
-    event.stopPropagation();
+  onToggle(): void {
     this.toggle.emit();
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -1,18 +1,18 @@
 import {
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  QueryList,
-  ContentChildren,
-  forwardRef,
-  ElementRef,
-  Renderer2,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
   ChangeDetectionStrategy,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  ElementRef,
+  EventEmitter,
+  forwardRef,
+  Input,
+  OnDestroy,
+  Output,
+  QueryList,
+  Renderer2,
+  ViewChild,
+  ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -3,7 +3,7 @@
 <ngx-section class="shadow" [sectionTitle]="'Single Select'">
 
   <h4>Basic</h4>
-  <ngx-select [filterable]="false" [label]="'Attack Type'">
+  <ngx-select [filterable]="false" [label]="'Attack Type'" data-cy="attackType">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
@@ -22,7 +22,7 @@
   <br />
 
   <h4>Required</h4>
-  <ngx-select [filterable]="false" [label]="'Attack Type'" [required]="true">
+  <ngx-select [filterable]="false" [label]="'Attack Type'" [required]="true" data-cy="attackTypeRequired">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>


### PR DESCRIPTION
- Make span.ngx-select-caret a sibling to div.ngx-select-input-box
instead of a child. This removes the need for event.stopPropagation
which cancels all click listener on the document.body (for
closeOnBodyClick)
- Add Cypress test for "close on body click" cases
   - Have not added tests for cases with closeOnBodyClick set to `false`
- Some imports reformating

## Summary

Replace me with a description of changes. Include screenshots where appropriate.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
