### PR TITLE
fix: change * imports to a namespaces compatible version

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # HEAD (unreleased)
 
+- Fix: Change \* imports to a namespaces compatible version
+- Bug: Jest test of some apps are failing
+
 ## 31.0.0 (2020-10-29)
 
 - Feature: Add `confirmButtonText` and `cancelButtonText` config options (`<ngx-alert-dialog />`).

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,7 +3,6 @@
 # HEAD (unreleased)
 
 - Fix: Change \* imports to a namespaces compatible version
-- Bug: Jest test of some apps are failing
 
 ## 31.0.0 (2020-10-29)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar-day.interface.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar-day.interface.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 
 export interface CalendarDay {
   num: number;

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/utils/get-days-for-month/get-days-for-month.util.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/utils/get-days-for-month/get-days-for-month.util.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 
 import { CalendarDay } from '../../calendar-day.interface';
 import { getNumberRange } from '../get-number-range/get-number-range.util';

--- a/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone } from '@angular/core';
-import * as Mousetrap from 'mousetrap';
+import Mousetrap from 'mousetrap';
 import { Subject } from 'rxjs';
 
 import { Hotkey } from './hotkey.interface';

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
@@ -1,4 +1,4 @@
-import * as Ajv from 'ajv';
+import Ajv from 'ajv';
 import { Injectable } from '@angular/core';
 
 @Injectable()

--- a/projects/swimlane/ngx-ui/src/lib/components/notification/notification.mock.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/notification/notification.mock.ts
@@ -1,4 +1,4 @@
-import * as faker from 'faker/locale/en';
+import faker from 'faker/locale/en';
 
 import { NotificationOptions } from './notification-options.interface';
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown-option.mock.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown-option.mock.ts
@@ -1,4 +1,4 @@
-import * as faker from 'faker/locale/en';
+import faker from 'faker/locale/en';
 
 import { SelectDropdownOption } from './select-dropdown-option.interface';
 


### PR DESCRIPTION
## Summary

Some Jest tests were failing with the latest library version on ng10. Still not sure why, but fixing the imports also fixes the tests. 

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
