### PR TITLE
feat: add withMargin prop to Input and DateTime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13200,21 +13200,6 @@
         }
       }
     },
-    "ngx-autosize-input": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/ngx-autosize-input/-/ngx-autosize-input-2.3.7.tgz",
-      "integrity": "sha512-fB4ZCLuSq0lUVIYozna7VfWCi+ctetUwJsSJnoL9lTzkZFCjslkJxGi1DWn3qxS7p7Ghaa9M/swt1fJ3sCllgw==",
-      "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
     "ngx-moment": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/ngx-moment/-/ngx-moment-3.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "d3-color": "^1.2.3",
     "moment-timezone": "^0.5.28",
     "mousetrap": "^1.6.5",
-    "ngx-autosize-input": "^2.3.7",
     "normalize.css": "^8.0.0",
     "prismjs": "^1.21.0",
     "resize-observer-polyfill": "^1.5.1",

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,13 +3,15 @@
 # HEAD (unreleased)
 
 - Fix: Change \* imports to a namespaces compatible version
-- Enhancement: Add `[withMargin]` option to `InputComponent`
-  - `[withMargin]` allows for consumers of `InputComponent` to remove the vertical margins that are added by the `InputComponent` itself, to take control of positioning of the `InputComponent`.
+- Enhancement: Add `[withMargin]` option to `ngx-input`
+  - `[withMargin]` allows for consumers of `ngx-input` to remove the vertical margins that are added by the `ngx-input` itself, to take control of positioning of the `ngx-input`.
   - Default is `true` to keep the current behavior intact.
-- Enhancement: Add `[withMargin]` option to `DateTimeComponent`
-  - `[withMargin]` on `DateTimeComponent` is passed down to `InputComponent` resulting the above points.
+- Enhancement: Add `[withMargin]` option to `ngx-date-time`
+  - `[withMargin]` on `ngx-date-time` is passed down to `ngx-input` resulting the above points.
   - Default is `true` to keep the current behavior intact.
   - `[withMargin]=true` adds `.marginless` CSS class to determine the `translateY` value of `calendar-dialog-btn` relative to the Host component.
+- Enhancement: Remove `padding-top` style to `ngx-input` if there's no `label` passed in.
+  - For `ngx-date-time`, **calendar toggle button** is positioned properly with no `label`.
 
 ## 31.0.0 (2020-10-29)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,13 @@
 # HEAD (unreleased)
 
 - Fix: Change \* imports to a namespaces compatible version
+- Enhancement: Add `[withMargin]` option to `InputComponent`
+  - `[withMargin]` allows for consumers of `InputComponent` to remove the vertical margins that are added by the `InputComponent` itself, to take control of positioning of the `InputComponent`.
+  - Default is `true` to keep the current behavior intact.
+- Enhancement: Add `[withMargin]` option to `DateTimeComponent`
+  - `[withMargin]` on `DateTimeComponent` is passed down to `InputComponent` resulting the above points.
+  - Default is `true` to keep the current behavior intact.
+  - `[withMargin]=true` adds `.marginless` CSS class to determine the `translateY` value of `calendar-dialog-btn` relative to the Host component.
 
 ## 31.0.0 (2020-10-29)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -12,6 +12,8 @@
   - `[withMargin]=true` adds `.marginless` CSS class to determine the `translateY` value of `calendar-dialog-btn` relative to the Host component.
 - Enhancement: Remove `padding-top` style to `ngx-input` if there's no `label` passed in.
   - For `ngx-date-time`, **calendar toggle button** is positioned properly with no `label`.
+- Enhancement: Port `AutoSizeInputDirective` from `ngx-autosize-input` to `ngx-ui` because of bad implementation on first `ngModel.valueChanges` in `ngx-autosize-input`.
+- Chore: Remove `ngx-autosize-input` as a dependency.
 
 ## 31.0.0 (2020-10-29)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calender.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calender.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { MomentModule } from 'ngx-moment';
@@ -15,13 +15,15 @@ describe('CalendarComponent', () => {
   let component: CalendarComponent;
   let fixture: ComponentFixture<CalendarComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [CalendarComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      imports: [MomentModule, PipesModule]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [CalendarComponent],
+        schemas: [NO_ERRORS_SCHEMA],
+        imports: [MomentModule, PipesModule]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CalendarComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -100,6 +100,7 @@
   [autofocus]="autofocus"
   [tabindex]="tabindex"
   [label]="label"
+  [withMargin]="withMargin"
   [ngModel]="displayValue"
   (ngModelChange)="inputChanged($event)"
   (blur)="onBlur()"

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
@@ -37,10 +37,23 @@ $animation-timing: 200ms;
     padding-right: 25px;
   }
 
+  &.no-label {
+    .calendar-dialog-btn {
+      top: 0.5rem;
+      transform: translateY(0);
+    }
+  }
+
   &.fill {
     .calendar-dialog-btn {
       transform: translateY(-35%);
       right: 10px;
+    }
+
+    &.no-label {
+      .calendar-dialog-btn {
+        transform: translateY(0);
+      }
     }
   }
 
@@ -68,6 +81,12 @@ $animation-timing: 200ms;
 
     &.marginless .calendar-dialog-btn {
       transform: translateY(-35%);
+    }
+
+    &.no-label {
+      .calendar-dialog-btn {
+        transform: translateY(0);
+      }
     }
 
     .ngx-input-hint {

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
@@ -23,6 +23,7 @@ $animation-timing: 200ms;
   }
 
   .calendar-dialog-btn {
+    display: inline-flex;
     position: absolute;
     padding: 0;
     right: 5px;
@@ -63,6 +64,10 @@ $animation-timing: 200ms;
 
     &.fill .calendar-dialog-btn {
       transform: translateY(-15%);
+    }
+
+    &.marginless .calendar-dialog-btn {
+      transform: translateY(-35%);
     }
 
     .ngx-input-hint {

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import moment from 'moment-timezone';
@@ -30,19 +30,21 @@ describe('DateTimeComponent', () => {
   let component: DateTimeComponent;
   let fixture: ComponentFixture<DateTimeComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DateTimeComponent],
-      imports: [MomentModule, PipesModule, DialogModule],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [InjectionService]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [DateTimeComponent],
+        imports: [MomentModule, PipesModule, DialogModule],
+        schemas: [NO_ERRORS_SCHEMA],
+        providers: [InjectionService]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
-    const injectionService = TestBed.get(InjectionService);
+    const injectionService = TestBed.inject(InjectionService);
     fixture = TestBed.createComponent(DateTimeComponent);
-    injectionService.setRootViewContainer(fixture.componentRef);
+    injectionService.setRootViewContainer(fixture.componentRef as any);
     component = fixture.componentInstance;
     component.disabled = false;
     component.tabindex = 0;

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -49,7 +49,8 @@ const DATE_TIME_VALUE_ACCESSOR = {
     '[class.sm]': 'size === "sm"',
     '[class.md]': 'size === "md"',
     '[class.lg]': 'size === "lg"',
-    '[class.autosize]': 'autosize'
+    '[class.autosize]': 'autosize',
+    '[class.marginless]': '!withMargin'
   }
 })
 export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
@@ -60,6 +61,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   @Input() placeholder: string = '';
   @Input() size: Size = Size.Small;
   @Input() appearance: Appearance = Appearance.Legacy;
+  @Input() withMargin = true;
 
   @Input() minDate: string | Date;
   @Input() maxDate: string | Date;

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -50,7 +50,8 @@ const DATE_TIME_VALUE_ACCESSOR = {
     '[class.md]': 'size === "md"',
     '[class.lg]': 'size === "lg"',
     '[class.autosize]': 'autosize',
-    '[class.marginless]': '!withMargin'
+    '[class.marginless]': '!withMargin',
+    '[class.no-label]': '!label'
   }
 })
 export class DateTimeComponent implements OnDestroy, ControlValueAccessor {

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/alert/alert.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/alert/alert.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -16,13 +16,15 @@ describe('AlertComponent', () => {
   let component: AlertComponent;
   let fixture: ComponentFixture<AlertComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [AlertComponent],
-      providers: [IconRegistryService],
-      imports: [FormsModule, HttpClientTestingModule, NoopAnimationsModule, InputModule, LongPressButtonModule]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [AlertComponent],
+        providers: [IconRegistryService],
+        imports: [FormsModule, HttpClientTestingModule, NoopAnimationsModule, InputModule, LongPressButtonModule]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AlertComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/alert/alert.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/alert/alert.service.spec.ts
@@ -23,7 +23,7 @@ describe('AlertService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(AlertService);
+    service = TestBed.inject(AlertService);
   });
 
   beforeEach(() => {

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DialogComponent } from './dialog.component';
@@ -7,12 +7,14 @@ describe('DialogComponent', () => {
   let component: DialogComponent;
   let fixture: ComponentFixture<DialogComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DialogComponent],
-      imports: [NoopAnimationsModule]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [DialogComponent],
+        imports: [NoopAnimationsModule]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DialogComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.service.spec.ts
@@ -32,9 +32,9 @@ describe('DialogService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(DialogService);
-    overlayService = TestBed.get(OverlayService);
-    injectionService = TestBed.get(InjectionService);
+    service = TestBed.inject(DialogService);
+    overlayService = TestBed.inject(OverlayService);
+    injectionService = TestBed.inject(InjectionService);
   });
 
   it('can load instance', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DrawerComponent } from './drawer.component';
@@ -8,12 +8,14 @@ describe('DrawerComponent', () => {
   let component: DrawerComponent;
   let fixture: ComponentFixture<DrawerComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DrawerComponent],
-      imports: [NoopAnimationsModule]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [DrawerComponent],
+        imports: [NoopAnimationsModule]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DrawerComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.service.spec.ts
@@ -32,9 +32,9 @@ describe('DrawerService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(DrawerService);
-    overlayService = TestBed.get(OverlayService);
-    injectionService = TestBed.get(InjectionService);
+    service = TestBed.inject(DrawerService);
+    overlayService = TestBed.inject(OverlayService);
+    injectionService = TestBed.inject(InjectionService);
   });
 
   it('can load instance', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-toggle.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-toggle.directive.spec.ts
@@ -1,5 +1,5 @@
 import { DebugElement } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { DropdownToggleDirective } from './dropdown-toggle.directive';
@@ -13,11 +13,13 @@ describe('DropdownToggleDirective', () => {
   let fixture: ComponentFixture<DropdownComponentFixture>;
   let debugElement: DebugElement;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DropdownComponent, DropdownMenuDirective, DropdownToggleDirective, DropdownComponentFixture]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [DropdownComponent, DropdownMenuDirective, DropdownToggleDirective, DropdownComponentFixture]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DropdownComponentFixture);

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.spec.ts
@@ -1,5 +1,5 @@
 import { DebugElement } from '@angular/core';
-import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { DropdownComponent } from './dropdown.component';
@@ -12,11 +12,13 @@ describe('DropdownComponent', () => {
   let fixture: ComponentFixture<DropdownComponentFixture>;
   let debugElement: DebugElement;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DropdownComponent, DropdownMenuDirective, DropdownToggleDirective, DropdownComponentFixture]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [DropdownComponent, DropdownMenuDirective, DropdownToggleDirective, DropdownComponentFixture]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DropdownComponentFixture);

--- a/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { HotkeysComponent } from './hotkeys.component';
 import { HotkeysService } from './hotkeys.service';
@@ -24,12 +24,14 @@ describe('HotkeysComponent', () => {
     }
   ];
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [HotkeysComponent],
-      providers: [HotkeysService]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [HotkeysComponent],
+        providers: [HotkeysService]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HotkeysComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.spec.ts
@@ -13,7 +13,7 @@ describe('HotkeysService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(hk.HotkeysService);
+    service = TestBed.inject(hk.HotkeysService);
   });
 
   afterEach(() => {

--- a/projects/swimlane/ngx-ui/src/lib/components/icon/icon.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/icon/icon.component.spec.ts
@@ -21,7 +21,7 @@ describe('IconComponent', () => {
   });
 
   beforeEach(() => {
-    httpClient = TestBed.get<HttpClient>(HttpClient);
+    httpClient = TestBed.inject<HttpClient>(HttpClient);
     fixture = TestBed.createComponent(IconComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
@@ -81,7 +81,7 @@
   <input
     *ngIf="type !== inputTypes.textarea && autosize"
     class="ngx-input-box"
-    AutoSizeInput
+    autoSizeInput
     [extraWidth]="type === inputTypes.number ? 20 : 0"
     [minWidth]="minWidth"
     [includePadding]="true"

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -17,6 +17,11 @@ $input-placeholder-color: $color-blue-grey-350;
   padding-top: calc(0.7em + 8px);
   padding-bottom: 0;
 
+  &.marginless {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
   &.md {
     .ngx-input-box,
     .ngx-input-textarea {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -22,6 +22,10 @@ $input-placeholder-color: $color-blue-grey-350;
     margin-bottom: 0;
   }
 
+  &.no-label {
+    padding-top: 0;
+  }
+
   &.md {
     .ngx-input-box,
     .ngx-input-textarea {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -126,6 +126,7 @@ $input-placeholder-color: $color-blue-grey-350;
     .ngx-input-box-wrap {
       position: relative;
       width: 100%;
+      display: flex;
 
       &:focus {
         outline: none;

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -61,7 +61,8 @@ const MIN_WIDTH = 60;
     '[class.lg]': 'size === "lg"',
     '[class.focused]': 'focused',
     '[class.autosize]': 'autosize',
-    '[class.marginless]': '!withMargin'
+    '[class.marginless]': '!withMargin',
+    '[class.no-label]': '!label'
   },
   animations: INPUT_ANIMATIONS,
   providers: [INPUT_VALUE_ACCESSOR, INPUT_VALIDATORS],

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -60,7 +60,8 @@ const MIN_WIDTH = 60;
     '[class.md]': 'size === "md"',
     '[class.lg]': 'size === "lg"',
     '[class.focused]': 'focused',
-    '[class.autosize]': 'autosize'
+    '[class.autosize]': 'autosize',
+    '[class.marginless]': '!withMargin'
   },
   animations: INPUT_ANIMATIONS,
   providers: [INPUT_VALUE_ACCESSOR, INPUT_VALIDATORS],
@@ -80,6 +81,7 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
   @Input() maxlength: number;
   @Input() size: Size = Size.Small;
   @Input() appearance: Appearance = Appearance.Legacy;
+  @Input() withMargin = true;
 
   @Input()
   get disabled() {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { AutoSizeInputModule } from 'ngx-autosize-input';
 
 import { TooltipModule } from '../tooltip/tooltip.module';
 
@@ -10,6 +9,7 @@ import { InputHintDirective } from './input-hint.directive';
 import { AutosizeDirective } from './input-autosize.directive';
 import { InputPrefixComponent } from './input-prefix.component';
 import { InputSuffixComponent } from './input-suffix.component';
+import { AutoSizeInputModule } from '../../directives/autosize-input/autosize-input.module';
 
 @NgModule({
   declarations: [InputComponent, InputHintDirective, AutosizeDirective, InputPrefixComponent, InputSuffixComponent],

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.spec.ts
@@ -1,5 +1,4 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { JsonEditorNodeInfoComponent } from './node-info.component';
 
@@ -7,11 +6,13 @@ describe('JsonEditorNodeInfoComponent', () => {
   let component: JsonEditorNodeInfoComponent;
   let fixture: ComponentFixture<JsonEditorNodeInfoComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [JsonEditorNodeInfoComponent]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [JsonEditorNodeInfoComponent]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(JsonEditorNodeInfoComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/loading/loading.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/loading/loading.service.spec.ts
@@ -23,7 +23,7 @@ describe('LoadingService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(LoadingService);
+    service = TestBed.inject(LoadingService);
     service.progress = 0;
     service.threshold = 0;
   });

--- a/projects/swimlane/ngx-ui/src/lib/components/navbar/navbar-item.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/navbar/navbar-item.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { NavbarItemComponent } from './navbar-item.component';
 
@@ -6,11 +6,13 @@ describe('Nav Item Component', () => {
   let component: NavbarItemComponent;
   let fixture: ComponentFixture<NavbarItemComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [NavbarItemComponent]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [NavbarItemComponent]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NavbarItemComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/notification/notification.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/notification/notification.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { EventEmitter, ComponentRef } from '@angular/core';
+import { ComponentRef, EventEmitter } from '@angular/core';
 
 import { InjectionService } from '../../services/injection/injection.service';
 import { NotificationService } from './notification.service';
@@ -22,8 +22,8 @@ describe('NotificationService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(NotificationService);
-    injectionService = TestBed.get(InjectionService);
+    service = TestBed.inject(NotificationService);
+    injectionService = TestBed.inject(InjectionService);
   });
 
   it('can load instance', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { InjectionService } from '../../services/injection/injection.service';
 import { OverlayModule } from './overlay.module';
@@ -16,9 +16,9 @@ describe('OverlayService', () => {
     }).compileComponents();
 
     component = TestBed.createComponent(OverlayComponent);
-    service = TestBed.get(OverlayService);
+    service = TestBed.inject(OverlayService);
     service.component = component.componentRef;
-    injectionService = TestBed.get(InjectionService);
+    injectionService = TestBed.inject(InjectionService);
     spyOn(injectionService, 'appendComponent').and.callFake(() => {
       return component.componentRef;
     });

--- a/projects/swimlane/ngx-ui/src/lib/components/progress-spinner/progress-spinner.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/progress-spinner/progress-spinner.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ProgressSpinnerComponent } from './progress-spinner.component';
 import { ProgressSpinnerMode } from './progress-spinner-mode.enum';
@@ -7,11 +7,13 @@ describe('ProgressSpinnerComponent', () => {
   let component: ProgressSpinnerComponent;
   let fixture: ComponentFixture<ProgressSpinnerComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ProgressSpinnerComponent]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ProgressSpinnerComponent]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ProgressSpinnerComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/stepper/step.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/stepper/step.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { StepComponent } from './step.component';
 
@@ -6,11 +6,13 @@ describe('StepComponent', () => {
   let component: StepComponent;
   let fixture: ComponentFixture<StepComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [StepComponent]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [StepComponent]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StepComponent);

--- a/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.directive.spec.ts
@@ -29,7 +29,7 @@ describe('TooltipDirective', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(TooltipService);
+    service = TestBed.inject(TooltipService);
     fixture = TestBed.createComponent(ToolTipFixtureComponent);
     directive = fixture.componentInstance.tooltipDirective;
     fixture.autoDetectChanges();

--- a/projects/swimlane/ngx-ui/src/lib/directives/autosize-input/autosize-input.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/directives/autosize-input/autosize-input.directive.spec.ts
@@ -1,0 +1,8 @@
+import { AutoSizeInputDirective } from './autosize-input.directive';
+
+describe('AutoSizeInputDirective', () => {
+  it('should create an instance', () => {
+    const directive = new AutoSizeInputDirective(null, null, null);
+    expect(directive).toBeTruthy();
+  });
+});

--- a/projects/swimlane/ngx-ui/src/lib/directives/autosize-input/autosize-input.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/directives/autosize-input/autosize-input.directive.ts
@@ -9,7 +9,7 @@ import {
   Renderer2
 } from '@angular/core';
 import { NgModel } from '@angular/forms';
-import { filter, startWith, take } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 
 @Directive({
   selector: '[autoSizeInput]'
@@ -41,8 +41,7 @@ export class AutoSizeInputDirective implements AfterContentChecked, AfterViewIni
     if (this.ngModel) {
       this.ngModel.valueChanges
         .pipe(
-          startWith(this.ngModel.value),
-          filter(val => val != null),
+          filter(val => !!val),
           take(1)
         )
         .subscribe(() => this.updateWidth());

--- a/projects/swimlane/ngx-ui/src/lib/directives/autosize-input/autosize-input.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/directives/autosize-input/autosize-input.directive.ts
@@ -1,0 +1,118 @@
+import {
+  AfterContentChecked,
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  HostListener,
+  Input,
+  Optional,
+  Renderer2
+} from '@angular/core';
+import { NgModel } from '@angular/forms';
+import { filter, startWith, take } from 'rxjs/operators';
+
+@Directive({
+  selector: '[autoSizeInput]'
+})
+export class AutoSizeInputDirective implements AfterContentChecked, AfterViewInit {
+  @Input() extraWidth = 0;
+  @Input() includeBorders = false;
+  @Input() includePadding = true;
+  @Input() includePlaceholder = true;
+  @Input() maxWidth = -1;
+  @Input() minWidth = -1;
+  @Input() setParentWidth = false;
+
+  constructor(private element: ElementRef, @Optional() private ngModel: NgModel, private renderer: Renderer2) {}
+
+  get borderWidth(): number {
+    return this.includeBorders ? 2 * this._getPropertyWidth('border') : 0;
+  }
+
+  get paddingWidth(): number {
+    return this.includePadding ? this._getPropertyWidth('padding-left') + this._getPropertyWidth('padding-right') : 0;
+  }
+
+  ngAfterContentChecked() {
+    this.updateWidth();
+  }
+
+  ngAfterViewInit() {
+    if (this.ngModel) {
+      this.ngModel.valueChanges
+        .pipe(
+          startWith(this.ngModel.value),
+          filter(val => val != null),
+          take(1)
+        )
+        .subscribe(() => this.updateWidth());
+    }
+  }
+
+  @HostListener('input')
+  public onInput(): void {
+    this.updateWidth();
+  }
+
+  setWidth(width: number): void {
+    const element = this.element.nativeElement;
+    const parent = this.renderer.parentNode(element);
+    this.setParentWidth
+      ? this.renderer.setStyle(parent, 'width', width + 'px')
+      : this.renderer.setStyle(element, 'width', width + 'px');
+  }
+
+  setWidthUsingText(text: string): void {
+    this.setWidth(this.textWidth(text) + this.extraWidth + this.borderWidth + this.paddingWidth);
+  }
+
+  textWidth(value: string): number {
+    const ctx = this.renderer.createElement('canvas').getContext('2d');
+    const style = window.getComputedStyle(this.element.nativeElement, '');
+    const fontStyle = style.getPropertyValue('font-style');
+    const fontVariant = style.getPropertyValue('font-variant');
+    const fontWeight = style.getPropertyValue('font-weight');
+    const fontSize = style.getPropertyValue('font-size');
+    const fontFamily = style.getPropertyValue('font-family');
+
+    // font string format: {normal, normal, 700, 20px, Roboto, "Helvetica Neue", sans-serif}
+    ctx.font = fontStyle + ' ' + fontVariant + ' ' + fontWeight + ' ' + fontSize + ' ' + fontFamily;
+
+    return ctx!.measureText(value).width;
+  }
+
+  updateWidth(): void {
+    const inputText = this.ngModel ? this.ngModel.value : this._getProperty('value');
+    const placeHolderText = this._getProperty('placeholder');
+    const inputTextWidth = this.textWidth(inputText) + this.extraWidth + this.borderWidth + this.paddingWidth;
+    const setMinWidth = this.minWidth > 0 && this.minWidth > inputTextWidth;
+    const setPlaceHolderWidth =
+      this.includePlaceholder &&
+      placeHolderText.length > 0 &&
+      this.textWidth(placeHolderText) > this.textWidth(inputText);
+    const setMaxWidth = this.maxWidth > 0 && this.maxWidth < inputTextWidth;
+
+    if (setMinWidth) {
+      this.setWidth(this.minWidth);
+    } else if (setPlaceHolderWidth) {
+      this.setWidthUsingText(placeHolderText);
+    } else if (setMaxWidth) {
+      this.setWidth(this.maxWidth);
+    } else {
+      this.setWidthUsingText(inputText);
+    }
+  }
+
+  private _getProperty(property: 'value' | 'placeholder') {
+    try {
+      return this.element.nativeElement[property];
+    } catch (error) {
+      return '';
+    }
+  }
+
+  private _getPropertyWidth(property: string): number {
+    const width = window.getComputedStyle(this.element.nativeElement, '').getPropertyValue(property);
+    return parseInt(width, 10);
+  }
+}

--- a/projects/swimlane/ngx-ui/src/lib/directives/autosize-input/autosize-input.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/directives/autosize-input/autosize-input.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { AutoSizeInputDirective } from './autosize-input.directive';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [AutoSizeInputDirective],
+  exports: [AutoSizeInputDirective]
+})
+export class AutoSizeInputModule {}

--- a/projects/swimlane/ngx-ui/src/lib/pipes/cammel-to-snake/cammel-to-snake.pipe.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/pipes/cammel-to-snake/cammel-to-snake.pipe.spec.ts
@@ -7,7 +7,7 @@ describe('CammelToSnakePipe', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({ providers: [CammelToSnakePipe] });
-    pipe = TestBed.get(CammelToSnakePipe);
+    pipe = TestBed.inject(CammelToSnakePipe);
   });
 
   it('can load instance', () => {

--- a/projects/swimlane/ngx-ui/src/lib/services/icon-registry/icon-registry.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/services/icon-registry/icon-registry.service.spec.ts
@@ -7,7 +7,7 @@ describe('IconRegistryService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({ providers: [IconRegistryService] });
-    service = TestBed.get(IconRegistryService);
+    service = TestBed.inject(IconRegistryService);
   });
 
   it('can load instance', () => {

--- a/projects/swimlane/ngx-ui/src/lib/services/injection/injection.service.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/services/injection/injection.service.spec.ts
@@ -3,8 +3,8 @@ import {
   ComponentFactoryResolver,
   ComponentRef,
   Injector,
-  ViewContainerRef,
-  Type
+  Type,
+  ViewContainerRef
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
@@ -41,7 +41,7 @@ describe('InjectionService', () => {
       ]
     });
 
-    service = TestBed.get(InjectionService);
+    service = TestBed.inject(InjectionService);
   });
 
   it('can load instance', () => {

--- a/projects/swimlane/ngx-ui/src/public_api.ts
+++ b/projects/swimlane/ngx-ui/src/public_api.ts
@@ -42,6 +42,8 @@ export * from './lib/directives/validators/pattern-validator/pattern-validator.m
 export * from './lib/directives/validators/pattern-validator/pattern-validator.directive';
 export * from './lib/directives/visibility/visibility.module';
 export * from './lib/directives/visibility/visibility.directive';
+export * from './lib/directives/autosize-input/autosize-input.module';
+export * from './lib/directives/autosize-input/autosize-input.directive';
 
 // components
 export * from './lib/components/button/button.module';

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -336,7 +336,7 @@
 
 <ngx-section class="shadow" sectionTitle="Autosize">
   Current Value: {{ curDate2 | json }}
-  
+
   <br />
 
   <ngx-date-time
@@ -384,6 +384,21 @@
     appearance="fill"
     inputType="datetime"
     label="Minutes"
+    precision="minute"
+    [(ngModel)]="curDate2"
+    format="MMM DD, YYYY, hh:mm:ss"
+    (change)="dateChanged($event)"
+  >
+  </ngx-date-time>
+
+  <br />
+
+  <ngx-date-time
+    autosize="true"
+    appearance="fill"
+    [withMargin]="false"
+    inputType="datetime"
+    label="Minutes without margin"
     precision="minute"
     [(ngModel)]="curDate2"
     format="MMM DD, YYYY, hh:mm:ss"

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -85,7 +85,7 @@
   </ngx-input>
 ]]>
   </app-prism>
-  
+
   <br />
 
   <ngx-input [label]="'Required Input Example Of The Day'" type="text" name="input4" [required]="true"
@@ -383,6 +383,6 @@
   <br />
 
   <app-prism>
-<![CDATA[<ngx-input autosize appearance="fill" type="number" label="Fill Resize Input"></ngx-input></ngx-input>]]>
+<![CDATA[<ngx-input autosize appearance="fill" type="number" label="Fill Resize Input"></ngx-input>]]>
   </app-prism>
 </ngx-section>

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -367,7 +367,7 @@
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Auto Size">
-  <ngx-input [(ngModel)]="inputValue" autosize label="Resize Input"></ngx-input>
+  <ngx-input [(ngModel)]="longInputValue" autosize label="Resize Input"></ngx-input>
 
   <br />
 

--- a/src/app/forms/inputs-page/inputs-page.component.ts
+++ b/src/app/forms/inputs-page/inputs-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'app-inputs-page',
@@ -8,6 +8,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 export class InputsPageComponent {
   searchInputValue: string = '';
   inputValue: any = 'A Value';
+  longInputValue = 'A very long input value that should be autosized';
   inputValue1: any;
   inputValue2: any;
   inputValue3: any;


### PR DESCRIPTION
- withMargin is default to `true` to keep the current behavior intact
- withMargin with a `false` value will add `marginless` CSS class to
`ngx-input` and `ngx-date-time` elements

## Summary

Before
![image](https://user-images.githubusercontent.com/25516557/98400533-ca9d8180-2029-11eb-91fb-297256986dee.png)

After
![image](https://user-images.githubusercontent.com/25516557/98400547-cf623580-2029-11eb-9480-d0bae7165234.png)

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
