### PR TITLE
fix: recalculate node type on model change

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # HEAD (unreleased)
 
-- Fix: Change \* imports to a namespaces compatible version
+- Fix: re-infer `json-editor` node types after model change
 
 ## 31.0.0 (2020-10-29)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fix: re-infer `json-editor` node types after model change
 
+## 31.0.1 (2020-11-03)
+
+- Fix: Change \* imports to a namespaces compatible version
+
 ## 31.0.0 (2020-10-29)
 
 - Feature: Add `confirmButtonText` and `cancelButtonText` config options (`<ngx-alert-dialog />`).

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -289,10 +289,16 @@ export class ObjectNode implements OnInit, OnChanges {
       const schema = this.propertyIndex[id];
       if (this.model[schema.propertyName] === undefined) {
         delete this.propertyIndex[id];
+      } else {
+        const model = this.model[schema.propertyName];
+        const { type } = inferType(model);
+        if (schema.type !== type) {
+          this.propertyIndex[schema.id].type = type;
+        }
       }
     }
 
-    this.propertyIndex = { ...this.propertyIndex };
+    this.propertyIndex = JSON.parse(JSON.stringify(this.propertyIndex));
     this.cdr.markForCheck();
   }
 


### PR DESCRIPTION
## Summary

The `object-node.component` is not re-inferring the properties type after the model input change

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
