### PR TITLE
fix: json editor prop duplication

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix: Reference leak caused when duplicating field names on a object
 
-## 30.1.1 (2020-11-03)
+## 31.0.1 (2020-11-03)
 
 - Fix: Change \* imports to a namespaces compatible version
 - Enhancement: Add `[withMargin]` option to `ngx-input`

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-# 30.1.0 (2020-09-22)
+# HEAD (unreleased)
+
+- Fix: Reference leak caused when duplicating field names on a object
+
+## 30.1.0 (2020-09-22)
 
 - Bug: Revert removal of ngx-datatable styles
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -4,14 +4,14 @@
       <span class="json-editor--vertical-separator" *ngFor="let separator of indentationArray"></span>
     </div>
     <div class="node" [class.compressed]="compressed">
-      <div class="error-box" *ngIf="!valid && !schemaBuilderMode"></div>
+      <div class="error-box" *ngIf="(!valid && !schemaBuilderMode) || isDuplicated"></div>
 
       <div class="left-options">
         <ng-container *ngIf="hideRoot || (nextLevel > 0 && !arrayItem)">
           <div class="required-indicator">
             <span
               *ngIf="required"
-              [class.invalid]="!childrenValid && !schemaBuilderMode"
+              [class.invalid]="(!childrenValid && !schemaBuilderMode) || isDuplicated"
               [innerHtml]="requiredIndicator"
             ></span>
             <span *ngIf="!required && schemaBuilderMode" class="not-required" [innerHtml]="requiredIndicator"></span>
@@ -30,7 +30,8 @@
             [type]="(schema?.format || schema?.type | titlecase) + (schema?.enum?.length ? ' + Enum' : '')"
             [description]="schema?.description"
             [examples]="schema?.examples"
-            [compressed]="compressed">
+            [compressed]="compressed"
+          >
           </ngx-json-editor-node-info>
         </div>
 
@@ -43,6 +44,7 @@
               (ngModelChange)="updateModel($event)"
               [requiredIndicator]="false"
               [required]="required"
+              [disabled]="isDuplicated"
             ></ngx-input>
           </div>
 
@@ -53,6 +55,7 @@
               [ngModel]="model"
               (ngModelChange)="updateModel($event)"
               [label]="model | json"
+              [disabled]="isDuplicated"
             >
             </ngx-toggle>
           </div>
@@ -68,6 +71,7 @@
                 (ngModelChange)="updateModel($event)"
                 [requiredIndicator]="false"
                 [required]="required"
+                [disabled]="isDuplicated"
               >
               </ngx-input>
 
@@ -77,6 +81,7 @@
                 [ngModel]="[model]"
                 (ngModelChange)="updateModel($event[0])"
                 [required]="required"
+                [disabled]="isDuplicated"
               >
                 <ngx-select-option *ngFor="let option of schema.enum" [name]="option" [value]="option">
                 </ngx-select-option>
@@ -91,6 +96,7 @@
                 (ngModelChange)="updateModel($event)"
                 [requiredIndicator]="false"
                 [required]="required"
+                [disabled]="isDuplicated"
               ></ngx-input>
             </div>
 
@@ -102,6 +108,7 @@
                 (ngModelChange)="updateModel($event)"
                 [requiredIndicator]="false"
                 [required]="required"
+                [disabled]="isDuplicated"
               ></ngx-input>
             </div>
 
@@ -113,6 +120,7 @@
                 (ngModelChange)="updateModel($event)"
                 [requiredIndicator]="false"
                 [required]="required"
+                [disabled]="isDuplicated"
               ></ngx-input>
             </div>
 
@@ -126,7 +134,7 @@
                 [disabled]="true"
               >
                 <ngx-input-suffix>
-                  <button (click)="openCodeEditor()">
+                  <button [disabled]="isDuplicated" (click)="openCodeEditor()">
                     <ngx-icon fontIcon="edit" class="edit-code-icon" ngx-tooltip tooltipTitle="Edit Code"> </ngx-icon>
                   </button>
                 </ngx-input-suffix>
@@ -166,7 +174,6 @@
           <div class="input-error">
             <span *ngFor="let error of ownErrors">{{ error.message }}</span>
           </div>
-
         </div>
 
         <div *ngIf="schemaBuilderMode" class="node-constrains">
@@ -220,6 +227,7 @@
       [errors]="childrenErrors"
       [typeCheckOverrides]="typeCheckOverrides"
       [level]="nextLevel"
+      [isDuplicated]="isDuplicated"
       [schemaBuilderMode]="schemaBuilderMode"
       [showKnownProperties]="showKnownProperties"
       (schemaChange)="schemaChange.emit(schemaRef)"

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -201,6 +201,7 @@
       (modelChange)="updateModel($event)"
       [path]="path"
       [errors]="childrenErrors"
+      [isDuplicated]="isDuplicated"
       [typeCheckOverrides]="typeCheckOverrides"
       [level]="nextLevel"
       [compressed]="compressed"

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
@@ -52,6 +52,8 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
 
   @Input() showKnownProperties = false;
 
+  @Input() isDuplicated = false;
+
   @Output() updatePropertyNameEvent = new EventEmitter<{ id: string | number; name: string }>();
 
   requiredIndicator: SafeHtml;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
@@ -21,6 +21,7 @@
       [arrayName]="(schema.title ? schema.title : schema.propertyName) + '[' + (schemaBuilderMode ? '' : i) + ']'"
       [indentationArray]="indentationArray"
       [showKnownProperties]="showKnownProperties"
+      [isDuplicated]="isDuplicated"
     >
       <div class="node-options" node-options>
         <button
@@ -65,7 +66,7 @@
     <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">
         <ngx-dropdown-toggle>
-          <button type="button">
+          <button [disabled]="isDuplicated" type="button">
             <i class="ngx-icon ngx-tree-expand"></i>
             <span>Add an item</span>
           </button>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
@@ -34,6 +34,8 @@ export class ArrayNodeFlatComponent extends ArrayNode implements OnInit, OnChang
 
   @Input() hideRoot = false;
 
+  @Input() isDuplicated = false;
+
   indentationArray: number[] = [];
 
   constructor(private dialogService: DialogService) {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -136,7 +136,7 @@
     <span class="json-editor--vertical-separator" *ngFor="let separator of indentationArray"></span>
     <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">
-        <ngx-dropdown-toggle>
+        <ngx-dropdown-toggle [disabled]="isDuplicated">
           <button type="button">
             <i class="ngx-icon ngx-tree-expand"></i>
             <span>Add {{ objectKeys(propertyIndex).length ? 'a' : 'your first' }} property</span>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -28,6 +28,7 @@
       [compressed]="compressed"
       [indentationArray]="indentationArray"
       [showKnownProperties]="showKnownProperties"
+      [isDuplicated]="duplicatedFields.has(prop.id)"
       (schemaChange)="schemaChange.emit(schemaRef)"
       (updatePropertyNameEvent)="onUpdatePropertyName($event)"
     >
@@ -85,20 +86,22 @@
 
   <ng-container *ngIf="showKnownProperties">
     <ng-container *ngFor="let prop of schema.properties | keyvalue">
-      <div class="node-container add-button add-prop-button" [class.compressed]="compressed" *ngIf="model[prop.key] === undefined">
-
+      <div
+        class="node-container add-button add-prop-button"
+        [class.compressed]="compressed"
+        *ngIf="model[prop.key] === undefined"
+      >
         <span class="json-editor--vertical-separator" *ngFor="let separator of indentationArray"></span>
 
-        <div class="node"
+        <div
+          class="node"
           [class.compressed]="compressed"
           [style.marginLeft]="level === 0 ? '20px' : '0'"
-          (click)="addSchemaProperty(prop.key)">
-
-          <div class="left-options">
-          </div>
+          (click)="addSchemaProperty(prop.key)"
+        >
+          <div class="left-options"></div>
 
           <div class="node-content">
-
             <div class="node-info">
               <ngx-json-editor-node-info
                 [nameEditable]="false"
@@ -107,7 +110,8 @@
                 [type]="(prop.value.format || prop.value.type | titlecase) + (prop.value.enum?.length ? ' + Enum' : '')"
                 [description]="prop.value?.description"
                 [examples]="prop.value.examples"
-                [compressed]="compressed">
+                [compressed]="compressed"
+              >
               </ngx-json-editor-node-info>
             </div>
 
@@ -115,18 +119,20 @@
               <button type="button">
                 <i class="ngx-icon ngx-tree-expand"></i>
                 <span>Include</span>
-              </button>              
+              </button>
             </div>
-          
           </div>
-
         </div>
-
       </div>
     </ng-container>
   </ng-container>
 
-  <div class="add-button" [class.compressed]="compressed" [class.background]="hideRoot ? level > -1 : level" *ngIf="!showKnownProperties || schema.additionalProperties !== false">
+  <div
+    class="add-button"
+    [class.compressed]="compressed"
+    [class.background]="hideRoot ? level > -1 : level"
+    *ngIf="!showKnownProperties || schema.additionalProperties !== false"
+  >
     <span class="json-editor--vertical-separator" *ngFor="let separator of indentationArray"></span>
     <div class="indented-content" [style.marginLeft]="hideRoot && level === 0 ? '20px' : '0'">
       <ngx-dropdown [showCaret]="true">
@@ -137,7 +143,10 @@
           </button>
         </ngx-dropdown-toggle>
         <ngx-dropdown-menu class="ngx-dropdown-dark-outline">
-          <ul class="vertical-list dropdown-column" *ngIf="schema.properties && !schemaBuilderMode && !showKnownProperties">
+          <ul
+            class="vertical-list dropdown-column"
+            *ngIf="schema.properties && !schemaBuilderMode && !showKnownProperties"
+          >
             <li *ngFor="let prop of schema.properties | keyvalue" (click)="addSchemaProperty(prop.key)">
               <button [disabled]="model[prop.key] !== undefined" type="button">
                 {{ prop.value.title ? prop.value.title : prop.key }}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -70,12 +70,17 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnCha
   }
 
   onUpdatePropertyName(options: { id: string; name: string }): void {
-    const oldName = this.propertyIndex[options.id].propertyName;
-    const index = Object.keys(this.schemaRef.properties).findIndex(prop => prop === oldName);
-    this.updateSchemaPropertyName(this.schemaRef, options.name, this.propertyIndex[options.id].propertyName);
-    this.swapSchemaProperties(index);
-    this.updatePropertyName(options.id, options.name);
-    this.schemaChange.emit();
+    const existingSchemaProperty = this.schemaRef.properties[options.name];
+    const existingPropertyValue = this.model[options.name];
+
+    if (!existingSchemaProperty && existingPropertyValue === undefined) {
+      const oldName = this.propertyIndex[options.id].propertyName;
+      const index = Object.keys(this.schemaRef.properties).findIndex(prop => prop === oldName);
+      this.updateSchemaPropertyName(this.schemaRef, options.name, this.propertyIndex[options.id].propertyName);
+      this.swapSchemaProperties(index);
+      this.updatePropertyName(options.id, options.name);
+      this.schemaChange.emit();
+    }
   }
 
   onPropertyConfig(property: JSONEditorSchema, index: number): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -43,6 +43,8 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnCha
 
   indentationArray: number[] = [];
 
+  duplicatedFields = new Map<string, string>();
+
   objectKeys = Object.keys;
 
   constructor(private dialogService: DialogService, protected cdr: ChangeDetectorRef) {
@@ -72,14 +74,18 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnCha
   onUpdatePropertyName(options: { id: string; name: string }): void {
     const existingSchemaProperty = this.schemaRef.properties[options.name];
     const existingPropertyValue = this.model[options.name];
+    const oldName = this.propertyIndex[options.id].propertyName;
+
+    this.duplicatedFields.delete(options.id);
 
     if (!existingSchemaProperty && existingPropertyValue === undefined) {
-      const oldName = this.propertyIndex[options.id].propertyName;
       const index = Object.keys(this.schemaRef.properties).findIndex(prop => prop === oldName);
       this.updateSchemaPropertyName(this.schemaRef, options.name, this.propertyIndex[options.id].propertyName);
       this.swapSchemaProperties(index);
       this.updatePropertyName(options.id, options.name);
       this.schemaChange.emit();
+    } else if (oldName !== options.name) {
+      this.duplicatedFields.set(options.id, options.name);
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -41,6 +41,8 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnCha
 
   @Input() hideRoot = false;
 
+  @Input() isDuplicated = false;
+
   indentationArray: number[] = [];
 
   duplicatedFields = new Map<string, string>();

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -85,7 +85,7 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnCha
       this.updateSchemaPropertyName(this.schemaRef, options.name, this.propertyIndex[options.id].propertyName);
       this.swapSchemaProperties(index);
       this.updatePropertyName(options.id, options.name);
-      this.schemaChange.emit();
+      this.schemaUpdate.emit();
     } else if (oldName !== options.name) {
       this.duplicatedFields.set(options.id, options.name);
     }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
@@ -1,14 +1,14 @@
 <div
   class="json-tree-node"
   [class.inline]="schema?.type !== 'object' && schema?.type !== 'array'"
-  [class.invalid]="!valid"
-  [class.children-invalid]="!childrenValid"
+  [class.invalid]="!valid || isDuplicated"
+  [class.children-invalid]="!childrenValid || isDuplicated"
 >
   <span
     *ngIf="schema?.type === 'object' || schema?.type === 'array'"
     class="ngx-expander"
     (click)="onExpandClick()"
-    [class.invalid]="!childrenValid"
+    [class.invalid]="!childrenValid || isDuplicated"
     [ngClass]="{
       'icon-tree-collapse': expanded,
       'icon-tree-expand': !expanded
@@ -35,6 +35,7 @@
         [schema]="schema"
         [model]="model"
         [expanded]="expanded"
+        [isDuplicated]="isDuplicated"
         (modelChange)="updateModel($event)"
         [path]="path"
         [errors]="childrenErrors"
@@ -49,6 +50,7 @@
         [schema]="schema"
         [model]="model"
         [expanded]="expanded"
+        [isDuplicated]="isDuplicated"
         (modelChange)="updateModel($event)"
         [path]="path"
         [errors]="childrenErrors"
@@ -63,6 +65,7 @@
         class="value-input"
         type="number"
         [placeholder]="placeholder"
+        [disabled]="isDuplicated"
         [ngModel]="model"
         (ngModelChange)="updateModel($event)"
         [required]="required"
@@ -71,7 +74,13 @@
 
     <!-- Boolean -->
     <div *ngIf="schema?.type === 'boolean'">
-      <ngx-toggle class="toggle-input" [ngModel]="model" (ngModelChange)="updateModel($event)" [label]="model | json">
+      <ngx-toggle
+        class="toggle-input"
+        [disabled]="isDuplicated"
+        [ngModel]="model"
+        (ngModelChange)="updateModel($event)"
+        [label]="model | json"
+      >
       </ngx-toggle>
     </div>
 
@@ -85,6 +94,7 @@
           type="text"
           [placeholder]="placeholder"
           [ngModel]="model"
+          [disabled]="isDuplicated"
           (ngModelChange)="updateModel($event)"
           [required]="required"
         />
@@ -100,6 +110,7 @@
           type="password"
           [placeholder]="placeholder"
           [ngModel]="model"
+          [disabled]="isDuplicated"
           (ngModelChange)="updateModel($event)"
           [required]="required"
         />
@@ -112,6 +123,7 @@
           type="date"
           [placeholder]="placeholder"
           [ngModel]="model"
+          [disabled]="isDuplicated"
           (ngModelChange)="updateModel($event)"
           [required]="required"
         />
@@ -124,6 +136,7 @@
           type="datetime-local"
           [placeholder]="placeholder"
           [ngModel]="model"
+          [disabled]="isDuplicated"
           (ngModelChange)="updateModel($event)"
           [required]="required"
         />
@@ -148,6 +161,7 @@
           <ngx-select
             class="mode-select"
             label="Language Mode"
+            [disabled]="isDuplicated"
             [ngModel]="[editorConfig.mode.name]"
             (ngModelChange)="selectEditorMode($event[0])"
           >
@@ -162,6 +176,7 @@
           <ngx-codemirror
             *ngIf="editorVisible"
             [ngModel]="editorModel"
+            [disabled]="isDuplicated"
             (ngModelChange)="editorModel = $event"
             [config]="editorConfig"
             class="code-editor"

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
@@ -22,6 +22,8 @@ export class JsonEditorNodeComponent extends JsonEditorNode {
 
   @Input() showKnownProperties = false;
 
+  @Input() isDuplicated = false;
+
   placeholder: string = '';
 
   constructor(public dialogMngr: DialogService) {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
@@ -29,6 +29,7 @@
       [schema]="schemas[i]"
       [path]="path + '[' + i + ']'"
       [errors]="errors"
+      [isDuplicated]="isDuplicated"
       [typeCheckOverrides]="typeCheckOverrides"
       [showKnownProperties]="showKnownProperties"
     >
@@ -36,7 +37,7 @@
   </div>
 
   <ngx-dropdown [showCaret]="true">
-    <ngx-dropdown-toggle>
+    <ngx-dropdown-toggle [disabled]="isDuplicated">
       <div class="add-button">
         <ngx-icon fontIcon="plus-bold"></ngx-icon>
       </div>
@@ -50,7 +51,7 @@
         </ng-template>
         <ng-container *ngIf="schema?.items?.type">
           <li *ngIf="!_array.isArray(schema.items.type)">
-            <button type="button" (click)="addArrayItem()">Add</button>
+            <button [disabled]="isDuplicated" type="button" (click)="addArrayItem()">Add</button>
           </li>
           <ng-container *ngIf="_array.isArray(schema.items.type)">
             <li *ngFor="let type of schema.items.type">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
 import { ArrayNode } from '../../../../node-types/array-node.component';
 
 @Component({
@@ -6,4 +6,6 @@ import { ArrayNode } from '../../../../node-types/array-node.component';
   templateUrl: 'array-node.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ArrayNodeComponent extends ArrayNode {}
+export class ArrayNodeComponent extends ArrayNode {
+  @Input() isDuplicated = false;
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
@@ -1,6 +1,6 @@
 <div [hidden]="!expanded">
   <div *ngFor="let prop of propertyIndex | objectValues; trackBy: trackBy">
-    <div class="property-def">
+    <div class="property-def" [class.invalid]="duplicatedFields.has(prop.id)">
       <ngx-dropdown [showCaret]="true">
         <ngx-dropdown-toggle>
           <div class="type-icon">
@@ -57,6 +57,7 @@
       [required]="!!requiredCache[prop.propertyName]"
       [inline]="prop.type !== 'array' && prop.type !== 'object'"
       [path]="path + getPath(prop.propertyName)"
+      [isDuplicated]="duplicatedFields.has(prop.id)"
       [errors]="errors"
       [typeCheckOverrides]="typeCheckOverrides"
       [showKnownProperties]="showKnownProperties"
@@ -65,7 +66,7 @@
   </div>
 
   <ngx-dropdown [showCaret]="true">
-    <ngx-dropdown-toggle>
+    <ngx-dropdown-toggle [disabled]="isDuplicated">
       <div class="add-button">
         <ngx-icon fontIcon="plus-bold"></ngx-icon>
       </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.scss
@@ -1,0 +1,3 @@
+.invalid {
+  border: 1px solid #e02f00;
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.ts
@@ -1,12 +1,15 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, Input } from '@angular/core';
 import { ObjectNode } from '../../../../node-types/object-node.component';
 
 @Component({
   selector: 'ngx-json-object-node',
   templateUrl: 'object-node.component.html',
+  styleUrls: ['object-node.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ObjectNodeComponent extends ObjectNode {
+  @Input() isDuplicated = false;
+
   constructor(protected cdr: ChangeDetectorRef) {
     super(cdr);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -56,6 +56,8 @@ export class ObjectNode implements OnInit, OnChanges {
   propertyId: number = 1;
   propertyIndex: PropertyIndex = {};
 
+  duplicatedFields = new Map<string, string>();
+
   dataTypeMap = dataTypeMap;
 
   constructor(protected cdr: ChangeDetectorRef) {}
@@ -116,12 +118,20 @@ export class ObjectNode implements OnInit, OnChanges {
    * @param name
    */
   updatePropertyName(id: number | string, name: string) {
+    const existingPropertyValue = this.model[name];
     const oldName = this.propertyIndex[id].propertyName;
-    this.model[name] = this.model[oldName];
-    this.propertyIndex[id].propertyName = name;
-    delete this.model[oldName];
-    this.propertyIndex = { ...this.propertyIndex };
-    this.modelChange.emit(this.model);
+
+    this.duplicatedFields.delete(id as string);
+
+    if (existingPropertyValue === undefined) {
+      this.model[name] = this.model[oldName];
+      this.propertyIndex[id].propertyName = name;
+      delete this.model[oldName];
+      this.propertyIndex = { ...this.propertyIndex };
+      this.modelChange.emit(this.model);
+    } else if (oldName !== name) {
+      this.duplicatedFields.set(id as string, name);
+    }
   }
 
   /**

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -68,6 +68,10 @@ export class ObjectNode implements OnInit, OnChanges {
     if (changes.model !== undefined || changes.schema !== undefined) {
       this.update();
     }
+
+    console.log(this.errors);
+    console.log(changes.model);
+    console.log(changes.schema);
   }
 
   update(): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -68,10 +68,6 @@ export class ObjectNode implements OnInit, OnChanges {
     if (changes.model !== undefined || changes.schema !== undefined) {
       this.update();
     }
-
-    console.log(this.errors);
-    console.log(changes.model);
-    console.log(changes.schema);
   }
 
   update(): void {


### PR DESCRIPTION
## Summary

When a property's name is duplicated in an `object-node` both properties are assigned with the same ref causing unexpected behaviors.

This PR provides a protection against property name duplication and visual warning.

![Screen Shot 2020-11-05 at 9 41 11 PM](https://user-images.githubusercontent.com/24899986/98615009-7bc94380-22d8-11eb-816e-26c3959c7976.png)
![Screen Shot 2020-11-05 at 9 40 58 PM](https://user-images.githubusercontent.com/24899986/98615020-808df780-22d8-11eb-8665-71bca9735d20.png)
<img width="1439" alt="Screen Shot 2020-11-05 at 9 39 39 PM" src="https://user-images.githubusercontent.com/24899986/98615034-8683d880-22d8-11eb-9d8e-7df55af8d5b7.png">

 
## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
