### PR TITLE
Add 'required' input to DateTimeComponent

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # HEAD (unreleased)
 
+- Enhancement: Add `required` and `requiredIndicator` inputs to `DateTimeComponent`.
+- Breaking: An empty value will no longer cause the `DateTimeComponent` to become invalid, unless it is explicitly marked as `required`.
+
 ## 31.1.0 (2020-11-10)
 
 - Fix: re-infer `json-editor` node types after model change

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -102,6 +102,8 @@
   [label]="label"
   [withMargin]="withMargin"
   [ngModel]="displayValue"
+  [required]="required"
+  [requiredIndicator]="requiredIndicator"
   (ngModelChange)="inputChanged($event)"
   (blur)="onBlur()"
 >

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -467,6 +467,20 @@ describe('DateTimeComponent', () => {
       expect(component.input.value).toBeDefined();
     });
 
+    it('should allow empty value if NOT required', () => {
+      component.value = '';
+      component.required = false;
+      component.onBlur();
+      expect(component.input.value).toEqual('');
+    });
+
+    it('should NOT allow empty value if required', () => {
+      component.value = '';
+      component.required = true;
+      component.onBlur();
+      expect(component.input.value).toBeUndefined();
+    });
+
     it('should invalidate and not set value', () => {
       component.value = 'test';
       component.onBlur();

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -134,6 +134,15 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     this.displayValue = this.getDisplayValue();
   }
 
+  @Input() requiredIndicator: string | boolean = '*';
+  @Input()
+  get required() {
+    return this._required;
+  }
+  set required(required: boolean) {
+    this._required = coerceBooleanProperty(required);
+  }
+
   get value() {
     return this._value;
   }
@@ -211,6 +220,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   private _tabindex: number;
   private _autosize: boolean = false;
   private _minWidth: number = MIN_WIDTH;
+  private _required: boolean = false;
 
   constructor(private readonly dialogService: DialogService, private readonly cdr: ChangeDetectorRef) {}
 
@@ -358,15 +368,20 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   }
 
   private validate(date: moment.Moment) {
+    // check if date input is empty
+    const dateInput = date.creationData().input;
+    const isEmpty = dateInput === '' || dateInput === null || dateInput === undefined; // 0 is a valid date input
+
     const isValid = date.isValid();
-    const outOfRange = this.getDayDisabled(date);
+    const isInRange = !this.getDayDisabled(date);
 
     let errorMsg = '';
     if (!isValid) errorMsg = 'Invalid Date';
-    if (outOfRange) errorMsg = 'Date out of range';
+    if (!isInRange) errorMsg = 'Date out of range';
     this.errorMsg = errorMsg;
 
-    return isValid && !outOfRange;
+    // date can be either valid, or an empty value if not required
+    return (isValid || (!this.required && isEmpty)) && isInRange;
   }
 
   private onTouchedCallback: () => void = () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -372,16 +372,18 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     const dateInput = date.creationData().input;
     const isEmpty = dateInput === '' || dateInput === null || dateInput === undefined; // 0 is a valid date input
 
-    const isValid = date.isValid();
+    // date can be either valid, or an empty value if not required
+    const isValid = date.isValid() || (!this.required && isEmpty);
     const isInRange = !this.getDayDisabled(date);
 
     let errorMsg = '';
-    if (!isValid) errorMsg = 'Invalid Date';
-    if (!isInRange) errorMsg = 'Date out of range';
+    if (this.required && isEmpty) {
+      /* no datetime component specific error message */
+    } else if (!isValid) errorMsg = 'Invalid Date';
+    else if (!isInRange) errorMsg = 'Date out of range';
     this.errorMsg = errorMsg;
 
-    // date can be either valid, or an empty value if not required
-    return (isValid || (!this.required && isEmpty)) && isInRange;
+    return isValid && isInRange;
   }
 
   private onTouchedCallback: () => void = () => {

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -199,6 +199,7 @@
     [label]="'Time of attack'"
     [(ngModel)]="curDate2"
     (change)="dateChanged($event)"
+    required
   >
   </ngx-date-time>
   <br />
@@ -209,6 +210,7 @@
   [label]="'Time of attack'"
   [(ngModel)]="curDate2"
   (change)="dateChanged($event)"
+  required
 >
 </ngx-date-time>]]>
   </app-prism>


### PR DESCRIPTION
## Summary

- Enhancement: Add `required` and `requiredIndicator` inputs to `DateTimeComponent`.
- Breaking: An empty value will no longer cause the `DateTimeComponent` to become invalid, unless it is explicitly marked as `required`.

![image](https://user-images.githubusercontent.com/19226858/100122210-1aac7e80-2e47-11eb-97ac-773ef483a7fe.png)
![image](https://user-images.githubusercontent.com/19226858/100122316-3b74d400-2e47-11eb-8683-91ec389068df.png)
![image](https://user-images.githubusercontent.com/19226858/100122422-59dacf80-2e47-11eb-8689-021f453be822.png)
![image](https://user-images.githubusercontent.com/19226858/100122491-6fe89000-2e47-11eb-9c24-e8d8288b5ab8.png)

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
