### PR TITLE
feat: add custom template to group on select with groupBy

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
@@ -1,96 +1,96 @@
 <div>
-  <div class="ngx-select-filter" *ngIf="filterable && !tagging">
-    <i class="ngx-icon ngx-search"></i>
+  <div class='ngx-select-filter' *ngIf='filterable && !tagging'>
+    <i class='ngx-icon ngx-search'></i>
     <input
       #filterInput
-      type="search"
-      tabindex=""
-      autocomplete="off"
-      autocorrect="off"
-      spellcheck="off"
-      class="ngx-select-filter-input"
-      [placeholder]="filterPlaceholder"
-      (keyup)="onInputKeyUp($event)"
+      type='search'
+      tabindex=''
+      autocomplete='off'
+      autocorrect='off'
+      spellcheck='off'
+      class='ngx-select-filter-input'
+      [placeholder]='filterPlaceholder'
+      (keyup)='onInputKeyUp($event)'
     />
-    <i [hidden]="!filterInput.value" class="ngx-icon ngx-x" (click)="clearFilter(filterInput)"></i>
+    <i [hidden]='!filterInput.value' class='ngx-icon ngx-x' (click)='clearFilter(filterInput)'></i>
   </div>
-  <ul class="vertical-list ngx-select-dropdown-options">
+  <ul class='vertical-list ngx-select-dropdown-options'>
     <li
-      *ngFor="let group of groups; let i = index; let first = first; let last = last; let odd = odd; let even = even"
-      class="ngx-select-option-group"
+      *ngFor='let group of groups; let i = index; let first = first; let last = last; let odd = odd; let even = even'
+      class='ngx-select-option-group'
     >
-      <ng-container *ngIf="group.name">
-        <ng-container *ngIf="groupNameTemplate; else defaultGroupName">
-          <span class="ngx-select-option-group-name">
+      <ng-container *ngIf='group.name'>
+        <ng-container *ngIf='groupByTemplate; else defaultGroupName'>
+          <span class='ngx-select-option-group-name'>
             <ng-container
-              *ngTemplateOutlet="
-                groupNameTemplate;
+              *ngTemplateOutlet='
+                groupByTemplate;
                 context: { groupName: group.name, index: i, first: first, last: last, odd: odd, even: even }
-              "
+              '
             ></ng-container>
           </span>
         </ng-container>
         <ng-template #defaultGroupName>
-          <span class="ngx-select-option-group-name" [innerHTML]="group.name"> </span>
+          <span class='ngx-select-option-group-name' [innerHTML]='group.name'> </span>
         </ng-template>
       </ng-container>
-      <ul class="vertical-list ngx-select-dropdown-options">
+      <ul class='vertical-list ngx-select-dropdown-options'>
         <li
-          *ngFor="let kv of group.options"
-          class="ngx-select-dropdown-option"
-          [class.disabled]="kv.option.disabled"
-          [class.active]="kv.index === focusIndex"
-          [class.selected]="isSelected(kv.option)"
-          [hidden]="kv.option.hidden"
-          tabindex="-1"
-          (click)="selection.emit(kv.option)"
-          (keydown)="onOptionKeyDown($event, kv.option)"
+          *ngFor='let kv of group.options'
+          class='ngx-select-dropdown-option'
+          [class.disabled]='kv.option.disabled'
+          [class.active]='kv.index === focusIndex'
+          [class.selected]='isSelected(kv.option)'
+          [hidden]='kv.option.hidden'
+          tabindex='-1'
+          (click)='selection.emit(kv.option)'
+          (keydown)='onOptionKeyDown($event, kv.option)'
         >
           <ng-template
-            *ngIf="kv.option.optionTemplate"
-            [ngTemplateOutlet]="kv.option.optionTemplate"
-            [ngTemplateOutletContext]="{ option: kv.option }"
+            *ngIf='kv.option.optionTemplate'
+            [ngTemplateOutlet]='kv.option.optionTemplate'
+            [ngTemplateOutletContext]='{ option: kv.option }'
           >
           </ng-template>
-          <span *ngIf="!kv.option.optionTemplate" [innerHTML]="kv.option.name"> </span>
+          <span *ngIf='!kv.option.optionTemplate' [innerHTML]='kv.option.name'> </span>
           <i
-            *ngIf="!kv.option.optionTemplate && isSelected(kv.option)"
-            class="ngx-icon ngx-check ngx-select-dropdown--selected-option"
+            *ngIf='!kv.option.optionTemplate && isSelected(kv.option)'
+            class='ngx-icon ngx-check ngx-select-dropdown--selected-option'
           ></i>
         </li>
         <li
-          *ngIf="allowAdditions && filterQuery && group.options?.length && !filterQueryIsInOptions"
-          class="ngx-select-empty-placeholder"
+          *ngIf='allowAdditions && filterQuery && group.options?.length && !filterQueryIsInOptions'
+          class='ngx-select-empty-placeholder'
         >
-          <a href="#" class="ngx-select-add-current-value" (click)="onAddClicked($event, filterQuery)">
-            <span *ngIf="isNotTemplate; else tpl" [innerHTML]="allowAdditionsText"> </span>
+          <a href='#' class='ngx-select-add-current-value' (click)='onAddClicked($event, filterQuery)'>
+            <span *ngIf='isNotTemplate; else tpl' [innerHTML]='allowAdditionsText'> </span>
             <ng-template #tpl>
-              <ng-container *ngTemplateOutlet="allowAdditionsText"></ng-container>
+              <ng-container *ngTemplateOutlet='allowAdditionsText'></ng-container>
             </ng-template>
           </a>
         </li>
 
         <li
-          *ngIf="filterQuery && filterEmptyPlaceholder && !group.options?.length"
-          class="ngx-select-empty-placeholder"
+          *ngIf='filterQuery && filterEmptyPlaceholder && !group.options?.length'
+          class='ngx-select-empty-placeholder'
         >
-          <span class="ngx-select-empty-placeholder-text" [innerHTML]="filterEmptyPlaceholder"> </span>
+          <span class='ngx-select-empty-placeholder-text' [innerHTML]='filterEmptyPlaceholder'> </span>
           <a
-            *ngIf="allowAdditions"
-            href="#"
-            class="ngx-select-empty-placeholder-add"
-            (click)="onAddClicked($event, filterQuery)"
+            *ngIf='allowAdditions'
+            href='#'
+            class='ngx-select-empty-placeholder-add'
+            (click)='onAddClicked($event, filterQuery)'
           >
-            <span *ngIf="isNotTemplate; else tpl" [innerHTML]="allowAdditionsText"> </span>
+            <span *ngIf='isNotTemplate; else tpl' [innerHTML]='allowAdditionsText'> </span>
             <ng-template #tpl>
-              <ng-container *ngTemplateOutlet="allowAdditionsText"></ng-container>
+              <ng-container *ngTemplateOutlet='allowAdditionsText'></ng-container>
             </ng-template>
           </a>
         </li>
         <li
-          *ngIf="!filterQuery && emptyPlaceholder && !group.options?.length"
-          class="ngx-select-empty-placeholder"
-          [innerHTML]="emptyPlaceholder"
+          *ngIf='!filterQuery && emptyPlaceholder && !group.options?.length'
+          class='ngx-select-empty-placeholder'
+          [innerHTML]='emptyPlaceholder'
         ></li>
       </ul>
     </li>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
@@ -15,8 +15,25 @@
     <i [hidden]="!filterInput.value" class="ngx-icon ngx-x" (click)="clearFilter(filterInput)"></i>
   </div>
   <ul class="vertical-list ngx-select-dropdown-options">
-    <li *ngFor="let group of groups" class="ngx-select-option-group">
-      <span class="ngx-select-option-group-name" *ngIf="group.name" [innerHTML]="group.name"> </span>
+    <li
+      *ngFor="let group of groups; let i = index; let first = first; let last = last; let odd = odd; let even = even"
+      class="ngx-select-option-group"
+    >
+      <ng-container *ngIf="group.name">
+        <ng-container *ngIf="groupNameTemplate; else defaultGroupName">
+          <span class="ngx-select-option-group-name">
+            <ng-container
+              *ngTemplateOutlet="
+                groupNameTemplate;
+                context: { groupName: group.name, index: i, first: first, last: last, odd: odd, even: even }
+              "
+            ></ng-container>
+          </span>
+        </ng-container>
+        <ng-template #defaultGroupName>
+          <span class="ngx-select-option-group-name" [innerHTML]="group.name"> </span>
+        </ng-template>
+      </ng-container>
       <ul class="vertical-list ngx-select-dropdown-options">
         <li
           *ngFor="let kv of group.options"

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.html
@@ -1,96 +1,96 @@
 <div>
-  <div class='ngx-select-filter' *ngIf='filterable && !tagging'>
-    <i class='ngx-icon ngx-search'></i>
+  <div class="ngx-select-filter" *ngIf="filterable && !tagging">
+    <i class="ngx-icon ngx-search"></i>
     <input
       #filterInput
-      type='search'
-      tabindex=''
-      autocomplete='off'
-      autocorrect='off'
-      spellcheck='off'
-      class='ngx-select-filter-input'
-      [placeholder]='filterPlaceholder'
-      (keyup)='onInputKeyUp($event)'
+      type="search"
+      tabindex=""
+      autocomplete="off"
+      autocorrect="off"
+      spellcheck="off"
+      class="ngx-select-filter-input"
+      [placeholder]="filterPlaceholder"
+      (keyup)="onInputKeyUp($event)"
     />
-    <i [hidden]='!filterInput.value' class='ngx-icon ngx-x' (click)='clearFilter(filterInput)'></i>
+    <i [hidden]="!filterInput.value" class="ngx-icon ngx-x" (click)="clearFilter(filterInput)"></i>
   </div>
-  <ul class='vertical-list ngx-select-dropdown-options'>
+  <ul class="vertical-list ngx-select-dropdown-options">
     <li
-      *ngFor='let group of groups; let i = index; let first = first; let last = last; let odd = odd; let even = even'
-      class='ngx-select-option-group'
+      *ngFor="let group of groups; let i = index; let first = first; let last = last; let odd = odd; let even = even"
+      class="ngx-select-option-group"
     >
-      <ng-container *ngIf='group.name'>
-        <ng-container *ngIf='groupByTemplate; else defaultGroupName'>
-          <span class='ngx-select-option-group-name'>
+      <ng-container *ngIf="group.name">
+        <ng-container *ngIf="groupByTemplate; else defaultGroupName">
+          <span class="ngx-select-option-group-name">
             <ng-container
-              *ngTemplateOutlet='
+              *ngTemplateOutlet="
                 groupByTemplate;
                 context: { groupName: group.name, index: i, first: first, last: last, odd: odd, even: even }
-              '
+              "
             ></ng-container>
           </span>
         </ng-container>
         <ng-template #defaultGroupName>
-          <span class='ngx-select-option-group-name' [innerHTML]='group.name'> </span>
+          <span class="ngx-select-option-group-name" [innerHTML]="group.name"> </span>
         </ng-template>
       </ng-container>
-      <ul class='vertical-list ngx-select-dropdown-options'>
+      <ul class="vertical-list ngx-select-dropdown-options">
         <li
-          *ngFor='let kv of group.options'
-          class='ngx-select-dropdown-option'
-          [class.disabled]='kv.option.disabled'
-          [class.active]='kv.index === focusIndex'
-          [class.selected]='isSelected(kv.option)'
-          [hidden]='kv.option.hidden'
-          tabindex='-1'
-          (click)='selection.emit(kv.option)'
-          (keydown)='onOptionKeyDown($event, kv.option)'
+          *ngFor="let kv of group.options"
+          class="ngx-select-dropdown-option"
+          [class.disabled]="kv.option.disabled"
+          [class.active]="kv.index === focusIndex"
+          [class.selected]="isSelected(kv.option)"
+          [hidden]="kv.option.hidden"
+          tabindex="-1"
+          (click)="selection.emit(kv.option)"
+          (keydown)="onOptionKeyDown($event, kv.option)"
         >
           <ng-template
-            *ngIf='kv.option.optionTemplate'
-            [ngTemplateOutlet]='kv.option.optionTemplate'
-            [ngTemplateOutletContext]='{ option: kv.option }'
+            *ngIf="kv.option.optionTemplate"
+            [ngTemplateOutlet]="kv.option.optionTemplate"
+            [ngTemplateOutletContext]="{ option: kv.option }"
           >
           </ng-template>
-          <span *ngIf='!kv.option.optionTemplate' [innerHTML]='kv.option.name'> </span>
+          <span *ngIf="!kv.option.optionTemplate" [innerHTML]="kv.option.name"> </span>
           <i
-            *ngIf='!kv.option.optionTemplate && isSelected(kv.option)'
-            class='ngx-icon ngx-check ngx-select-dropdown--selected-option'
+            *ngIf="!kv.option.optionTemplate && isSelected(kv.option)"
+            class="ngx-icon ngx-check ngx-select-dropdown--selected-option"
           ></i>
         </li>
         <li
-          *ngIf='allowAdditions && filterQuery && group.options?.length && !filterQueryIsInOptions'
-          class='ngx-select-empty-placeholder'
+          *ngIf="allowAdditions && filterQuery && group.options?.length && !filterQueryIsInOptions"
+          class="ngx-select-empty-placeholder"
         >
-          <a href='#' class='ngx-select-add-current-value' (click)='onAddClicked($event, filterQuery)'>
-            <span *ngIf='isNotTemplate; else tpl' [innerHTML]='allowAdditionsText'> </span>
+          <a href="#" class="ngx-select-add-current-value" (click)="onAddClicked($event, filterQuery)">
+            <span *ngIf="isNotTemplate; else tpl" [innerHTML]="allowAdditionsText"> </span>
             <ng-template #tpl>
-              <ng-container *ngTemplateOutlet='allowAdditionsText'></ng-container>
+              <ng-container *ngTemplateOutlet="allowAdditionsText"></ng-container>
             </ng-template>
           </a>
         </li>
 
         <li
-          *ngIf='filterQuery && filterEmptyPlaceholder && !group.options?.length'
-          class='ngx-select-empty-placeholder'
+          *ngIf="filterQuery && filterEmptyPlaceholder && !group.options?.length"
+          class="ngx-select-empty-placeholder"
         >
-          <span class='ngx-select-empty-placeholder-text' [innerHTML]='filterEmptyPlaceholder'> </span>
+          <span class="ngx-select-empty-placeholder-text" [innerHTML]="filterEmptyPlaceholder"> </span>
           <a
-            *ngIf='allowAdditions'
-            href='#'
-            class='ngx-select-empty-placeholder-add'
-            (click)='onAddClicked($event, filterQuery)'
+            *ngIf="allowAdditions"
+            href="#"
+            class="ngx-select-empty-placeholder-add"
+            (click)="onAddClicked($event, filterQuery)"
           >
-            <span *ngIf='isNotTemplate; else tpl' [innerHTML]='allowAdditionsText'> </span>
+            <span *ngIf="isNotTemplate; else tpl" [innerHTML]="allowAdditionsText"> </span>
             <ng-template #tpl>
-              <ng-container *ngTemplateOutlet='allowAdditionsText'></ng-container>
+              <ng-container *ngTemplateOutlet="allowAdditionsText"></ng-container>
             </ng-template>
           </a>
         </li>
         <li
-          *ngIf='!filterQuery && emptyPlaceholder && !group.options?.length'
-          class='ngx-select-empty-placeholder'
-          [innerHTML]='emptyPlaceholder'
+          *ngIf="!filterQuery && emptyPlaceholder && !group.options?.length"
+          class="ngx-select-empty-placeholder"
+          [innerHTML]="emptyPlaceholder"
         ></li>
       </ul>
     </li>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -1,3 +1,4 @@
+import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -10,12 +11,11 @@ import {
   TemplateRef,
   ViewChild
 } from '@angular/core';
-import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
+import { debounceable } from '../../decorators/debounceable/debounceable.decorator';
 
 import { KeyboardKeys } from '../../enums/keyboard-keys.enum';
 import { containsFilter } from './contains-filter.util';
 import { SelectDropdownOption } from './select-dropdown-option.interface';
-import { debounceable } from '../../decorators/debounceable/debounceable.decorator';
 
 @Component({
   exportAs: 'ngxSelectDropdown',
@@ -101,7 +101,7 @@ export class SelectDropdownComponent implements AfterViewInit {
     this.groups = this.calculateGroups(val, this.options);
   }
 
-  @Input() groupNameTemplate: TemplateRef<unknown>;
+  @Input() groupByTemplate: TemplateRef<unknown>;
 
   @Input()
   get options() {
@@ -274,6 +274,8 @@ export class SelectDropdownComponent implements AfterViewInit {
         opt.push(kv);
       }
     }
+
+    console.log('map', map);
 
     const result = [];
     map.forEach((value, key) => {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -1,14 +1,14 @@
 import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
+  ElementRef,
+  EventEmitter,
   Input,
   Output,
-  EventEmitter,
-  ViewChild,
-  AfterViewInit,
-  ElementRef,
   TemplateRef,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef
+  ViewChild
 } from '@angular/core';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 
@@ -39,6 +39,7 @@ export class SelectDropdownComponent implements AfterViewInit {
   get tagging() {
     return this._tagging;
   }
+
   set tagging(tagging) {
     this._tagging = coerceBooleanProperty(tagging);
   }
@@ -47,6 +48,7 @@ export class SelectDropdownComponent implements AfterViewInit {
   get allowAdditions() {
     return this._allowAdditions;
   }
+
   set allowAdditions(allowAdditions) {
     this._allowAdditions = coerceBooleanProperty(allowAdditions);
   }
@@ -55,6 +57,7 @@ export class SelectDropdownComponent implements AfterViewInit {
   get filterable() {
     return this._filterable;
   }
+
   set filterable(filterable) {
     this._filterable = coerceBooleanProperty(filterable);
   }
@@ -63,6 +66,7 @@ export class SelectDropdownComponent implements AfterViewInit {
   get filterCaseSensitive() {
     return this._filterCaseSensitive;
   }
+
   set filterCaseSensitive(filterCaseSensitive) {
     this._filterCaseSensitive = coerceBooleanProperty(filterCaseSensitive);
   }
@@ -71,6 +75,7 @@ export class SelectDropdownComponent implements AfterViewInit {
   get focusIndex() {
     return this._focusIndex;
   }
+
   set focusIndex(val: number) {
     this._focusIndex = coerceNumberProperty(val);
     this.focusElement(this._focusIndex);
@@ -80,6 +85,7 @@ export class SelectDropdownComponent implements AfterViewInit {
   get filterQuery() {
     return this._filterQuery;
   }
+
   set filterQuery(val: string) {
     this._filterQuery = val;
     this.groups = this.calculateGroups(this.groupBy, this.options, val);
@@ -89,15 +95,19 @@ export class SelectDropdownComponent implements AfterViewInit {
   get groupBy() {
     return this._groupBy;
   }
+
   set groupBy(val: string) {
     this._groupBy = val;
     this.groups = this.calculateGroups(val, this.options);
   }
 
+  @Input() groupNameTemplate: TemplateRef<unknown>;
+
   @Input()
   get options() {
     return this._options;
   }
+
   set options(val) {
     this.groups = this.calculateGroups(this.groupBy, val);
     this._options = val;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
@@ -34,6 +34,7 @@
     [allowAdditionsText]="allowAdditionsText"
     [selected]="value"
     [groupBy]="groupBy"
+    [groupNameTemplate]="groupNameTemplate"
     [emptyPlaceholder]="emptyPlaceholder"
     [tagging]="tagging"
     [filterEmptyPlaceholder]="filterEmptyPlaceholder"

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
@@ -1,49 +1,49 @@
-<div class="ngx-select-wrap">
-  <div class="ngx-select-flex-wrap" [style.min-width]="autosize ? autosizeMinWidth : undefined">
-    <div class="ngx-select-flex-wrap-inner">
+<div class='ngx-select-wrap'>
+  <div class='ngx-select-flex-wrap' [style.min-width]='autosize ? autosizeMinWidth : undefined'>
+    <div class='ngx-select-flex-wrap-inner'>
       <ngx-select-input
-        [autofocus]="autofocus"
-        [options]="options"
-        [allowClear]="allowClear"
-        [label]="label"
-        [requiredIndicator]="requiredIndicatorView"
-        [placeholder]="placeholder"
-        [multiple]="multiple"
-        [identifier]="identifier"
-        [tagging]="tagging"
-        [allowAdditions]="allowAdditions"
-        [selectCaret]="selectCaret"
-        [selected]="value"
-        [hint]="hint"
-        [disableDropdown]="disableDropdown"
-        (keyup)="onKeyUp($event)"
-        (toggle)="onToggle()"
-        (activate)="onFocus()"
-        (selection)="onInputSelection($event)"
+        [autofocus]='autofocus'
+        [options]='options'
+        [allowClear]='allowClear'
+        [label]='label'
+        [requiredIndicator]='requiredIndicatorView'
+        [placeholder]='placeholder'
+        [multiple]='multiple'
+        [identifier]='identifier'
+        [tagging]='tagging'
+        [allowAdditions]='allowAdditions'
+        [selectCaret]='selectCaret'
+        [selected]='value'
+        [hint]='hint'
+        [disableDropdown]='disableDropdown'
+        (keyup)='onKeyUp($event)'
+        (toggle)='onToggle()'
+        (activate)='onFocus()'
+        (selection)='onInputSelection($event)'
       >
       </ngx-select-input>
     </div>
   </div>
   <ngx-select-dropdown
-    *ngIf="dropdownVisible"
-    [focusIndex]="focusIndex"
-    [filterQuery]="filterQuery"
-    [filterPlaceholder]="filterPlaceholder"
-    [filterCaseSensitive]="filterCaseSensitive"
-    [allowAdditions]="allowAdditions"
-    [allowAdditionsText]="allowAdditionsText"
-    [selected]="value"
-    [groupBy]="groupBy"
-    [groupNameTemplate]="groupNameTemplate"
-    [emptyPlaceholder]="emptyPlaceholder"
-    [tagging]="tagging"
-    [filterEmptyPlaceholder]="filterEmptyPlaceholder"
-    [filterable]="filterable"
-    [identifier]="identifier"
-    [options]="options"
-    (keyup)="keyup.emit($event)"
-    (close)="onClose()"
-    (selection)="onDropdownSelection($event)"
+    *ngIf='dropdownVisible'
+    [focusIndex]='focusIndex'
+    [filterQuery]='filterQuery'
+    [filterPlaceholder]='filterPlaceholder'
+    [filterCaseSensitive]='filterCaseSensitive'
+    [allowAdditions]='allowAdditions'
+    [allowAdditionsText]='allowAdditionsText'
+    [selected]='value'
+    [groupBy]='groupBy'
+    [groupByTemplate]='groupByTemplate'
+    [emptyPlaceholder]='emptyPlaceholder'
+    [tagging]='tagging'
+    [filterEmptyPlaceholder]='filterEmptyPlaceholder'
+    [filterable]='filterable'
+    [identifier]='identifier'
+    [options]='options'
+    (keyup)='keyup.emit($event)'
+    (close)='onClose()'
+    (selection)='onDropdownSelection($event)'
   >
   </ngx-select-dropdown>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
@@ -1,49 +1,49 @@
-<div class='ngx-select-wrap'>
-  <div class='ngx-select-flex-wrap' [style.min-width]='autosize ? autosizeMinWidth : undefined'>
-    <div class='ngx-select-flex-wrap-inner'>
+<div class="ngx-select-wrap">
+  <div class="ngx-select-flex-wrap" [style.min-width]="autosize ? autosizeMinWidth : undefined">
+    <div class="ngx-select-flex-wrap-inner">
       <ngx-select-input
-        [autofocus]='autofocus'
-        [options]='options'
-        [allowClear]='allowClear'
-        [label]='label'
-        [requiredIndicator]='requiredIndicatorView'
-        [placeholder]='placeholder'
-        [multiple]='multiple'
-        [identifier]='identifier'
-        [tagging]='tagging'
-        [allowAdditions]='allowAdditions'
-        [selectCaret]='selectCaret'
-        [selected]='value'
-        [hint]='hint'
-        [disableDropdown]='disableDropdown'
-        (keyup)='onKeyUp($event)'
-        (toggle)='onToggle()'
-        (activate)='onFocus()'
-        (selection)='onInputSelection($event)'
+        [autofocus]="autofocus"
+        [options]="options"
+        [allowClear]="allowClear"
+        [label]="label"
+        [requiredIndicator]="requiredIndicatorView"
+        [placeholder]="placeholder"
+        [multiple]="multiple"
+        [identifier]="identifier"
+        [tagging]="tagging"
+        [allowAdditions]="allowAdditions"
+        [selectCaret]="selectCaret"
+        [selected]="value"
+        [hint]="hint"
+        [disableDropdown]="disableDropdown"
+        (keyup)="onKeyUp($event)"
+        (toggle)="onToggle()"
+        (activate)="onFocus()"
+        (selection)="onInputSelection($event)"
       >
       </ngx-select-input>
     </div>
   </div>
   <ngx-select-dropdown
-    *ngIf='dropdownVisible'
-    [focusIndex]='focusIndex'
-    [filterQuery]='filterQuery'
-    [filterPlaceholder]='filterPlaceholder'
-    [filterCaseSensitive]='filterCaseSensitive'
-    [allowAdditions]='allowAdditions'
-    [allowAdditionsText]='allowAdditionsText'
-    [selected]='value'
-    [groupBy]='groupBy'
-    [groupByTemplate]='groupByTemplate'
-    [emptyPlaceholder]='emptyPlaceholder'
-    [tagging]='tagging'
-    [filterEmptyPlaceholder]='filterEmptyPlaceholder'
-    [filterable]='filterable'
-    [identifier]='identifier'
-    [options]='options'
-    (keyup)='keyup.emit($event)'
-    (close)='onClose()'
-    (selection)='onDropdownSelection($event)'
+    *ngIf="dropdownVisible"
+    [focusIndex]="focusIndex"
+    [filterQuery]="filterQuery"
+    [filterPlaceholder]="filterPlaceholder"
+    [filterCaseSensitive]="filterCaseSensitive"
+    [allowAdditions]="allowAdditions"
+    [allowAdditionsText]="allowAdditionsText"
+    [selected]="value"
+    [groupBy]="groupBy"
+    [groupByTemplate]="groupByTemplate"
+    [emptyPlaceholder]="emptyPlaceholder"
+    [tagging]="tagging"
+    [filterEmptyPlaceholder]="filterEmptyPlaceholder"
+    [filterable]="filterable"
+    [identifier]="identifier"
+    [options]="options"
+    (keyup)="keyup.emit($event)"
+    (close)="onClose()"
+    (selection)="onDropdownSelection($event)"
   >
   </ngx-select-dropdown>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -1,8 +1,8 @@
+import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  ContentChild,
   ContentChildren,
   ElementRef,
   EventEmitter,
@@ -17,14 +17,13 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
-
-import { SelectOptionDirective } from './select-option.directive';
-import { SelectInputComponent } from './select-input.component';
-import { SelectDropdownOption } from './select-dropdown-option.interface';
 import { KeyboardKeys } from '../../enums/keyboard-keys.enum';
 import { appearanceMixin } from '../../mixins/appearance/appearance.mixin';
 import { sizeMixin } from '../../mixins/size/size.mixin';
+import { SelectDropdownOption } from './select-dropdown-option.interface';
+import { SelectInputComponent } from './select-input.component';
+
+import { SelectOptionDirective } from './select-option.directive';
 
 let nextId = 0;
 
@@ -242,10 +241,14 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   /**
    * Custom Template for groupBy
    * Only works with groupBy on
+   *
+   * TemplateContext:
+   * - groupName: the name of the group (`option.value[this.groupBy]` is the value)
+   * - index, first, last, odd, even (ngFor properties)
    */
-  @ContentChild(TemplateRef) groupNameTemplate: TemplateRef<unknown>;
+  @Input() groupByTemplate: TemplateRef<unknown>;
 
-  @ContentChildren(SelectOptionDirective)
+  @ContentChildren(SelectOptionDirective, { descendants: true })
   get optionTemplates() {
     return this._optionTemplates;
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChild,
   ContentChildren,
   ElementRef,
   EventEmitter,
@@ -11,6 +12,7 @@ import {
   Output,
   QueryList,
   Renderer2,
+  TemplateRef,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
@@ -33,6 +35,7 @@ const SELECT_VALUE_ACCESSOR = {
 };
 
 class InputBase {}
+
 const _InputMixinBase = appearanceMixin(sizeMixin(InputBase));
 
 @Component({
@@ -85,6 +88,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get minSelections() {
     return this._minSelections;
   }
+
   set minSelections(minSelections) {
     this._minSelections = coerceNumberProperty(minSelections, undefined);
   }
@@ -93,6 +97,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get autosizeMinWidth(): number | string {
     return this._autosizeMinWidth;
   }
+
   set autosizeMinWidth(autosizeMinWidth) {
     if (!isNaN(+autosizeMinWidth)) {
       this._autosizeMinWidth = `${autosizeMinWidth}px`;
@@ -105,6 +110,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get maxSelections() {
     return this._maxSelections;
   }
+
   set maxSelections(maxSelections) {
     this._maxSelections = coerceNumberProperty(maxSelections, undefined);
   }
@@ -113,6 +119,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get autofocus() {
     return this._autofocus;
   }
+
   set autofocus(autofocus) {
     this._autofocus = coerceBooleanProperty(autofocus);
   }
@@ -121,6 +128,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get autosize() {
     return this._autosize;
   }
+
   set autosize(autosize) {
     this._autosize = coerceBooleanProperty(autosize);
   }
@@ -129,6 +137,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get allowClear() {
     return this._allowClear;
   }
+
   set allowClear(allowClear) {
     this._allowClear = coerceBooleanProperty(allowClear);
   }
@@ -137,6 +146,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get allowAdditions() {
     return this._allowAdditions;
   }
+
   set allowAdditions(allowAdditions) {
     this._allowAdditions = coerceBooleanProperty(allowAdditions);
   }
@@ -145,6 +155,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get disableDropdown() {
     return this._disableDropdown;
   }
+
   set disableDropdown(disableDropdown) {
     this._disableDropdown = coerceBooleanProperty(disableDropdown);
   }
@@ -153,6 +164,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get closeOnSelect() {
     return this._closeOnSelect;
   }
+
   set closeOnSelect(closeOnSelect) {
     this._closeOnSelect = coerceBooleanProperty(closeOnSelect);
   }
@@ -161,6 +173,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get closeOnBodyClick() {
     return this._closeOnBodyClick;
   }
+
   set closeOnBodyClick(closeOnBodyClick) {
     this._closeOnBodyClick = coerceBooleanProperty(closeOnBodyClick);
   }
@@ -169,6 +182,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get filterable() {
     return this._filterable;
   }
+
   set filterable(filterable) {
     this._filterable = coerceBooleanProperty(filterable);
   }
@@ -177,6 +191,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get required() {
     return this._required;
   }
+
   set required(required) {
     this._required = coerceBooleanProperty(required);
   }
@@ -185,6 +200,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get filterCaseSensitive() {
     return this._filterCaseSensitive;
   }
+
   set filterCaseSensitive(filterCaseSensitive) {
     this._filterCaseSensitive = coerceBooleanProperty(filterCaseSensitive);
   }
@@ -193,6 +209,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get tagging() {
     return this._tagging;
   }
+
   set tagging(tagging) {
     this._tagging = coerceBooleanProperty(tagging);
   }
@@ -201,6 +218,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get multiple() {
     return this._multiple;
   }
+
   set multiple(multiple) {
     this._multiple = coerceBooleanProperty(multiple);
   }
@@ -209,6 +227,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get disabled() {
     return this._disabled;
   }
+
   set disabled(disabled) {
     this._disabled = coerceBooleanProperty(disabled);
   }
@@ -220,10 +239,17 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   @ViewChild(SelectInputComponent, { static: true })
   readonly inputComponent: SelectInputComponent;
 
+  /**
+   * Custom Template for groupBy
+   * Only works with groupBy on
+   */
+  @ContentChild(TemplateRef) groupNameTemplate: TemplateRef<unknown>;
+
   @ContentChildren(SelectOptionDirective)
   get optionTemplates() {
     return this._optionTemplates;
   }
+
   set optionTemplates(val: QueryList<SelectOptionDirective>) {
     this._optionTemplates = val;
 
@@ -270,6 +296,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   get value() {
     return this._value;
   }
+
   set value(val: any[]) {
     if (val !== this._value) {
       this._value = val;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.module.ts
@@ -1,12 +1,12 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { SelectDropdownComponent } from './select-dropdown.component';
+import { SelectInputComponent } from './select-input.component';
+import { SelectOptionInputTemplateDirective } from './select-option-input-template.directive';
+import { SelectOptionTemplateDirective } from './select-option-template.directive';
+import { SelectOptionDirective } from './select-option.directive';
 
 import { SelectComponent } from './select.component';
-import { SelectInputComponent } from './select-input.component';
-import { SelectDropdownComponent } from './select-dropdown.component';
-import { SelectOptionDirective } from './select-option.directive';
-import { SelectOptionTemplateDirective } from './select-option-template.directive';
-import { SelectOptionInputTemplateDirective } from './select-option-input-template.directive';
 
 @NgModule({
   declarations: [

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -9,15 +9,14 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="false" [label]="'Attack Type'">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="false" [label]="'Attack Type'">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -30,15 +29,14 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="false" [label]="'Attack Type'" [required]="true">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="false" [label]="'Attack Type'" [required]="true">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -51,15 +49,14 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="true" (keyup)="onSelectKeyUp($event)">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="true" (keyup)="onSelectKeyUp($event)">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -72,15 +69,14 @@
     <ngx-select-option name="Physical" value="Physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="true" (keyup)="onSelectKeyUp($event)" [filterCaseSensitive]="true">
-      <ngx-select-option name="Breach" value="Breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="DDOS"></ngx-select-option>
-      <ngx-select-option name="Physical" value="Physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="true" (keyup)="onSelectKeyUp($event)" [filterCaseSensitive]="true">
+  <ngx-select-option name="Breach" value="Breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="DDOS"></ngx-select-option>
+  <ngx-select-option name="Physical" value="Physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -93,15 +89,14 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="true" [allowAdditions]="true" [allowAdditionsText]="'Add New Value'">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="true" [allowAdditions]="true" [allowAdditionsText]="'Add New Value'">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -118,21 +113,20 @@
     <ngx-select-option name="super califragilisticex pialidoc ious" value="s3121"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select
-      style="max-width: 300px"
-      [filterable]="true"
-      [ngModel]="['supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious']">
-      <ngx-select-option
-        name="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious"
-        value="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious">
-      </ngx-select-option>
-      <ngx-select-option name="supe rcalifragilist icexpialidocious" value="s2344"></ngx-select-option>
-      <ngx-select-option name="super califragilisticex pialidoc ious" value="s3121"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select
+  style="max-width: 300px"
+  [filterable]="true"
+  [ngModel]="['supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious']">
+  <ngx-select-option
+    name="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious"
+    value="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious">
+  </ngx-select-option>
+  <ngx-select-option name="supe rcalifragilist icexpialidocious" value="s2344"></ngx-select-option>
+  <ngx-select-option name="super califragilisticex pialidoc ious" value="s3121"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -144,17 +138,16 @@
     </ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [identifier]="'attr'" [ngModel]="[selects[0]]" label="Select a value...">
-      <ngx-select-option
-        *ngFor="let option of selects"
-        [name]="option.name"
-        [value]="option">
-      </ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [identifier]="'attr'" [ngModel]="[selects[0]]" label="Select a value...">
+  <ngx-select-option
+    *ngFor="let option of selects"
+    [name]="option.name"
+    [value]="option">
+  </ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -166,18 +159,17 @@
     </ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [ngModel]="[singleSelectModel]" (ngModelChange)="singleSelectModel = $event[0]"
-                label="Select a value...">
-      <ngx-select-option
-        *ngFor="let option of selects"
-        [name]="option.name"
-        [value]="option">
-      </ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [ngModel]="[singleSelectModel]" (ngModelChange)="singleSelectModel = $event[0]"
+            label="Select a value...">
+  <ngx-select-option
+    *ngFor="let option of selects"
+    [name]="option.name"
+    [value]="option">
+  </ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <h4>Input and Option Templates</h4>
   <ngx-select>
@@ -197,26 +189,25 @@
     </ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select>
-      <ngx-select-option value="breach">
-        <ng-template ngx-select-option-input-template let-option="option">
-          <span class="tag">option.value</span>
-        </ng-template>
-        <ng-template ngx-select-option-template let-option="option">
-          <span class="icon-bug"></span> option.value
-        </ng-template>
-      </ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical">
-        <ng-template ngx-select-option-template let-option="option">
-          <span class="icon-logo"></span> option.value
-        </ng-template>
-      </ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select>
+  <ngx-select-option value="breach">
+    <ng-template ngx-select-option-input-template let-option="option">
+      <span class="tag">option.value</span>
+    </ng-template>
+    <ng-template ngx-select-option-template let-option="option">
+      <span class="icon-bug"></span> option.value
+    </ng-template>
+  </ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical">
+    <ng-template ngx-select-option-template let-option="option">
+      <span class="icon-logo"></span> option.value
+    </ng-template>
+  </ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -229,15 +220,14 @@
     <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [groupBy]="'type'">
-      <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
-      <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
-      <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [groupBy]="'type'">
+  <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -257,22 +247,21 @@
     </ng-container>
   </ng-template>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [groupBy]="'type'" [groupByTemplate]="groupByTemplate">
-      <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
-      <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
-      <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
-    </ngx-select>
-    <ng-template #groupByTemplate let-name="groupName">
-      {{'\{{name}\}'}}
-      <ng-container [ngSwitch]="name">
-        <ng-container *ngSwitchCase="'IOS'">🔥🔥🔥</ng-container>
-        <ng-container *ngSwitchDefault>🎄🎄🎄</ng-container>
-      </ng-container>
-    </ng-template>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [groupBy]="'type'" [groupByTemplate]="groupByTemplate">
+  <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+</ngx-select>
+<ng-template #groupByTemplate let-name="groupName">
+  {{'\{{name}\}'}}
+  <ng-container [ngSwitch]="name">
+    <ng-container *ngSwitchCase="'IOS'">🔥🔥🔥</ng-container>
+    <ng-container *ngSwitchDefault>🎄🎄🎄</ng-container>
+  </ng-container>
+</ng-template>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -285,15 +274,14 @@
     <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [placeholder]="'Select incident type...'">
-      <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
-      <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
-      <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [placeholder]="'Select incident type...'">
+  <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -306,15 +294,14 @@
     <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true" [hidden]="true"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [placeholder]="'Select incident type...'">
-      <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
-      <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true" [hidden]="true"></ngx-select-option>
-      <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true" [hidden]="true"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [placeholder]="'Select incident type...'">
+  <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true" [hidden]="true"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true" [hidden]="true"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -327,15 +314,14 @@
     <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [disabled]="true" [ngModel]="['Breach']">
-      <ngx-select-option [name]="'Breach'" [value]="'Breach'"></ngx-select-option>
-      <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
-      <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [disabled]="true" [ngModel]="['Breach']">
+  <ngx-select-option [name]="'Breach'" [value]="'Breach'"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -348,15 +334,14 @@
     <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [ngModel]="['Breach']">
-      <ngx-select-option [name]="'Breach'" [value]="'Breach'" [hidden]="true"></ngx-select-option>
-      <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
-      <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [ngModel]="['Breach']">
+  <ngx-select-option [name]="'Breach'" [value]="'Breach'" [hidden]="true"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -364,11 +349,10 @@
 
   <h4>No Options</h4>
   <ngx-select [filterable]="false"></ngx-select>
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="false"></ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="false"></ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -382,11 +366,10 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="false"></ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="false"></ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -404,24 +387,23 @@
     <ngx-icon fontIcon="double-down"></ngx-icon>
   </ng-template>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select
-      [filterable]="true"
-      [allowAdditions]="true"
-      [allowAdditionsText]="Add New Value'"
-      [selectCaret]="doubleDown">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<app-prism>
+<![CDATA[<ngx-select
+  [filterable]="true"
+  [allowAdditions]="true"
+  [allowAdditionsText]="Add New Value'"
+  [selectCaret]="doubleDown">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ng-template #doubleDown>
-      <ngx-icon fontIcon="double-down"></ngx-icon>
-    </ng-template>
+<ng-template #doubleDown>
+  <ngx-icon fontIcon="double-down"></ngx-icon>
+</ng-template>
 
-    <!-- `allowAdditionsText` and `selectCaret` both accept strings or template references -->]]>
-  </app-prism>
+<!-- `allowAdditionsText` and `selectCaret` both accept strings or template references -->]]>
+</app-prism>
 </ngx-section>
 
 <ngx-section class="shadow" [sectionTitle]="'Multi Select'">
@@ -432,15 +414,14 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="false" [multiple]="true">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="false" [multiple]="true">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
 
   <br />
@@ -454,16 +435,15 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select label="Select one or two" [filterable]="false" [multiple]="true" [minSelections]="1"
-                [maxSelections]="2">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select label="Select one or two" [filterable]="false" [multiple]="true" [minSelections]="1"
+            [maxSelections]="2">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -476,15 +456,14 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="false" [multiple]="true" [closeOnSelect]="true">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="false" [multiple]="true" [closeOnSelect]="true">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -498,21 +477,20 @@
     </ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select
-      [multiple]="true"
-      [identifier]="'attr'"
-      [ngModel]="[selects[0], selects[1], selects[2], selects[3], selects[4], selects[5], selects[6], selects[7], selects[8]]">
-      <ngx-select-option
-        *ngFor="let option of selects"
-        [name]="option.name"
-        [disabled]="option.disabled"
-        [value]="option">
-      </ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select
+  [multiple]="true"
+  [identifier]="'attr'"
+  [ngModel]="[selects[0], selects[1], selects[2], selects[3], selects[4], selects[5], selects[6], selects[7], selects[8]]">
+  <ngx-select-option
+    *ngFor="let option of selects"
+    [name]="option.name"
+    [disabled]="option.disabled"
+    [value]="option">
+  </ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -537,15 +515,14 @@
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="false" [tagging]="true" (keyup)="onSelectKeyUp($event)">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="false" [tagging]="true" (keyup)="onSelectKeyUp($event)">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 
   <br />
   <br />
@@ -555,14 +532,13 @@
   <ngx-select [filterable]="false" [tagging]="true">
   </ngx-select>
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select
-      [filterable]="false"
-      [tagging]="true">
-    </ngx-select>
-    ]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<ngx-select
+  [filterable]="false"
+  [tagging]="true">
+</ngx-select>
+]]>
+</app-prism>
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Native">
@@ -573,13 +549,14 @@
   </select>
   <br />
   <br />
-  <app-prism>
-    <![CDATA[<select>
-    <option>Red</option>
-    <option>Blue</option>
-    <option>Green</option>
-  </select>]]>
-  </app-prism>
+<app-prism>
+<![CDATA[<select>
+  <option>Red</option>
+  <option>Blue</option>
+  <option>Green</option>
+</select>
+]]>
+</app-prism>
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Async">
@@ -712,93 +689,92 @@
 
   <br />
 
-  <app-prism>
-    <![CDATA[
-    <ngx-select [filterable]="false" appearance="legacy">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<app-prism>
+<![CDATA[<ngx-select [filterable]="false" appearance="legacy">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="false" appearance="legacy" label="Legacy input with autosize" autosize="true">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-      <ngx-select-option name="Really long option to show autosize of the component when autosize is selected"
-                         value="Really long option to show autosize of the component when autosize is selected"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="false" appearance="legacy" label="Legacy input with autosize" autosize="true">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+  <ngx-select-option name="Really long option to show autosize of the component when autosize is selected"
+                     value="Really long option to show autosize of the component when autosize is selected"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="false" appearance="fill">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="false" appearance="fill">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="true" appearance="fill" label="Fill With Search">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="true" appearance="fill" label="Fill With Search">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options">
-    </ngx-select>
+<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options">
+</ngx-select>
 
-    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type">
-      <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
-      <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
-      <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type">
+  <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+</ngx-select>
 
-    <h4>Autosize</h4>
+<h4>Autosize</h4>
 
-    <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint"
-                placeholder="Select a value..." autosize="true">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint"
+            placeholder="Select a value..." autosize="true">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="true" appearance="fill" label="Fill With Search" autosize="true">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="true" appearance="fill" label="Fill With Search" autosize="true">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections"
-                autosize="true">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections"
+            autosize="true">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging" autosize="true">
-      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    </ngx-select>
+<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging" autosize="true">
+  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+</ngx-select>
 
-    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options"
-                autosize="true">
-    </ngx-select>
+<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options"
+            autosize="true">
+</ngx-select>
 
-    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type"
-                autosize="true">
-      <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
-      <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
-      <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
-    </ngx-select>
-    ]]>
-  </app-prism>
+<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type"
+            autosize="true">
+  <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+</ngx-select>
+]]>
+</app-prism>
 </ngx-section>

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -223,18 +223,18 @@
   <br />
 
   <h4>Objects with Grouping - with custom template</h4>
-  <ngx-select [groupBy]="'type'">
-    <ng-template let-name="groupName">
-      {{name}}
-      <ng-container [ngSwitch]="name">
-        <ng-container *ngSwitchCase="'IOS'">🔥🔥🔥</ng-container>
-        <ng-container *ngSwitchDefault>🎄🎄🎄</ng-container>
-      </ng-container>
-    </ng-template>
+  <ngx-select [groupBy]="'type'" [groupByTemplate]='groupByTemplate'>
     <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
     <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
     <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
   </ngx-select>
+  <ng-template #groupByTemplate let-name="groupName">
+    {{name}}
+    <ng-container [ngSwitch]="name">
+      <ng-container *ngSwitchCase="'IOS'">🔥🔥🔥</ng-container>
+      <ng-container *ngSwitchDefault>🎄🎄🎄</ng-container>
+    </ng-container>
+  </ng-template>
 
   <app-prism>
 <![CDATA[<ngx-select [groupBy]="'type'">

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -222,6 +222,39 @@
   <br />
   <br />
 
+  <h4>Objects with Grouping - with custom template</h4>
+  <ngx-select [groupBy]="'type'">
+    <ng-template let-name="groupName">
+      {{name}}
+      <ng-container [ngSwitch]="name">
+        <ng-container *ngSwitchCase="'IOS'">🔥🔥🔥</ng-container>
+        <ng-container *ngSwitchDefault>🎄🎄🎄</ng-container>
+      </ng-container>
+    </ng-template>
+    <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+    <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+    <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+  </ngx-select>
+
+  <app-prism>
+<![CDATA[<ngx-select [groupBy]="'type'">
+  <ng-template let-name="groupName">
+    {{'\{{name}\}'}}
+    <ng-container [ngSwitch]="name">
+      <ng-container *ngSwitchCase="'IOS'">🔥🔥🔥</ng-container>
+      <ng-container *ngSwitchDefault>🎄🎄🎄</ng-container>
+    </ng-container>
+  </ng-template>
+  <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+</ngx-select>]]>
+  </app-prism>
+
+  <br />
+  <br />
+  <br />
+
   <h4>Disabled Options with Placeholder</h4>
   <ngx-select [placeholder]="'Select incident type...'">
     <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -10,11 +10,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="false" [label]="'Attack Type'">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="false" [label]="'Attack Type'">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -29,11 +31,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="false" [label]="'Attack Type'" [required]="true">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="false" [label]="'Attack Type'" [required]="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -48,11 +52,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="true" (keyup)="onSelectKeyUp($event)">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="true" (keyup)="onSelectKeyUp($event)">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -67,11 +73,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="true" (keyup)="onSelectKeyUp($event)" [filterCaseSensitive]="true">
-  <ngx-select-option name="Breach" value="Breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="DDOS"></ngx-select-option>
-  <ngx-select-option name="Physical" value="Physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="true" (keyup)="onSelectKeyUp($event)" [filterCaseSensitive]="true">
+      <ngx-select-option name="Breach" value="Breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="DDOS"></ngx-select-option>
+      <ngx-select-option name="Physical" value="Physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -86,11 +94,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="true" [allowAdditions]="true" [allowAdditionsText]="'Add New Value'">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="true" [allowAdditions]="true" [allowAdditionsText]="'Add New Value'">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -99,7 +109,7 @@
 
   <h4>Long Values</h4>
   <ngx-select style="max-width: 300px"
-    [ngModel]="['supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious']">
+              [ngModel]="['supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious']">
     <ngx-select-option
       name="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious"
       value="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious">
@@ -109,17 +119,19 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select
-  style="max-width: 300px"
-  [filterable]="true"
-  [ngModel]="['supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious']">
-  <ngx-select-option
-    name="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious"
-    value="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious">
-  </ngx-select-option>
-  <ngx-select-option name="supe rcalifragilist icexpialidocious" value="s2344"></ngx-select-option>
-  <ngx-select-option name="super califragilisticex pialidoc ious" value="s3121"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select
+      style="max-width: 300px"
+      [filterable]="true"
+      [ngModel]="['supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious']">
+      <ngx-select-option
+        name="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious"
+        value="supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious">
+      </ngx-select-option>
+      <ngx-select-option name="supe rcalifragilist icexpialidocious" value="s2344"></ngx-select-option>
+      <ngx-select-option name="super califragilisticex pialidoc ious" value="s3121"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -133,13 +145,15 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [identifier]="'attr'" [ngModel]="[selects[0]]" label="Select a value...">
-  <ngx-select-option
-    *ngFor="let option of selects"
-    [name]="option.name"
-    [value]="option">
-  </ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [identifier]="'attr'" [ngModel]="[selects[0]]" label="Select a value...">
+      <ngx-select-option
+        *ngFor="let option of selects"
+        [name]="option.name"
+        [value]="option">
+      </ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -153,13 +167,16 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [ngModel]="[singleSelectModel]" (ngModelChange)="singleSelectModel = $event[0]" label="Select a value...">
-  <ngx-select-option
-    *ngFor="let option of selects"
-    [name]="option.name"
-    [value]="option">
-  </ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [ngModel]="[singleSelectModel]" (ngModelChange)="singleSelectModel = $event[0]"
+                label="Select a value...">
+      <ngx-select-option
+        *ngFor="let option of selects"
+        [name]="option.name"
+        [value]="option">
+      </ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <h4>Input and Option Templates</h4>
@@ -181,22 +198,24 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select>
-  <ngx-select-option value="breach">
-    <ng-template ngx-select-option-input-template let-option="option">
-      <span class="tag">option.value</span>
-    </ng-template>
-    <ng-template ngx-select-option-template let-option="option">
-      <span class="icon-bug"></span> option.value
-    </ng-template>
-  </ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical">
-    <ng-template ngx-select-option-template let-option="option">
-      <span class="icon-logo"></span> option.value
-    </ng-template>
-  </ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select>
+      <ngx-select-option value="breach">
+        <ng-template ngx-select-option-input-template let-option="option">
+          <span class="tag">option.value</span>
+        </ng-template>
+        <ng-template ngx-select-option-template let-option="option">
+          <span class="icon-bug"></span> option.value
+        </ng-template>
+      </ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical">
+        <ng-template ngx-select-option-template let-option="option">
+          <span class="icon-logo"></span> option.value
+        </ng-template>
+      </ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -211,11 +230,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [groupBy]="'type'">
-  <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
-  <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
-  <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [groupBy]="'type'">
+      <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -223,7 +244,7 @@
   <br />
 
   <h4>Objects with Grouping - with custom template</h4>
-  <ngx-select [groupBy]="'type'" [groupByTemplate]='groupByTemplate'>
+  <ngx-select [groupBy]="'type'" [groupByTemplate]="groupByTemplate">
     <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
     <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
     <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
@@ -237,18 +258,20 @@
   </ng-template>
 
   <app-prism>
-<![CDATA[<ngx-select [groupBy]="'type'">
-  <ng-template let-name="groupName">
-    {{'\{{name}\}'}}
-    <ng-container [ngSwitch]="name">
-      <ng-container *ngSwitchCase="'IOS'">🔥🔥🔥</ng-container>
-      <ng-container *ngSwitchDefault>🎄🎄🎄</ng-container>
-    </ng-container>
-  </ng-template>
-  <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
-  <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
-  <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [groupBy]="'type'" [groupByTemplate]="groupByTemplate">
+      <ngx-select-option [name]="'Breach'" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option [name]="'DDOS'" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option [name]="'Physical'" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+    </ngx-select>
+    <ng-template #groupByTemplate let-name="groupName">
+      {{'\{{name}\}'}}
+      <ng-container [ngSwitch]="name">
+        <ng-container *ngSwitchCase="'IOS'">🔥🔥🔥</ng-container>
+        <ng-container *ngSwitchDefault>🎄🎄🎄</ng-container>
+      </ng-container>
+    </ng-template>
+    ]]>
   </app-prism>
 
   <br />
@@ -263,11 +286,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [placeholder]="'Select incident type...'">
-  <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
-  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
-  <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [placeholder]="'Select incident type...'">
+      <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
+      <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
+      <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -282,11 +307,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [placeholder]="'Select incident type...'">
-  <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
-  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true" [hidden]="true"></ngx-select-option>
-  <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true" [hidden]="true"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [placeholder]="'Select incident type...'">
+      <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
+      <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true" [hidden]="true"></ngx-select-option>
+      <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="true" [hidden]="true"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -301,11 +328,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [disabled]="true" [ngModel]="['Breach']">
-  <ngx-select-option [name]="'Breach'" [value]="'Breach'"></ngx-select-option>
-  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
-  <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [disabled]="true" [ngModel]="['Breach']">
+      <ngx-select-option [name]="'Breach'" [value]="'Breach'"></ngx-select-option>
+      <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
+      <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -320,11 +349,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [ngModel]="['Breach']">
-  <ngx-select-option [name]="'Breach'" [value]="'Breach'" [hidden]="true"></ngx-select-option>
-  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
-  <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [ngModel]="['Breach']">
+      <ngx-select-option [name]="'Breach'" [value]="'Breach'" [hidden]="true"></ngx-select-option>
+      <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
+      <ngx-select-option [name]="'Physical'" [value]="'Physical'" [disabled]="true"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -334,7 +365,9 @@
   <h4>No Options</h4>
   <ngx-select [filterable]="false"></ngx-select>
   <app-prism>
-<![CDATA[<ngx-select [filterable]="false"></ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="false"></ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -343,14 +376,16 @@
 
   <h4>Events</h4>
   <ngx-select [filterable]="true" label="Attack Type" (change)="onEvent('ngx-select change', $event)"
-    (keyup)="onEvent('ngx-select change', $event)" (toggle)="onEvent('ngx-select toggle', $event)">
+              (keyup)="onEvent('ngx-select change', $event)" (toggle)="onEvent('ngx-select toggle', $event)">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="false"></ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="false"></ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -359,7 +394,7 @@
 
   <h4>Customization</h4>
   <ngx-select [filterable]="true" [allowAdditions]="true" [allowAdditionsText]="'Add New Value'"
-    [selectCaret]="doubleDown">
+              [selectCaret]="doubleDown">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
@@ -370,21 +405,22 @@
   </ng-template>
 
   <app-prism>
-<![CDATA[<ngx-select
-  [filterable]="true"
-  [allowAdditions]="true"
-  [allowAdditionsText]="Add New Value'"
-  [selectCaret]="doubleDown">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <![CDATA[
+    <ngx-select
+      [filterable]="true"
+      [allowAdditions]="true"
+      [allowAdditionsText]="Add New Value'"
+      [selectCaret]="doubleDown">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ng-template #doubleDown>
-  <ngx-icon fontIcon="double-down"></ngx-icon>
-</ng-template>
+    <ng-template #doubleDown>
+      <ngx-icon fontIcon="double-down"></ngx-icon>
+    </ng-template>
 
-<!-- `allowAdditionsText` and `selectCaret` both accept strings or template references -->]]>
+    <!-- `allowAdditionsText` and `selectCaret` both accept strings or template references -->]]>
   </app-prism>
 </ngx-section>
 
@@ -397,11 +433,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="false" [multiple]="true">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="false" [multiple]="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
 
@@ -417,11 +455,14 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select label="Select one or two" [filterable]="false" [multiple]="true" [minSelections]="1" [maxSelections]="2">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select label="Select one or two" [filterable]="false" [multiple]="true" [minSelections]="1"
+                [maxSelections]="2">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -436,11 +477,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="false" [multiple]="true" [closeOnSelect]="true">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="false" [multiple]="true" [closeOnSelect]="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -449,24 +492,26 @@
 
   <h4>Several Default Selections</h4>
   <ngx-select [multiple]="true" [identifier]="'attr'"
-    [ngModel]="[selects[0], selects[1], selects[2], selects[3], selects[4], selects[5], selects[6], selects[7], selects[8]]">
+              [ngModel]="[selects[0], selects[1], selects[2], selects[3], selects[4], selects[5], selects[6], selects[7], selects[8]]">
     <ngx-select-option *ngFor="let option of selects" [name]="option.name" [disabled]="option.disabled"
-      [value]="option">
+                       [value]="option">
     </ngx-select-option>
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select
-  [multiple]="true"
-  [identifier]="'attr'"
-  [ngModel]="[selects[0], selects[1], selects[2], selects[3], selects[4], selects[5], selects[6], selects[7], selects[8]]">
-  <ngx-select-option
-    *ngFor="let option of selects"
-    [name]="option.name"
-    [disabled]="option.disabled"
-    [value]="option">
-  </ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select
+      [multiple]="true"
+      [identifier]="'attr'"
+      [ngModel]="[selects[0], selects[1], selects[2], selects[3], selects[4], selects[5], selects[6], selects[7], selects[8]]">
+      <ngx-select-option
+        *ngFor="let option of selects"
+        [name]="option.name"
+        [disabled]="option.disabled"
+        [value]="option">
+      </ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -476,7 +521,7 @@
   <h4>Templates</h4>
   <ngx-select [multiple]="true" (keyup)="onSelectKeyUp($event)" [identifier]="'attr'" [ngModel]="[selects[0]]">
     <ngx-select-option *ngFor="let option of selects" [name]="option.name" [disabled]="option.disabled"
-      [value]="option">
+                       [value]="option">
       <ng-template ngx-select-option-input-template let-option="option">
         <span class="icon-bug"></span> {{option.value.name}}
       </ng-template>
@@ -493,11 +538,13 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="false" [tagging]="true" (keyup)="onSelectKeyUp($event)">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select [filterable]="false" [tagging]="true" (keyup)="onSelectKeyUp($event)">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 
   <br />
@@ -509,10 +556,12 @@
   </ngx-select>
 
   <app-prism>
-<![CDATA[<ngx-select
-  [filterable]="false"
-  [tagging]="true">
-</ngx-select>]]>
+    <![CDATA[
+    <ngx-select
+      [filterable]="false"
+      [tagging]="true">
+    </ngx-select>
+    ]]>
   </app-prism>
 </ngx-section>
 
@@ -525,11 +574,11 @@
   <br />
   <br />
   <app-prism>
-<![CDATA[<select>
-  <option>Red</option>
-  <option>Blue</option>
-  <option>Green</option>
-</select>]]>
+    <![CDATA[<select>
+    <option>Red</option>
+    <option>Blue</option>
+    <option>Green</option>
+  </select>]]>
   </app-prism>
 </ngx-section>
 
@@ -557,12 +606,14 @@
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-    <ngx-select-option name="Really long option to show autosize of the component when autosize is selected" value="Really long option to show autosize of the component when autosize is selected"></ngx-select-option>
+    <ngx-select-option name="Really long option to show autosize of the component when autosize is selected"
+                       value="Really long option to show autosize of the component when autosize is selected"></ngx-select-option>
   </ngx-select>
 
   <br />
 
-  <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint" placeholder="Select a value...">
+  <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint"
+              placeholder="Select a value...">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
@@ -610,7 +661,8 @@
   <h4>Autosize</h4>
   <br />
 
-  <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint" placeholder="Select a value..." autosize="true">
+  <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint" placeholder="Select a value..."
+              autosize="true">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
@@ -626,7 +678,8 @@
 
   <br />
 
-  <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections" autosize="true">
+  <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections"
+              autosize="true">
     <ngx-select-option name="Breach" value="breach"></ngx-select-option>
     <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
     <ngx-select-option name="Physical" value="physical"></ngx-select-option>
@@ -642,12 +695,14 @@
 
   <br />
 
-  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options" autosize="true">
+  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options"
+              autosize="true">
   </ngx-select>
 
   <br />
 
-  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type" autosize="true">
+  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type"
+              autosize="true">
     <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
     <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
     <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
@@ -658,85 +713,92 @@
   <br />
 
   <app-prism>
-<![CDATA[<ngx-select [filterable]="false" appearance="legacy">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <![CDATA[
+    <ngx-select [filterable]="false" appearance="legacy">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="false" appearance="legacy" label="Legacy input with autosize" autosize="true">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-  <ngx-select-option name="Really long option to show autosize of the component when autosize is selected" value="Really long option to show autosize of the component when autosize is selected"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="false" appearance="legacy" label="Legacy input with autosize" autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+      <ngx-select-option name="Really long option to show autosize of the component when autosize is selected"
+                         value="Really long option to show autosize of the component when autosize is selected"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="false" appearance="fill">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="false" appearance="fill">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="a very long choice that you need to make" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="true" appearance="fill" label="Fill With Search">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="true" appearance="fill" label="Fill With Search">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options">
-</ngx-select>
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options">
+    </ngx-select>
 
-<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type">
-  <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
-  <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
-  <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type">
+      <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+    </ngx-select>
 
-<h4>Autosize</h4>
+    <h4>Autosize</h4>
 
-<ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint" placeholder="Select a value..." autosize="true">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="false" appearance="fill" label="Fill Input" hint="im a hint"
+                placeholder="Select a value..." autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical" disabled></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="true" appearance="fill" label="Fill With Search" autosize="true">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="true" appearance="fill" label="Fill With Search" autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections" autosize="true">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="false" [multiple]="true" appearance="fill" label="Fill With Multiple Selections"
+                autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging" autosize="true">
-  <ngx-select-option name="Breach" value="breach"></ngx-select-option>
-  <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
-  <ngx-select-option name="Physical" value="physical"></ngx-select-option>
-</ngx-select>
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Tagging" autosize="true">
+      <ngx-select-option name="Breach" value="breach"></ngx-select-option>
+      <ngx-select-option name="DDOS" value="ddos"></ngx-select-option>
+      <ngx-select-option name="Physical" value="physical"></ngx-select-option>
+    </ngx-select>
 
-<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options" autosize="true">
-</ngx-select>
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options"
+                autosize="true">
+    </ngx-select>
 
-<ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type" autosize="true">
-  <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
-  <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
-  <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
-</ngx-select>]]>
+    <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill With Grouping" groupBy="type"
+                autosize="true">
+      <ngx-select-option name="Breach" [value]="{ value: 'breach', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option name="DDOS" [value]="{ value: 'ddos', type: 'IOS' }"></ngx-select-option>
+      <ngx-select-option name="Physical" [value]="{ value: 'Physical', type: 'MOX' }"></ngx-select-option>
+    </ngx-select>
+    ]]>
   </app-prism>
 </ngx-section>


### PR DESCRIPTION
## Summary

Add ability to use custom template for `group` when `groupBy` is on.

normal:
![image](https://user-images.githubusercontent.com/25516557/101676906-710de580-3a21-11eb-93a4-93a991e0b034.png)
with custom template:
![image](https://user-images.githubusercontent.com/25516557/101676914-73703f80-3a21-11eb-9de0-c9d748e138e2.png)



## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
