### PR TITLE
Fix: datetime displayValue

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # HEAD (unreleased)
 
+## 33.1.0 (2020-12-14)
+
+- Feature: add `groupByTemplate` Input to `ngx-select`. Check [Selects Documentation](https://swimlane.github.io/ngx-ui/selects) for usage
+
 ## 33.0.0 (2020-12-8)
 
 - Feature: add `ngx-plus-menu`

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # HEAD (unreleased)
 
+- Fix(DateTime): Component no longer emits a `(change)` event when input value is invalid.
+- Fix(DateTime): Display value not updated correctly.
+
 ## 33.1.0 (2020-12-14)
 
 - Feature: add `groupByTemplate` Input to `ngx-select`. Check [Selects Documentation](https://swimlane.github.io/ngx-ui/selects) for usage

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "33.0.0",
+  "version": "33.1.0",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -587,4 +587,24 @@ describe('DateTimeComponent', () => {
       component.onBlur();
     });
   });
+
+  describe('set value', () => {
+    it('should emit "change" event', () => {
+      component.change.subscribe(date => expect(date).toBe(MOON_LANDING));
+      component.value = MOON_LANDING;
+    });
+
+    it('should NOT emit "change" event if value does not change', () => {
+      spyOn(component.change, 'emit');
+      component.value = MOON_LANDING;
+      component.value = MOON_LANDING_DATE;
+      expect(component.change.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT emit "change" event if invalid', () => {
+      spyOn(component.change, 'emit');
+      component.value = 'INVALID_DATE';
+      expect(component.change.emit).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -167,9 +167,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
       isSame = val === this._value;
     }
 
-    if (val && date) {
-      this.validate(date);
-    }
+    this.validate(date);
     this._value = date && date.isValid() ? date.toDate() : val;
 
     if (!isSame) {
@@ -329,6 +327,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   inputChanged(val: string): void {
     const date = this.parseDate(val);
     this.value = date.isValid() ? date.toDate() : val;
+    this.displayValue = val;
   }
 
   close(): void {
@@ -367,13 +366,13 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     return val;
   }
 
-  private validate(date: moment.Moment) {
+  private validate(date?: moment.Moment) {
     // check if date input is empty
-    const dateInput = date.creationData().input;
+    const dateInput = date?.creationData().input;
     const isEmpty = dateInput === '' || dateInput === null || dateInput === undefined; // 0 is a valid date input
 
     // date can be either valid, or an empty value if not required
-    const isValid = date.isValid() || (!this.required && isEmpty);
+    const isValid = date?.isValid() || (!this.required && isEmpty);
     const isInRange = !this.getDayDisabled(date);
 
     let errorMsg = '';

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -368,7 +368,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     return val;
   }
 
-  private validate(date?: moment.Moment) {
+  private validate(date: moment.Moment | undefined) {
     // check if date input is empty
     const dateInput = date?.creationData().input;
     const isEmpty = dateInput === '' || dateInput === null || dateInput === undefined; // 0 is a valid date input

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -167,10 +167,12 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
       isSame = val === this._value;
     }
 
-    this.validate(date);
+    const isValid = this.validate(date);
     this._value = date && date.isValid() ? date.toDate() : val;
 
-    if (!isSame) {
+    // notify of changes only when the component is cleared
+    // or when the set value is valid
+    if ((!val || isValid) && !isSame) {
       this.onChangeCallback(val);
       this.change.emit(val);
     }


### PR DESCRIPTION
## Summary

- Fix(DateTime): Component no longer emits a `(change)` event when input value is invalid.
- Fix(DateTime): Display value not updated correctly when input cleared.

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
