### PR TITLE
changes to plus menu

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # HEAD (unreleased)
 
+- Breaking: `ngx-plus-menu` takes items containing `title` and `subtitle`. Does not setup it's own hotkeys.
+- Fix: no popup us shown if `menuTitle` is not passed as an input to `ngx-plus-menu`
+
 ## 33.1.0 (2020-12-14)
 
 - Feature: add `groupByTemplate` Input to `ngx-select`. Check [Selects Documentation](https://swimlane.github.io/ngx-ui/selects) for usage

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
@@ -1,4 +1,4 @@
-<div class="ngx-plus-menu--circle-container" (click)="onClickOpenClose()" ngx-tooltip [tooltipDisabled]="position !== PlusMenuPosition.Right" [tooltipTitle]="menuTitle" tooltipPlacement="left">
+<div class="ngx-plus-menu--circle-container" (click)="onClickOpenClose()" ngx-tooltip [tooltipDisabled]="!menuTitle || position !== PlusMenuPosition.Right" [tooltipTitle]="menuTitle" tooltipPlacement="left">
   <ngx-icon class="ngx-plus-menu--circle" fontIcon="add-circle-medium"></ngx-icon>
   <span class="ngx-plus-menu--menu-title">{{ menuTitle }}</span>
 </div>
@@ -63,8 +63,8 @@
   <div class="ngx-plus-menu--items-container">
     <div *ngFor="let item of items; index as i" (click)="onClickItem(i)">
       <div [class]="'ngx-plus-menu--item ngx-plus-menu--item-' + i">
-        {{item.description}}
-        <div class="keys" *ngIf="item.keys">{{item.keys.join(' + ')}}</div>      
+        {{item.title}}
+        <div class="subtitle" *ngIf="item.subtitle">{{item.subtitle}}</div>      
       </div>
       <div [class]="'ngx-plus-menu--icon ngx-plus-menu--icon-' + i">
         <ngx-icon [fontIcon]="item.icon"></ngx-icon>

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
@@ -96,7 +96,7 @@
       font-weight: 600;
       cursor: pointer;
 
-      .keys {
+      .subtitle {
         font-style: normal;
         font-weight: 600;
         font-size: 13px;

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.spec.ts
@@ -22,19 +22,19 @@ describe('PlusMenuComponent', () => {
   let shallow: Shallow<PlusMenuComponent>;
 
   const upload = {
-    description: 'Upload a plugin',
-    hotkey: 'ctrl+alt+u',
+    title: 'Upload a plugin',
+    subtitle: 'ctrl + alt + u',
     icon: 'upload-outline'
   };
 
   const create = {
-    description: 'Create',
-    hotkey: 'ctrl+alt+n',
+    title: 'Create',
+    subtitle: 'ctrl + alt + n',
     icon: 'add-circle-thin'
   };
 
   const search = {
-    description: 'Search',
+    title: 'Search',
     icon: 'search'
   };
 
@@ -86,7 +86,7 @@ describe('PlusMenuComponent', () => {
           `
           <div class="ngx-plus-menu--item ngx-plus-menu--item-0">
             Upload a plugin
-            <div class="keys">
+            <div class="subtitle">
               ctrl + alt + u
             </div>
           </div>`
@@ -97,7 +97,7 @@ describe('PlusMenuComponent', () => {
           `
           <div class="ngx-plus-menu--item ngx-plus-menu--item-1">
             Create
-            <div class="keys">
+            <div class="subtitle">
               ctrl + alt + n
             </div>
           </div>`
@@ -155,7 +155,7 @@ describe('PlusMenuComponent', () => {
           `
           <div class="ngx-plus-menu--item ngx-plus-menu--item-0">
             Upload a plugin
-            <div class="keys">
+            <div class="subtitle">
               ctrl + alt + u
             </div>
           </div>`
@@ -166,7 +166,7 @@ describe('PlusMenuComponent', () => {
           `
           <div class="ngx-plus-menu--item ngx-plus-menu--item-1">
             Create
-            <div class="keys">
+            <div class="subtitle">
               ctrl + alt + n
             </div>
           </div>`

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
@@ -12,14 +12,12 @@ import {
   OnInit,
   OnDestroy
 } from '@angular/core';
-import { HotkeysService } from '../hotkeys/hotkeys.service';
 import { PlusMenuPosition } from './plus-menu-position.enum';
 
-interface PlusMenuItem {
-  description: string;
+export interface PlusMenuItem {
+  title: string;
+  subtitle?: string;
   icon: string;
-  hotkey?: string;
-  keys?: string[];
 }
 
 @Component({
@@ -58,15 +56,12 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
   private documentClickEvent: () => void;
 
   constructor(
-    private readonly hotkeysService: HotkeysService,
     private readonly elementRef: ElementRef,
     private readonly renderer: Renderer2,
     private readonly cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
-    this.initKeys();
-
     this.elementRef.nativeElement.style.setProperty('--menu-color', this.menuColor);
   }
 
@@ -104,23 +99,5 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
     this.cdr.markForCheck();
 
     if (this.documentClickEvent) this.documentClickEvent();
-  }
-
-  private initKeys() {
-    this.hotkeysService.deregister(this);
-
-    this.items.map((item, i) => {
-      if (item.hotkey) {
-        const opt = this.hotkeysService.add(item.hotkey, {
-          callback: () => {
-            this.onClickItem(i);
-          },
-          description: item.description,
-          component: this
-        });
-
-        item.keys = opt.keys;
-      }
-    });
   }
 }

--- a/src/app/components/plus-menu-page/plus-menu-page.component.html
+++ b/src/app/components/plus-menu-page/plus-menu-page.component.html
@@ -1,7 +1,7 @@
 <h3 class="style-header">Plus Menu</h3>
 <ngx-section class="shadow" sectionTitle="Plus Menu - Right - Two Items">
   <div class="container-right">
-    <ngx-plus-menu [items]="[upload, create]" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+    <ngx-plus-menu [items]="[upload, create]" (clickItem)="onClick($event)"></ngx-plus-menu>
   </div>
   <app-prism>
     <![CDATA[

--- a/src/app/components/plus-menu-page/plus-menu-page.component.ts
+++ b/src/app/components/plus-menu-page/plus-menu-page.component.ts
@@ -9,19 +9,19 @@ import { Component, ChangeDetectionStrategy, ViewEncapsulation } from '@angular/
 })
 export class PlusMenuPageComponent {
   upload = {
-    description: 'Upload a plugin',
-    hotkey: 'ctrl+alt+u',
-    icon: 'upload-outline'
+    title: 'Upload a plugin',
+    subtitle: 'ctrl+alt+u',
+    icon: 'download-outline-small'
   };
 
   create = {
-    description: 'Create',
-    hotkey: 'ctrl+alt+n',
-    icon: 'add-circle-thin'
+    title: 'Create',
+    subtitle: 'ctrl+alt+n',
+    icon: 'add-circle-medium'
   };
 
   search = {
-    description: 'Search',
+    title: 'Search',
     icon: 'search'
   };
 


### PR DESCRIPTION
## Summary

Breaking:
To support multiple plus-menu instances on a single page:
- `ngx-plus-menu` takes items containing `title` and `subtitle` instead of `description` and `hotkeys`. 
- Does not setup it's own hotkeys.

Bugfix:
- no popup us shown if `menuTitle` is not passed as an input to `ngx-plus-menu`

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
