### PR TITLE
Add blur and dateTimeSelected outputs to dateTimeComponent

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # HEAD (unreleased)
 
+- Enhancement: Add `blur` and `dateTimeSelected` outputs to `DateTimeComponent`.
+
 ## 34.0.1 (2020-12-17)
 
 - Fix(ngx-plus-menu): classes not set correctly in some cases.

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -105,7 +105,7 @@
   [required]="required"
   [requiredIndicator]="requiredIndicator"
   (ngModelChange)="inputChanged($event)"
-  (blur)="onBlur()"
+  (blur)="onBlur($event)"
 >
   <ngx-input-hint class="date-time-hint">
     <div *ngIf="hint">{{ hint }}</div>

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -196,6 +196,8 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   }
 
   @Output() change = new EventEmitter<string | Date>();
+  @Output() blur = new EventEmitter<Event>();
+  @Output() dateTimeSelected = new EventEmitter<Date | string>();
 
   @ViewChild('dialogTpl', { static: true })
   readonly calendarTpl: TemplateRef<ElementRef>;
@@ -233,7 +235,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     this.displayValue = this.getDisplayValue();
   }
 
-  onBlur() {
+  onBlur(event: Event) {
     this.onTouchedCallback();
 
     const value = this.parseDate(this.value);
@@ -243,6 +245,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
         this.input.value = displayValue;
       }
     }
+    this.blur.emit(event);
   }
 
   open(): void {
@@ -261,6 +264,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   apply(): void {
     this.value = this.dialogModel.toDate();
     this.displayValue = this.getDisplayValue();
+    this.dateTimeSelected.emit(this.value);
     this.close();
   }
 
@@ -300,6 +304,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   clear(): void {
     this.value = undefined;
     this.displayValue = this.getDisplayValue();
+    this.dateTimeSelected.emit(this.value);
     this.close();
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -235,7 +235,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     this.displayValue = this.getDisplayValue();
   }
 
-  onBlur(event: Event) {
+  onBlur(event?: Event) {
     this.onTouchedCallback();
 
     const value = this.parseDate(this.value);

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -7,6 +7,8 @@
     [label]="'Date of attack'"
     [(ngModel)]="curDate2"
     (change)="dateChanged($event)"
+    (blur)="onBlurEvent($event)"
+    (dateTimeSelected)="dateTimeSelected($event)"
   >
   </ngx-date-time>
   <br />
@@ -17,6 +19,8 @@
   [disabled]="true"
   [(ngModel)]="curDate2"
   (change)="dateChanged($event)"
+  (blur)="onBlurEvent($event)"
+    (dateTimeSelected)="dateTimeSelected($event)"
 >
 </ngx-date-time>]]>
   </app-prism>

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -20,7 +20,7 @@
   [(ngModel)]="curDate2"
   (change)="dateChanged($event)"
   (blur)="onBlurEvent($event)"
-    (dateTimeSelected)="dateTimeSelected($event)"
+  (dateTimeSelected)="dateTimeSelected($event)"
 >
 </ngx-date-time>]]>
   </app-prism>

--- a/src/app/forms/datetime-page/datetime-page.component.ts
+++ b/src/app/forms/datetime-page/datetime-page.component.ts
@@ -16,4 +16,12 @@ export class DatetimePageComponent {
   dateChanged(val) {
     console.log('date changed!', val);
   }
+
+  onBlurEvent(val) {
+    console.log('blur event triggered', val);
+  }
+
+  dateTimeSelected(val) {
+    console.log('date time selected', val);
+  }
 }


### PR DESCRIPTION
## Summary

Add `blur` and `dateTimeSelected` outputs to DateTimeComponent

![image](https://user-images.githubusercontent.com/62297014/103695829-e6a69c00-4f62-11eb-8a0f-fe0708454d25.png)


## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
