### PR TITLE
Fix/multi model change on init

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # HEAD (unreleased)
 
+- Fix(JsonEditor): Remove unnecessary `onModelChange` event emissions on init.
 - Enhancement: Add `blur` and `dateTimeSelected` outputs to `DateTimeComponent`.
 
 ## 34.0.1 (2020-12-17)

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -51,6 +51,8 @@ export class ObjectNode implements OnInit, OnChanges {
 
   requiredCache: { [key: string]: boolean } = {};
 
+  wasInitialized = false;
+
   dataTypes: JsonSchemaDataType[] = [...jsonSchemaDataTypes, ...jsonSchemaDataFormats];
   propertyCounter: number = 1;
   propertyId: number = 1;
@@ -98,6 +100,7 @@ export class ObjectNode implements OnInit, OnChanges {
       this.indexProperties();
       this.addRequiredProperties();
       this.updateIcons();
+      this.wasInitialized = true;
     });
   }
 
@@ -176,7 +179,9 @@ export class ObjectNode implements OnInit, OnChanges {
     this.propertyIndex[schema.id] = schema;
     this.propertyIndex = { ...this.propertyIndex };
 
-    this.modelChange.emit(this.model);
+    if (this.wasInitialized) {
+      this.modelChange.emit(this.model);
+    }
     this.updateIcons();
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -51,7 +51,7 @@ export class ObjectNode implements OnInit, OnChanges {
 
   requiredCache: { [key: string]: boolean } = {};
 
-  wasInitialized = false;
+  initialized = false;
 
   dataTypes: JsonSchemaDataType[] = [...jsonSchemaDataTypes, ...jsonSchemaDataFormats];
   propertyCounter: number = 1;
@@ -100,7 +100,7 @@ export class ObjectNode implements OnInit, OnChanges {
       this.indexProperties();
       this.addRequiredProperties();
       this.updateIcons();
-      this.wasInitialized = true;
+      this.initialized = true;
     });
   }
 
@@ -179,7 +179,7 @@ export class ObjectNode implements OnInit, OnChanges {
     this.propertyIndex[schema.id] = schema;
     this.propertyIndex = { ...this.propertyIndex };
 
-    if (this.wasInitialized) {
+    if (this.initialized) {
       this.modelChange.emit(this.model);
     }
     this.updateIcons();


### PR DESCRIPTION
## Summary

Avoid emitting unnecessary `valueChage` events on component init.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
