### PR TITLE
Allow 'null' as a valid schema type

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 # HEAD (unreleased)
 
 - Enhancement: Add `blur` and `dateTimeSelected` outputs to `DateTimeComponent`.
+- Fix(json-editor): allow 'null' type in schema.
 
 ## 34.0.1 (2020-12-17)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.helper.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.helper.ts
@@ -35,9 +35,20 @@ export interface JsonSchemaDataType {
   matchType: (value: string) => boolean;
 }
 
-export const propTypes: string[] = ['string', 'number', 'integer', 'boolean', 'object', 'array'];
+export const propTypes: string[] = ['null', 'string', 'number', 'integer', 'boolean', 'object', 'array'];
 
 export const jsonSchemaDataTypes: JsonSchemaDataType[] = [
+  {
+    name: 'Null',
+    defaultValue: () => null,
+    schema: {
+      type: 'null'
+    },
+    icon: 'disable', // ??
+    matchType: (value: any): boolean => {
+      return value === null; // ??
+    }
+  },
   {
     name: 'String',
     defaultValue: () => '',

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.helper.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.helper.ts
@@ -39,17 +39,6 @@ export const propTypes: string[] = ['null', 'string', 'number', 'integer', 'bool
 
 export const jsonSchemaDataTypes: JsonSchemaDataType[] = [
   {
-    name: 'Null',
-    defaultValue: () => null,
-    schema: {
-      type: 'null'
-    },
-    icon: 'disable', // ??
-    matchType: (value: any): boolean => {
-      return value === null; // ??
-    }
-  },
-  {
     name: 'String',
     defaultValue: () => '',
     schema: {
@@ -113,6 +102,20 @@ export const jsonSchemaDataTypes: JsonSchemaDataType[] = [
     icon: 'integrations',
     matchType: (value: any): boolean => {
       return Array.isArray(value);
+    }
+  },
+  {
+    name: 'Null',
+    defaultValue: () => null,
+    schema: {
+      type: 'null'
+    },
+    icon: 'disable', // ??
+    matchType: (value: any): boolean => {
+      // NOTE: because of the way type inference is implemented, we need
+      // to check for 'null' AFTER we check for 'object', since
+      // typeof null === 'object'
+      return value === null;
     }
   }
 ];
@@ -185,7 +188,6 @@ export function createValueForSchema(schema: JSONEditorSchema): any {
   if (schema.type) {
     return dataTypeMap[schema.type as string].defaultValue();
   }
-  return null;
 }
 
 /**

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
@@ -1,6 +1,6 @@
 <div
   class="json-tree-node"
-  [class.inline]="schema?.type !== 'object' && schema?.type !== 'array'"
+  [class.inline]="schema?.type !== 'object' && schema?.type !== 'array' && schema?.type !== 'null'"
   [class.invalid]="!valid || isDuplicated"
   [class.children-invalid]="!childrenValid || isDuplicated"
 >


### PR DESCRIPTION
## Summary

JSON Editor should handle 'null' property type. See: https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.1.1

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
