### PR TITLE
Add 'showIcons' input to ToggleComponent

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 # HEAD (unreleased)
 
 - Enhancement: Add `blur` and `dateTimeSelected` outputs to `DateTimeComponent`.
+- Enhancement: Add `showIcons` input to `ToggleComponent` to display optional icons.
 
 ## 34.0.1 (2020-12-17)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.html
@@ -11,7 +11,10 @@
     [name]="name"
     (blur)="onBlur()"
   />
-  <label [attr.for]="id" class="ngx-toggle-label"> </label>
+  <label [attr.for]="id" class="ngx-toggle-label">
+    <span *ngIf="showIcons && value" class="ngx-icon ngx-check"></span>
+    <span *ngIf="showIcons && !value" class="ngx-icon ngx-x"></span>
+  </label>
   <label [attr.for]="id" class="ngx-toggle-text">
     <span *ngIf="label" [innerHTML]="label"></span>
     <ng-content></ng-content>

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.scss
@@ -67,7 +67,7 @@
       &.ngx-check {
         opacity: 0.5;
         color: $color-white;
-        padding: 3.5px 4px;
+        padding: 2.5px 4px;
         font-size: 9px;
       }
 
@@ -75,7 +75,7 @@
         flex-direction: row-reverse;
         opacity: 0.7;
         color: $color-blue-grey-400;
-        padding: 4.5px 5px;
+        padding: 4px 5px;
         font-size: 7px;
         font-weight: 900;
       }

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.scss
@@ -24,7 +24,7 @@
     display: none;
 
     &:checked ~ .ngx-toggle-label {
-      background: $color-blue-400;
+      background: $color-blue-700;
 
       &:after {
         left: 15px;
@@ -38,7 +38,7 @@
     display: block;
     height: 14px;
     width: 34px;
-    background: $color-blue-grey-700;
+    background: $color-blue-grey-900;
     border-radius: 100px;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -59,6 +59,26 @@
       box-shadow: 0px 3px 3px $color-blue-grey-900;
       content: '';
       transition: all 0.3s ease;
+    }
+
+    .ngx-icon {
+      display: flex;
+
+      &.ngx-check {
+        opacity: 0.5;
+        color: $color-white;
+        padding: 3.5px 4px;
+        font-size: 9px;
+      }
+
+      &.ngx-x {
+        flex-direction: row-reverse;
+        opacity: 0.7;
+        color: $color-blue-grey-400;
+        padding: 4.5px 5px;
+        font-size: 7px;
+        font-weight: 900;
+      }
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.spec.ts
@@ -37,6 +37,10 @@ describe('ToggleComponent', () => {
     expect(component.required).toEqual(false);
   });
 
+  it('showIcons defaults to: false', () => {
+    expect(component.showIcons).toEqual(false);
+  });
+
   it('tabIndex defaults to: 0', () => {
     expect(component.tabIndex).toEqual(0);
   });
@@ -44,6 +48,11 @@ describe('ToggleComponent', () => {
   it('required property can be set', () => {
     component.required = true;
     expect(component.required).toEqual(true);
+  });
+
+  it('showIcons property can be set', () => {
+    component.showIcons = true;
+    expect(component.showIcons).toEqual(true);
   });
 
   it('tabIndex property can be set', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.spec.ts
@@ -37,8 +37,8 @@ describe('ToggleComponent', () => {
     expect(component.required).toEqual(false);
   });
 
-  it('showIcons defaults to: false', () => {
-    expect(component.showIcons).toEqual(false);
+  it('showIcons defaults to: true', () => {
+    expect(component.showIcons).toEqual(true);
   });
 
   it('tabIndex defaults to: 0', () => {
@@ -51,8 +51,8 @@ describe('ToggleComponent', () => {
   });
 
   it('showIcons property can be set', () => {
-    component.showIcons = true;
-    expect(component.showIcons).toEqual(true);
+    component.showIcons = false;
+    expect(component.showIcons).toEqual(false);
   });
 
   it('tabIndex property can be set', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
@@ -52,6 +52,15 @@ export class ToggleComponent implements ControlValueAccessor {
   }
 
   @Input()
+  get showIcons() {
+    return this._showIcons;
+  }
+
+  set showIcons(showIcons) {
+    this._showIcons = coerceBooleanProperty(showIcons);
+  }
+
+  @Input()
   get tabIndex() {
     return this._tabIndex;
   }
@@ -82,6 +91,7 @@ export class ToggleComponent implements ControlValueAccessor {
   private _value: boolean = false;
   private _disabled: boolean = false;
   private _required: boolean = false;
+  private _showIcons: boolean = false;
   private _tabIndex: number = 0;
 
   constructor(private readonly cdr: ChangeDetectorRef) {}

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
@@ -91,7 +91,7 @@ export class ToggleComponent implements ControlValueAccessor {
   private _value: boolean = false;
   private _disabled: boolean = false;
   private _required: boolean = false;
-  private _showIcons: boolean = false;
+  private _showIcons: boolean = true;
   private _tabIndex: number = 0;
 
   constructor(private readonly cdr: ChangeDetectorRef) {}

--- a/src/app/forms/toggle-page/toggle-page.component.html
+++ b/src/app/forms/toggle-page/toggle-page.component.html
@@ -38,14 +38,14 @@
   <br />
   <br />
 
-  <ngx-toggle name="toggle4" [(ngModel)]="toggleChk" [label]="'High Priority With Icons'" [showIcons]="true">
+  <ngx-toggle name="toggle4" [(ngModel)]="toggleChk" [label]="'High Priority With No Icons'" [showIcons]="false">
   </ngx-toggle>
   <app-prism>
 <![CDATA[<ngx-toggle 
   name="toggle4" 
   [(ngModel)]="toggleChk" 
-  [label]="'High Priority With Icons'" 
-  [showIcons]="true">
+  [label]="'High Priority With No Icons'" 
+  [showIcons]="false">
 </ngx-toggle>]]>
   </app-prism>
 </ngx-section>

--- a/src/app/forms/toggle-page/toggle-page.component.html
+++ b/src/app/forms/toggle-page/toggle-page.component.html
@@ -35,4 +35,17 @@
   <strong class="color-green" [hidden]="toggleChk">All good!</strong>
 </ngx-toggle>]]>
   </app-prism>
+  <br />
+  <br />
+
+  <ngx-toggle name="toggle4" [(ngModel)]="toggleChk" [label]="'High Priority With Icons'" [showIcons]="true">
+  </ngx-toggle>
+  <app-prism>
+<![CDATA[<ngx-toggle 
+  name="toggle4" 
+  [(ngModel)]="toggleChk" 
+  [label]="'High Priority With Icons'" 
+  [showIcons]="true">
+</ngx-toggle>]]>
+  </app-prism>
 </ngx-section>


### PR DESCRIPTION
## Summary
Enhancement: Add `showIcons` input to `ToggleComponent`  in order to display the optional icons.
Default value is set to true. But you can turn it off anytime you want.
![image](https://user-images.githubusercontent.com/74981795/105241762-8a7f7280-5b33-11eb-8b1e-715475f8343c.png)



## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
