### PR TITLE
Add timeout option to ngx-button

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # HEAD (unreleased)
 
+- Feature: Add `timeout` option to `ButtonComponent`
+
 ## 34.1.0 (2021-01-20)
 
 - Enhancement: Add `blur` and `dateTimeSelected` outputs to `DateTimeComponent`.

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.spec.ts
@@ -26,6 +26,10 @@ describe('ButtonComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should have timeout default to: 3000', () => {
+    expect(component.timeout).toEqual(3000);
+  });
+
   it('should update state and promise on change', () => {
     const stateSpy = spyOn(component, 'updateState');
     const promiseSpy = spyOn(component, 'updatePromise');

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
@@ -7,7 +7,7 @@ import {
   HostListener,
   ChangeDetectionStrategy
 } from '@angular/core';
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 import { BehaviorSubject } from 'rxjs';
 
 import { ButtonState } from './button-state.enum';
@@ -52,6 +52,14 @@ export class ButtonComponent implements OnInit, OnChanges {
     this.fail$.next(v === ButtonState.Fail);
   }
 
+  @Input()
+  get timeout() {
+    return this._timeout === undefined ? 3000 : this._timeout;
+  }
+  set timeout(v: number) {
+    this._timeout = coerceNumberProperty(v);
+  }
+
   readonly inProgress$ = new BehaviorSubject(false);
   readonly active$ = new BehaviorSubject(false);
   readonly success$ = new BehaviorSubject(false);
@@ -60,6 +68,7 @@ export class ButtonComponent implements OnInit, OnChanges {
   private _state = ButtonState.Active;
   private _disabled = false;
   private _timer: any;
+  private _timeout: any;
 
   ngOnInit() {
     this.updateState();
@@ -92,15 +101,14 @@ export class ButtonComponent implements OnInit, OnChanges {
     }
 
     if (
-      this.state === ButtonState.Success ||
-      this.state === ButtonState.Fail ||
-      this.state === ButtonState.InProgress
+      this.timeout &&
+      (this.state === ButtonState.Success || this.state === ButtonState.Fail || this.state === ButtonState.InProgress)
     ) {
       clearTimeout(this._timer);
       this._timer = setTimeout(() => {
         this.state = ButtonState.Active;
         this.updateState();
-      }, 3000);
+      }, this.timeout);
     }
   }
 

--- a/src/app/forms/buttons-page/buttons-page.component.html
+++ b/src/app/forms/buttons-page/buttons-page.component.html
@@ -206,6 +206,8 @@
     class="btn btn-bordered">Bordered</ngx-button>
   <ngx-button #linkButton [promise]="promises['linkButton']" (click)="onClick('button click', 'linkButton')"
     class="btn btn-link">Link</ngx-button>
+  <ngx-button #noTimeoutButton [promise]="promises['noTimeoutButton']" [timeout]="0" (click)="onClick('button click', 'noTimeoutButton')"
+    class="btn">No Timeout</ngx-button>
   <p></p>
   <ngx-button (click)="onClick('button click')" class="btn" disabled="true">Default</ngx-button>
   <ngx-button state="inProgress" class="btn btn-primary" disabled="true">Primary</ngx-button>
@@ -215,6 +217,7 @@
   <ngx-button state="success" class="btn btn-danger" disabled="true">Danger</ngx-button>
   <ngx-button class="btn btn-bordered" disabled="true">Bordered</ngx-button>
   <ngx-button class="btn btn-link" disabled="true">Link</ngx-button>
+  <ngx-button [timeout]="0" disabled="true" class="btn">No Timeout</ngx-button>
 
   <app-prism>
 <![CDATA[<ngx-button #defaultButton [promise]="promises['defaultButton']" (click)="onClick('button click', 'defaultButton')"
@@ -231,6 +234,8 @@
   class="btn btn-bordered">Bordered</ngx-button>
 <ngx-button #linkButton [promise]="promises['linkButton']" (click)="onClick('button click', 'linkButton')"
   class="btn btn-link">Link</ngx-button>
+<ngx-button #noTimeoutButton [promise]="promises['noTimeoutButton']" [timeout]="0" (click)="onClick('button click', 'noTimeoutButton')"
+  class="btn">No Timeout</ngx-button>
 <p></p>
 <ngx-button (click)="onClick('button click')" class="btn" disabled="true">Default</ngx-button>
 <ngx-button state="inProgress" class="btn btn-primary" disabled="true">Primary</ngx-button>
@@ -239,7 +244,9 @@
 <ngx-button state="fail" class="btn btn-warning" disabled="true">Warning</ngx-button>
 <ngx-button state="success" class="btn btn-danger" disabled="true">Danger</ngx-button>
 <ngx-button class="btn btn-bordered" disabled="true">Bordered</ngx-button>
-<ngx-button class="btn btn-link" disabled="true">Link</ngx-button>]]>
+<ngx-button class="btn btn-link" disabled="true">Link</ngx-button>
+<ngx-button [timeout]="0" disabled="true" class="btn">No Timeout</ngx-button>
+]]>
   </app-prism>
 </ngx-section>
 


### PR DESCRIPTION
## Summary

- When `timeout` is 0, do not add the timeout
- When `timeout` is undefined, default to 3000ms

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
