### PR TITLE
Make lockpad icon clickable when textbox is unlockable and appearance is set to fill

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # HEAD (unreleased)
 
+- Fix(ngx-input): Make the lockpad button clickable when the textbox appearance is set to "Fill" and has `[unlockable] = "true"` set. Also fix vertical alignment.
+
 ## 34.1.0 (2021-01-20)
 
 - Enhancement: Add `blur` and `dateTimeSelected` outputs to `DateTimeComponent`.

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -265,6 +265,12 @@ $input-placeholder-color: $color-blue-grey-350;
 
   &.fill {
     .ngx-input-wrap .ngx-input-box-wrap {
+      .icon-eye,
+      .icon-lock {
+        line-height: 33.33px;
+        z-index: 2;
+      }
+
       .ngx-input-box,
       .ngx-input-textarea {
         margin: 0;


### PR DESCRIPTION
## Summary

Make clickable the lockpad icon that appears when a textbox has `[unlockable]="true"` set. This was not functional when using the fill appearance. Also, fixes vertical alignment.

![ngx_ui_fix](https://user-images.githubusercontent.com/66797479/108536354-fe7f7880-72a1-11eb-87d6-dcd97f2d1563.gif)

Closes #552

## Checklist

- [ ] \*Added unit tests
- [X] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [X] Included screenshots of visual changes

_\*required_
