### PR TITLE
Add a custom color option for ngx-plus-menu items

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # HEAD (unreleased)
 
+- Feature: Add an option to add `color` to `items` in `PlusMenuComponent`
 - Feature: Add `timeout` option to `ButtonComponent`
 
 ## 34.1.0 (2021-01-20)

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
@@ -15,108 +15,108 @@
     <g class="right two" transform="translate(0, 0)">
       <defs>
         <linearGradient [id]="'right-two-grad--' + uid">
-          <stop class="stop stop-0" offset="28%" />
-          <stop class="stop stop-1" offset="50%" />
+          <stop class="stop stop--color-0" offset="28%" />
+          <stop class="stop stop--color-1" offset="50%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#right-two-grad--' + uid + ')'" d="M633.883 119C654.069 163.463 689.972 199.275 734.5 219.343" stroke-width="2" />
-      <path class="arrow arrow-0" d="M653.8 141.5C651 144.5 651.971 148.918 653.441 151.174L651.739 152.175C650.873 150.829 647.5 147.5 641.5 148L653.8 141.5Z" />
-      <path class="arrow arrow-1" d="M711.863 199.563C708.863 202.363 704.445 201.392 702.189 199.922L701.188 201.624C702.534 202.49 705.863 205.863 705.363 211.863L711.863 199.563Z" />
+      <path class="arrow arrow--color-0" d="M653.8 141.5C651 144.5 651.971 148.918 653.441 151.174L651.739 152.175C650.873 150.829 647.5 147.5 641.5 148L653.8 141.5Z" />
+      <path class="arrow arrow--color-1" d="M711.863 199.563C708.863 202.363 704.445 201.392 702.189 199.922L701.188 201.624C702.534 202.49 705.863 205.863 705.363 211.863L711.863 199.563Z" />
     </g>
 
     <g class="right three" transform="translate(519, -25)">
       <defs>
         <linearGradient [id]="'right-three-grad--' + uid">
-          <stop class="stop stop-0" offset="0%" />
-          <stop class="stop stop-0" offset="5%" />
-          <stop class="stop stop-1" offset="20%" />
-          <stop class="stop stop-1" offset="60%" />
-          <stop class="stop stop-2" offset="70%" />
-          <stop class="stop stop-2" offset="100%" />
+          <stop class="stop stop--color-0" offset="0%" />
+          <stop class="stop stop--color-0" offset="5%" />
+          <stop class="stop stop--color-1" offset="20%" />
+          <stop class="stop stop--color-1" offset="60%" />
+          <stop class="stop stop--color-2" offset="70%" />
+          <stop class="stop stop--color-2" offset="100%" />
         </linearGradient>
       </defs>
 
       <path class="arc" [attr.stroke]="'url(#right-three-grad--' + uid + ')'" d="M260 259.219C180.273 243.543 117.457 180.727 101.781 101" stroke-width="2"/>
-      <path class="arrow arrow-0" d="M117 127C113.5 129 112.5 134.5 113.5 137L111.652 137.642C111.066 136.153 108 131.5 102 131L117 127Z" />
-      <path class="arrow arrow-1" d="M184 217C181.5 221.5 183.629 225.48 185.876 226.964L184.711 228.563C183.38 227.674 178 226 173.5 229L184 217Z" />
-      <path class="arrow arrow-1" d="M144 177C139.5 179.5 135.52 177.371 134.036 175.124L132.437 176.289C133.326 177.62 135 183 132 187.5L144 177Z" />
-      <path class="arrow arrow-2" d="M234 244C232 247.5 226.5 248.5 224 247.5L223.359 249.348C224.847 249.934 229.5 253 230 259L234 244Z" />
+      <path class="arrow arrow--color-0" d="M117 127C113.5 129 112.5 134.5 113.5 137L111.652 137.642C111.066 136.153 108 131.5 102 131L117 127Z" />
+      <path class="arrow arrow--color-1" d="M184 217C181.5 221.5 183.629 225.48 185.876 226.964L184.711 228.563C183.38 227.674 178 226 173.5 229L184 217Z" />
+      <path class="arrow arrow--color-1" d="M144 177C139.5 179.5 135.52 177.371 134.036 175.124L132.437 176.289C133.326 177.62 135 183 132 187.5L144 177Z" />
+      <path class="arrow arrow--color-2" d="M234 244C232 247.5 226.5 248.5 224 247.5L223.359 249.348C224.847 249.934 229.5 253 230 259L234 244Z" />
     </g>
 
     <g class="bottom two" transform="translate(210, 600)">
       <defs>
         <linearGradient [id]="'bottom-two-grad--' + uid">
-          <stop class="stop stop-0" offset="50%"/>
-          <stop class="stop stop-1" offset="50%" />
+          <stop class="stop stop--color-0" offset="50%"/>
+          <stop class="stop stop--color-1" offset="50%" />
         </linearGradient>
         <linearGradient [id]="'bottom-two-circle-grad--' + uid">
-          <stop class="stop stop-0" offset="30%"/>
-          <stop class="stop stop-1" offset="90%" />
+          <stop class="stop stop--color-0" offset="30%"/>
+          <stop class="stop stop--color-1" offset="90%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#bottom-two-grad--' + uid + ')'" d="M350 138C350 117.565 296.498 101 230.5 101C164.502 101 111 117.565 111 138" stroke-width="2"/>
-      <path class="arrow arrow-1" d="M311.029 117.617C311 113 307.5 110.72 305.5 110.22L306 108.3C307.266 108.601 312.5 109 314 106L311.029 117.617Z"/>
-      <path class="arrow arrow-0" d="M149.971 117.617C150 113 153.5 110.72 155.5 110.22L155 108.3C153.734 108.601 148.5 109 147 106L149.971 117.617Z"/>
-      <path class="arrow arrow-1" d="M237.093 97.4119C238.5 99.5 240 100 241.945 100.18L241.917 102.15C240.335 102.15 238.5 102.5 236.956 105.254L237.093 97.4119Z"/>
-      <circle fill="rgb(7, 8, 11)" [attr.stroke]="'url(#bottom-two-circle-grad--' + uid + ')'" cx="230" cy="101" r="7" stroke-width="2"></circle>
-      <path class="arrow arrow-0" d="M223.513 97.4119C222.106 99.5 220.606 100 218.662 100.18L218.689 102.15C220.271 102.15 222.106 102.5 223.65 105.254L223.513 97.4119Z"/>
+      <path class="arrow arrow--color-1" d="M311.029 117.617C311 113 307.5 110.72 305.5 110.22L306 108.3C307.266 108.601 312.5 109 314 106L311.029 117.617Z"/>
+      <path class="arrow arrow--color-0" d="M149.971 117.617C150 113 153.5 110.72 155.5 110.22L155 108.3C153.734 108.601 148.5 109 147 106L149.971 117.617Z"/>
+      <path class="arrow arrow--color-1" d="M237.093 97.4119C238.5 99.5 240 100 241.945 100.18L241.917 102.15C240.335 102.15 238.5 102.5 236.956 105.254L237.093 97.4119Z"/>
+      <circle class="dot" [attr.stroke]="'url(#bottom-two-circle-grad--' + uid + ')'" cx="230" cy="101" r="7" stroke-width="2"></circle>
+      <path class="arrow arrow--color-0" d="M223.513 97.4119C222.106 99.5 220.606 100 218.662 100.18L218.689 102.15C220.271 102.15 222.106 102.5 223.65 105.254L223.513 97.4119Z"/>
     </g>
 
     <g class="bottom three" transform="translate(190, 580)">
       <defs>
         <linearGradient [id]="'bottom-three-left-grad--' + uid">
-          <stop class="stop stop-0" offset="30%" />
-          <stop class="stop stop-1" offset="70%" />
+          <stop class="stop stop--color-0" offset="30%" />
+          <stop class="stop stop--color-1" offset="70%" />
         </linearGradient>
         <linearGradient [id]="'bottom-three-right-grad--' + uid">
-          <stop class="stop stop-1" offset="30%" />
-          <stop class="stop stop-2" offset="80%" />
+          <stop class="stop stop--color-1" offset="30%" />
+          <stop class="stop stop--color-2" offset="80%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#bottom-three-left-grad--' + uid + ')'" d="M100.5 136.194C140.708 115.721 187.856 103.158 238.5 101.253" stroke-width="2"/>
       <path class="arc" [attr.stroke]="'url(#bottom-three-right-grad--' + uid + ')'" d="M403.5 136.194C363.292 115.721 316.144 103.158 265.5 101.253" stroke-width="2"/>
-      <path class="arrow arrow-0" d="M131.858 128.317C132.878 124.348 136.05 122.041 137.509 121.384L136.687 119.561C135.228 120.218 131.399 121.066 127.75 119.2L131.858 128.317Z"/>
-      <path class="arrow arrow-2" d="M372.192 128.317C371.173 124.348 368 122.041 366.541 121.384L367.363 119.561C368.822 120.218 372.651 121.066 376.3 119.2L372.192 128.317Z"/>
-      <path class="arrow arrow-1" d="M222.5 107.5C221.5 105.5 220 103.5 216.117 103.805L216.117 101.802C219 101.5 221.5 99.5 222.5 96.5L222.5 107.5Z"/>
-      <path class="arrow arrow-1" d="M281.5 107.5C282.5 105.5 284 103.5 287.883 103.805L287.883 101.802C285 101.5 282.5 99.5 281.5 96.5L281.5 107.5Z"/>
+      <path class="arrow arrow--color-0" d="M131.858 128.317C132.878 124.348 136.05 122.041 137.509 121.384L136.687 119.561C135.228 120.218 131.399 121.066 127.75 119.2L131.858 128.317Z"/>
+      <path class="arrow arrow--color-2" d="M372.192 128.317C371.173 124.348 368 122.041 366.541 121.384L367.363 119.561C368.822 120.218 372.651 121.066 376.3 119.2L372.192 128.317Z"/>
+      <path class="arrow arrow--color-1" d="M222.5 107.5C221.5 105.5 220 103.5 216.117 103.805L216.117 101.802C219 101.5 221.5 99.5 222.5 96.5L222.5 107.5Z"/>
+      <path class="arrow arrow--color-1" d="M281.5 107.5C282.5 105.5 284 103.5 287.883 103.805L287.883 101.802C285 101.5 282.5 99.5 281.5 96.5L281.5 107.5Z"/>
     </g>
 
     <g class="top two" transform="translate(210, -60)">
       <defs>
         <linearGradient [id]="'top-two-grad--' + uid">
-          <stop class="stop stop-0" offset="50%"/>
-          <stop class="stop stop-1" offset="50%" />
+          <stop class="stop stop--color-0" offset="50%"/>
+          <stop class="stop stop--color-1" offset="50%" />
         </linearGradient>
         <linearGradient [id]="'top-two-circle-grad--' + uid">
-          <stop class="stop stop-0" offset="30%"/>
-          <stop class="stop stop-1" offset="90%" />
+          <stop class="stop stop--color-0" offset="30%"/>
+          <stop class="stop stop--color-1" offset="90%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#top-two-grad--' + uid + ')'"  d="M350 100C350 120.435 296.498 137 230.5 137C164.502 137 111 120.435 111 100" stroke-width="2"/>
-      <path class="arrow arrow-1" d="M311.029 120.383C311 125 307.5 127.28 305.5 127.78L306 129.7C307.266 129.399 312.5 129 314 132L311.029 120.383Z"/>
-      <path class="arrow arrow-0" d="M149.971 120.383C150 125 153.5 127.28 155.5 127.78L155 129.7C153.734 129.399 148.5 129 147 132L149.971 120.383Z"/>
-      <path class="arrow arrow-1" d="M237.093 140.588C238.5 138.5 240 138 241.944 137.82L241.917 135.85C240.335 135.85 238.5 135.5 236.956 132.746L237.093 140.588Z"/>
-      <circle fill="rgb(7, 8, 11)" [attr.stroke]="'url(#top-two-circle-grad--' + uid + ')'" cx="230" cy="137" r="7" stroke-width="2"></circle>
-      <path class="arrow arrow-0" d="M223.513 140.588C222.106 138.5 220.606 138 218.662 137.82L218.689 135.85C220.271 135.85 222.106 135.5 223.65 132.746L223.513 140.588Z"/>
+      <path class="arrow arrow--color-1" d="M311.029 120.383C311 125 307.5 127.28 305.5 127.78L306 129.7C307.266 129.399 312.5 129 314 132L311.029 120.383Z"/>
+      <path class="arrow arrow--color-0" d="M149.971 120.383C150 125 153.5 127.28 155.5 127.78L155 129.7C153.734 129.399 148.5 129 147 132L149.971 120.383Z"/>
+      <path class="arrow arrow--color-1" d="M237.093 140.588C238.5 138.5 240 138 241.944 137.82L241.917 135.85C240.335 135.85 238.5 135.5 236.956 132.746L237.093 140.588Z"/>
+      <circle class="dot" [attr.stroke]="'url(#top-two-circle-grad--' + uid + ')'" cx="230" cy="137" r="7" stroke-width="2"></circle>
+      <path class="arrow arrow--color-0" d="M223.513 140.588C222.106 138.5 220.606 138 218.662 137.82L218.689 135.85C220.271 135.85 222.106 135.5 223.65 132.746L223.513 140.588Z"/>
     </g>
 
     <g class="top three" transform="translate(188, -55)">
       <defs>
         <linearGradient [id]="'top-three-left-grad--' + uid">
-          <stop class="stop stop-0" offset="30%" />
-          <stop class="stop stop-1" offset="70%" />
+          <stop class="stop stop--color-0" offset="30%" />
+          <stop class="stop stop--color-1" offset="70%" />
         </linearGradient>
         <linearGradient [id]="'top-three-right-grad--' + uid">
-          <stop class="stop stop-1" offset="30%" />
-          <stop class="stop stop-2" offset="80%" />
+          <stop class="stop stop--color-1" offset="30%" />
+          <stop class="stop stop--color-2" offset="80%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#top-three-right-grad--' + uid + ')'"  d="M403.5 101.806C363.292 122.279 316.144 134.842 265.5 136.747" stroke-width="2"/>
       <path class="arc" [attr.stroke]="'url(#top-three-left-grad--' + uid + ')'"  d="M100.5 101.806C140.708 122.279 187.856 134.842 238.5 136.747" stroke-width="2"/>
-      <path class="arrow arrow-0" d="M131.858 109.683C132.878 113.652 136.05 115.959 137.509 116.616L136.687 118.439C135.228 117.782 131.399 116.934 127.75 118.8L131.858 109.683Z"/>
-      <path class="arrow arrow-2" d="M372.192 109.683C371.173 113.652 368 115.959 366.541 116.616L367.363 118.439C368.822 117.782 372.651 116.934 376.3 118.8L372.192 109.683Z"/>
-      <path class="arrow arrow-1" d="M222.5 130.5C221.5 132.5 220 134.5 216.117 134.195L216.117 136.198C219 136.5 221.5 138.5 222.5 141.5L222.5 130.5Z"/>
-      <path class="arrow arrow-1" d="M281.5 130.5C282.5 132.5 284 134.5 287.883 134.195L287.883 136.198C285 136.5 282.5 138.5 281.5 141.5L281.5 130.5Z"/>
+      <path class="arrow arrow--color-0" d="M131.858 109.683C132.878 113.652 136.05 115.959 137.509 116.616L136.687 118.439C135.228 117.782 131.399 116.934 127.75 118.8L131.858 109.683Z"/>
+      <path class="arrow arrow--color-2" d="M372.192 109.683C371.173 113.652 368 115.959 366.541 116.616L367.363 118.439C368.822 117.782 372.651 116.934 376.3 118.8L372.192 109.683Z"/>
+      <path class="arrow arrow--color-1" d="M222.5 130.5C221.5 132.5 220 134.5 216.117 134.195L216.117 136.198C219 136.5 221.5 138.5 222.5 141.5L222.5 130.5Z"/>
+      <path class="arrow arrow--color-1" d="M281.5 130.5C282.5 132.5 284 134.5 287.883 134.195L287.883 136.198C285 136.5 282.5 138.5 281.5 141.5L281.5 130.5Z"/>
     </g>
   </svg>
 

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
@@ -15,108 +15,108 @@
     <g class="right two" transform="translate(0, 0)">
       <defs>
         <linearGradient [id]="'right-two-grad--' + uid">
-          <stop offset="28%" stop-color="var(--item-0-color)"/>
-          <stop offset="50%" stop-color="var(--item-1-color)" />
+          <stop class="stop stop-0" offset="28%" />
+          <stop class="stop stop-1" offset="50%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#right-two-grad--' + uid + ')'" d="M633.883 119C654.069 163.463 689.972 199.275 734.5 219.343" stroke-width="2" />
-      <path class="arrow" fill="var(--item-0-color)" d="M653.8 141.5C651 144.5 651.971 148.918 653.441 151.174L651.739 152.175C650.873 150.829 647.5 147.5 641.5 148L653.8 141.5Z" />
-      <path class="arrow" fill="var(--item-1-color)" d="M711.863 199.563C708.863 202.363 704.445 201.392 702.189 199.922L701.188 201.624C702.534 202.49 705.863 205.863 705.363 211.863L711.863 199.563Z" />
+      <path class="arrow arrow-0" d="M653.8 141.5C651 144.5 651.971 148.918 653.441 151.174L651.739 152.175C650.873 150.829 647.5 147.5 641.5 148L653.8 141.5Z" />
+      <path class="arrow arrow-1" d="M711.863 199.563C708.863 202.363 704.445 201.392 702.189 199.922L701.188 201.624C702.534 202.49 705.863 205.863 705.363 211.863L711.863 199.563Z" />
     </g>
 
     <g class="right three" transform="translate(519, -25)">
       <defs>
         <linearGradient [id]="'right-three-grad--' + uid">
-          <stop offset="0%" stop-color="var(--item-0-color)" />
-          <stop offset="5%" stop-color="var(--item-0-color)" />
-          <stop offset="20%" stop-color="var(--item-1-color)" />
-          <stop offset="60%" stop-color="var(--item-1-color)" />
-          <stop offset="70%" stop-color="var(--item-2-color)" />
-          <stop offset="100%" stop-color="var(--item-2-color)" />
+          <stop class="stop stop-0" offset="0%" />
+          <stop class="stop stop-0" offset="5%" />
+          <stop class="stop stop-1" offset="20%" />
+          <stop class="stop stop-1" offset="60%" />
+          <stop class="stop stop-2" offset="70%" />
+          <stop class="stop stop-2" offset="100%" />
         </linearGradient>
       </defs>
 
       <path class="arc" [attr.stroke]="'url(#right-three-grad--' + uid + ')'" d="M260 259.219C180.273 243.543 117.457 180.727 101.781 101" stroke-width="2"/>
-      <path class="arrow" fill="var(--item-0-color)" d="M117 127C113.5 129 112.5 134.5 113.5 137L111.652 137.642C111.066 136.153 108 131.5 102 131L117 127Z" />
-      <path class="arrow" fill="var(--item-1-color)" d="M184 217C181.5 221.5 183.629 225.48 185.876 226.964L184.711 228.563C183.38 227.674 178 226 173.5 229L184 217Z" />
-      <path class="arrow" fill="var(--item-1-color)" d="M144 177C139.5 179.5 135.52 177.371 134.036 175.124L132.437 176.289C133.326 177.62 135 183 132 187.5L144 177Z" />
-      <path class="arrow" fill="var(--item-2-color)" d="M234 244C232 247.5 226.5 248.5 224 247.5L223.359 249.348C224.847 249.934 229.5 253 230 259L234 244Z" />
+      <path class="arrow arrow-0" d="M117 127C113.5 129 112.5 134.5 113.5 137L111.652 137.642C111.066 136.153 108 131.5 102 131L117 127Z" />
+      <path class="arrow arrow-1" d="M184 217C181.5 221.5 183.629 225.48 185.876 226.964L184.711 228.563C183.38 227.674 178 226 173.5 229L184 217Z" />
+      <path class="arrow arrow-1" d="M144 177C139.5 179.5 135.52 177.371 134.036 175.124L132.437 176.289C133.326 177.62 135 183 132 187.5L144 177Z" />
+      <path class="arrow arrow-2" d="M234 244C232 247.5 226.5 248.5 224 247.5L223.359 249.348C224.847 249.934 229.5 253 230 259L234 244Z" />
     </g>
 
     <g class="bottom two" transform="translate(210, 600)">
       <defs>
         <linearGradient [id]="'bottom-two-grad--' + uid">
-          <stop offset="50%" stop-color="var(--item-0-color)"/>
-          <stop offset="50%" stop-color="var(--item-1-color)" />
+          <stop class="stop stop-0" offset="50%"/>
+          <stop class="stop stop-1" offset="50%" />
         </linearGradient>
         <linearGradient [id]="'bottom-two-circle-grad--' + uid">
-          <stop offset="30%" stop-color="var(--item-0-color)"/>
-          <stop offset="90%" stop-color="var(--item-1-color)" />
+          <stop class="stop stop-0" offset="30%"/>
+          <stop class="stop stop-1" offset="90%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#bottom-two-grad--' + uid + ')'" d="M350 138C350 117.565 296.498 101 230.5 101C164.502 101 111 117.565 111 138" stroke-width="2"/>
-      <path class="arrow" fill="var(--item-1-color)" d="M311.029 117.617C311 113 307.5 110.72 305.5 110.22L306 108.3C307.266 108.601 312.5 109 314 106L311.029 117.617Z"/>
-      <path class="arrow" fill="var(--item-0-color)" d="M149.971 117.617C150 113 153.5 110.72 155.5 110.22L155 108.3C153.734 108.601 148.5 109 147 106L149.971 117.617Z"/>
-      <path class="arrow" fill="var(--item-1-color)" d="M237.093 97.4119C238.5 99.5 240 100 241.945 100.18L241.917 102.15C240.335 102.15 238.5 102.5 236.956 105.254L237.093 97.4119Z"/>
+      <path class="arrow arrow-1" d="M311.029 117.617C311 113 307.5 110.72 305.5 110.22L306 108.3C307.266 108.601 312.5 109 314 106L311.029 117.617Z"/>
+      <path class="arrow arrow-0" d="M149.971 117.617C150 113 153.5 110.72 155.5 110.22L155 108.3C153.734 108.601 148.5 109 147 106L149.971 117.617Z"/>
+      <path class="arrow arrow-1" d="M237.093 97.4119C238.5 99.5 240 100 241.945 100.18L241.917 102.15C240.335 102.15 238.5 102.5 236.956 105.254L237.093 97.4119Z"/>
       <circle fill="rgb(7, 8, 11)" [attr.stroke]="'url(#bottom-two-circle-grad--' + uid + ')'" cx="230" cy="101" r="7" stroke-width="2"></circle>
-      <path class="arrow" fill="var(--item-0-color)" d="M223.513 97.4119C222.106 99.5 220.606 100 218.662 100.18L218.689 102.15C220.271 102.15 222.106 102.5 223.65 105.254L223.513 97.4119Z"/>
+      <path class="arrow arrow-0" d="M223.513 97.4119C222.106 99.5 220.606 100 218.662 100.18L218.689 102.15C220.271 102.15 222.106 102.5 223.65 105.254L223.513 97.4119Z"/>
     </g>
 
     <g class="bottom three" transform="translate(190, 580)">
       <defs>
         <linearGradient [id]="'bottom-three-left-grad--' + uid">
-          <stop offset="30%" stop-color="var(--item-0-color)" />
-          <stop offset="70%" stop-color="var(--item-1-color)" />
+          <stop class="stop stop-0" offset="30%" />
+          <stop class="stop stop-1" offset="70%" />
         </linearGradient>
         <linearGradient [id]="'bottom-three-right-grad--' + uid">
-          <stop offset="30%" stop-color="var(--item-1-color)" />
-          <stop offset="80%" stop-color="var(--item-2-color)" />
+          <stop class="stop stop-1" offset="30%" />
+          <stop class="stop stop-2" offset="80%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#bottom-three-left-grad--' + uid + ')'" d="M100.5 136.194C140.708 115.721 187.856 103.158 238.5 101.253" stroke-width="2"/>
       <path class="arc" [attr.stroke]="'url(#bottom-three-right-grad--' + uid + ')'" d="M403.5 136.194C363.292 115.721 316.144 103.158 265.5 101.253" stroke-width="2"/>
-      <path class="arrow" fill="var(--item-0-color)" d="M131.858 128.317C132.878 124.348 136.05 122.041 137.509 121.384L136.687 119.561C135.228 120.218 131.399 121.066 127.75 119.2L131.858 128.317Z"/>
-      <path class="arrow" fill="var(--item-2-color)" d="M372.192 128.317C371.173 124.348 368 122.041 366.541 121.384L367.363 119.561C368.822 120.218 372.651 121.066 376.3 119.2L372.192 128.317Z"/>
-      <path class="arrow" fill="var(--item-1-color)" d="M222.5 107.5C221.5 105.5 220 103.5 216.117 103.805L216.117 101.802C219 101.5 221.5 99.5 222.5 96.5L222.5 107.5Z"/>
-      <path class="arrow" fill="var(--item-1-color)" d="M281.5 107.5C282.5 105.5 284 103.5 287.883 103.805L287.883 101.802C285 101.5 282.5 99.5 281.5 96.5L281.5 107.5Z"/>
+      <path class="arrow arrow-0" d="M131.858 128.317C132.878 124.348 136.05 122.041 137.509 121.384L136.687 119.561C135.228 120.218 131.399 121.066 127.75 119.2L131.858 128.317Z"/>
+      <path class="arrow arrow-2" d="M372.192 128.317C371.173 124.348 368 122.041 366.541 121.384L367.363 119.561C368.822 120.218 372.651 121.066 376.3 119.2L372.192 128.317Z"/>
+      <path class="arrow arrow-1" d="M222.5 107.5C221.5 105.5 220 103.5 216.117 103.805L216.117 101.802C219 101.5 221.5 99.5 222.5 96.5L222.5 107.5Z"/>
+      <path class="arrow arrow-1" d="M281.5 107.5C282.5 105.5 284 103.5 287.883 103.805L287.883 101.802C285 101.5 282.5 99.5 281.5 96.5L281.5 107.5Z"/>
     </g>
 
     <g class="top two" transform="translate(210, -60)">
       <defs>
         <linearGradient [id]="'top-two-grad--' + uid">
-          <stop offset="50%" stop-color="var(--item-0-color)"/>
-          <stop offset="50%" stop-color="var(--item-1-color)" />
+          <stop class="stop stop-0" offset="50%"/>
+          <stop class="stop stop-1" offset="50%" />
         </linearGradient>
         <linearGradient [id]="'top-two-circle-grad--' + uid">
-          <stop offset="30%" stop-color="var(--item-0-color)"/>
-          <stop offset="90%" stop-color="var(--item-1-color)" />
+          <stop class="stop stop-0" offset="30%"/>
+          <stop class="stop stop-1" offset="90%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#top-two-grad--' + uid + ')'"  d="M350 100C350 120.435 296.498 137 230.5 137C164.502 137 111 120.435 111 100" stroke-width="2"/>
-      <path class="arrow" fill="var(--item-1-color)" d="M311.029 120.383C311 125 307.5 127.28 305.5 127.78L306 129.7C307.266 129.399 312.5 129 314 132L311.029 120.383Z"/>
-      <path class="arrow" fill="var(--item-0-color)" d="M149.971 120.383C150 125 153.5 127.28 155.5 127.78L155 129.7C153.734 129.399 148.5 129 147 132L149.971 120.383Z"/>
-      <path class="arrow" fill="var(--item-1-color)" d="M237.093 140.588C238.5 138.5 240 138 241.944 137.82L241.917 135.85C240.335 135.85 238.5 135.5 236.956 132.746L237.093 140.588Z"/>
+      <path class="arrow arrow-1" d="M311.029 120.383C311 125 307.5 127.28 305.5 127.78L306 129.7C307.266 129.399 312.5 129 314 132L311.029 120.383Z"/>
+      <path class="arrow arrow-0" d="M149.971 120.383C150 125 153.5 127.28 155.5 127.78L155 129.7C153.734 129.399 148.5 129 147 132L149.971 120.383Z"/>
+      <path class="arrow arrow-1" d="M237.093 140.588C238.5 138.5 240 138 241.944 137.82L241.917 135.85C240.335 135.85 238.5 135.5 236.956 132.746L237.093 140.588Z"/>
       <circle fill="rgb(7, 8, 11)" [attr.stroke]="'url(#top-two-circle-grad--' + uid + ')'" cx="230" cy="137" r="7" stroke-width="2"></circle>
-      <path class="arrow" fill="var(--item-0-color)" d="M223.513 140.588C222.106 138.5 220.606 138 218.662 137.82L218.689 135.85C220.271 135.85 222.106 135.5 223.65 132.746L223.513 140.588Z"/>
+      <path class="arrow arrow-0" d="M223.513 140.588C222.106 138.5 220.606 138 218.662 137.82L218.689 135.85C220.271 135.85 222.106 135.5 223.65 132.746L223.513 140.588Z"/>
     </g>
 
     <g class="top three" transform="translate(188, -55)">
       <defs>
         <linearGradient [id]="'top-three-left-grad--' + uid">
-          <stop offset="30%" stop-color="var(--item-0-color)" />
-          <stop offset="70%" stop-color="var(--item-1-color)" />
+          <stop class="stop stop-0" offset="30%" />
+          <stop class="stop stop-1" offset="70%" />
         </linearGradient>
         <linearGradient [id]="'top-three-right-grad--' + uid">
-          <stop offset="30%" stop-color="var(--item-1-color)" />
-          <stop offset="80%" stop-color="var(--item-2-color)" />
+          <stop class="stop stop-1" offset="30%" />
+          <stop class="stop stop-2" offset="80%" />
         </linearGradient>
       </defs>
       <path class="arc" [attr.stroke]="'url(#top-three-right-grad--' + uid + ')'"  d="M403.5 101.806C363.292 122.279 316.144 134.842 265.5 136.747" stroke-width="2"/>
       <path class="arc" [attr.stroke]="'url(#top-three-left-grad--' + uid + ')'"  d="M100.5 101.806C140.708 122.279 187.856 134.842 238.5 136.747" stroke-width="2"/>
-      <path class="arrow" fill="var(--item-0-color)" d="M131.858 109.683C132.878 113.652 136.05 115.959 137.509 116.616L136.687 118.439C135.228 117.782 131.399 116.934 127.75 118.8L131.858 109.683Z"/>
-      <path class="arrow" fill="var(--item-2-color)" d="M372.192 109.683C371.173 113.652 368 115.959 366.541 116.616L367.363 118.439C368.822 117.782 372.651 116.934 376.3 118.8L372.192 109.683Z"/>
-      <path class="arrow" fill="var(--item-1-color)" d="M222.5 130.5C221.5 132.5 220 134.5 216.117 134.195L216.117 136.198C219 136.5 221.5 138.5 222.5 141.5L222.5 130.5Z"/>
-      <path class="arrow" fill="var(--item-1-color)" d="M281.5 130.5C282.5 132.5 284 134.5 287.883 134.195L287.883 136.198C285 136.5 282.5 138.5 281.5 141.5L281.5 130.5Z"/>
+      <path class="arrow arrow-0" d="M131.858 109.683C132.878 113.652 136.05 115.959 137.509 116.616L136.687 118.439C135.228 117.782 131.399 116.934 127.75 118.8L131.858 109.683Z"/>
+      <path class="arrow arrow-2" d="M372.192 109.683C371.173 113.652 368 115.959 366.541 116.616L367.363 118.439C368.822 117.782 372.651 116.934 376.3 118.8L372.192 109.683Z"/>
+      <path class="arrow arrow-1" d="M222.5 130.5C221.5 132.5 220 134.5 216.117 134.195L216.117 136.198C219 136.5 221.5 138.5 222.5 141.5L222.5 130.5Z"/>
+      <path class="arrow arrow-1" d="M281.5 130.5C282.5 132.5 284 134.5 287.883 134.195L287.883 136.198C285 136.5 282.5 138.5 281.5 141.5L281.5 130.5Z"/>
     </g>
   </svg>
 

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
@@ -11,52 +11,112 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
+
     <g class="right two" transform="translate(0, 0)">
-      <path class="arc" d="M633.883 119C654.069 163.463 689.972 199.275 734.5 219.343" stroke-width="2" />
-      <path class="arrow" d="M653.8 141.5C651 144.5 651.971 148.918 653.441 151.174L651.739 152.175C650.873 150.829 647.5 147.5 641.5 148L653.8 141.5Z" />
-      <path class="arrow" d="M711.863 199.563C708.863 202.363 704.445 201.392 702.189 199.922L701.188 201.624C702.534 202.49 705.863 205.863 705.363 211.863L711.863 199.563Z" />
+      <defs>
+        <linearGradient [id]="'right-two-grad--' + uid">
+          <stop offset="28%" stop-color="var(--item-0-color)"/>
+          <stop offset="50%" stop-color="var(--item-1-color)" />
+        </linearGradient>
+      </defs>
+      <path class="arc" [attr.stroke]="'url(#right-two-grad--' + uid + ')'" d="M633.883 119C654.069 163.463 689.972 199.275 734.5 219.343" stroke-width="2" />
+      <path class="arrow" fill="var(--item-0-color)" d="M653.8 141.5C651 144.5 651.971 148.918 653.441 151.174L651.739 152.175C650.873 150.829 647.5 147.5 641.5 148L653.8 141.5Z" />
+      <path class="arrow" fill="var(--item-1-color)" d="M711.863 199.563C708.863 202.363 704.445 201.392 702.189 199.922L701.188 201.624C702.534 202.49 705.863 205.863 705.363 211.863L711.863 199.563Z" />
     </g>
 
     <g class="right three" transform="translate(519, -25)">
-      <path class="arc" d="M260 259.219C180.273 243.543 117.457 180.727 101.781 101" stroke="#CDD2DD" stroke-width="2"/>
-      <path class="arrow" d="M117 127C113.5 129 112.5 134.5 113.5 137L111.652 137.642C111.066 136.153 108 131.5 102 131L117 127Z" />
-      <path class="arrow" d="M184 217C181.5 221.5 183.629 225.48 185.876 226.964L184.711 228.563C183.38 227.674 178 226 173.5 229L184 217Z" />
-      <path class="arrow" d="M144 177C139.5 179.5 135.52 177.371 134.036 175.124L132.437 176.289C133.326 177.62 135 183 132 187.5L144 177Z" />
-      <path class="arrow" d="M234 244C232 247.5 226.5 248.5 224 247.5L223.359 249.348C224.847 249.934 229.5 253 230 259L234 244Z" />
+      <defs>
+        <linearGradient [id]="'right-three-grad--' + uid">
+          <stop offset="0%" stop-color="var(--item-0-color)" />
+          <stop offset="5%" stop-color="var(--item-0-color)" />
+          <stop offset="20%" stop-color="var(--item-1-color)" />
+          <stop offset="60%" stop-color="var(--item-1-color)" />
+          <stop offset="70%" stop-color="var(--item-2-color)" />
+          <stop offset="100%" stop-color="var(--item-2-color)" />
+        </linearGradient>
+      </defs>
+
+      <path class="arc" [attr.stroke]="'url(#right-three-grad--' + uid + ')'" d="M260 259.219C180.273 243.543 117.457 180.727 101.781 101" stroke-width="2"/>
+      <path class="arrow" fill="var(--item-0-color)" d="M117 127C113.5 129 112.5 134.5 113.5 137L111.652 137.642C111.066 136.153 108 131.5 102 131L117 127Z" />
+      <path class="arrow" fill="var(--item-1-color)" d="M184 217C181.5 221.5 183.629 225.48 185.876 226.964L184.711 228.563C183.38 227.674 178 226 173.5 229L184 217Z" />
+      <path class="arrow" fill="var(--item-1-color)" d="M144 177C139.5 179.5 135.52 177.371 134.036 175.124L132.437 176.289C133.326 177.62 135 183 132 187.5L144 177Z" />
+      <path class="arrow" fill="var(--item-2-color)" d="M234 244C232 247.5 226.5 248.5 224 247.5L223.359 249.348C224.847 249.934 229.5 253 230 259L234 244Z" />
     </g>
 
     <g class="bottom two" transform="translate(210, 600)">
-      <path class="arc" d="M350 138C350 117.565 296.498 101 230.5 101C164.502 101 111 117.565 111 138" stroke-width="2"/>
-      <path class="arrow" d="M311.029 117.617C311 113 307.5 110.72 305.5 110.22L306 108.3C307.266 108.601 312.5 109 314 106L311.029 117.617Z"/>
-      <path class="arrow" d="M149.971 117.617C150 113 153.5 110.72 155.5 110.22L155 108.3C153.734 108.601 148.5 109 147 106L149.971 117.617Z"/>
-      <path class="arrow" d="M237.093 97.4119C238.5 99.5 240 100 241.945 100.18L241.917 102.15C240.335 102.15 238.5 102.5 236.956 105.254L237.093 97.4119Z"/>
-      <path class="arrow" d="M223.513 97.4119C222.106 99.5 220.606 100 218.662 100.18L218.689 102.15C220.271 102.15 222.106 102.5 223.65 105.254L223.513 97.4119Z"/>
+      <defs>
+        <linearGradient [id]="'bottom-two-grad--' + uid">
+          <stop offset="50%" stop-color="var(--item-0-color)"/>
+          <stop offset="50%" stop-color="var(--item-1-color)" />
+        </linearGradient>
+        <linearGradient [id]="'bottom-two-circle-grad--' + uid">
+          <stop offset="30%" stop-color="var(--item-0-color)"/>
+          <stop offset="90%" stop-color="var(--item-1-color)" />
+        </linearGradient>
+      </defs>
+      <path class="arc" [attr.stroke]="'url(#bottom-two-grad--' + uid + ')'" d="M350 138C350 117.565 296.498 101 230.5 101C164.502 101 111 117.565 111 138" stroke-width="2"/>
+      <path class="arrow" fill="var(--item-1-color)" d="M311.029 117.617C311 113 307.5 110.72 305.5 110.22L306 108.3C307.266 108.601 312.5 109 314 106L311.029 117.617Z"/>
+      <path class="arrow" fill="var(--item-0-color)" d="M149.971 117.617C150 113 153.5 110.72 155.5 110.22L155 108.3C153.734 108.601 148.5 109 147 106L149.971 117.617Z"/>
+      <path class="arrow" fill="var(--item-1-color)" d="M237.093 97.4119C238.5 99.5 240 100 241.945 100.18L241.917 102.15C240.335 102.15 238.5 102.5 236.956 105.254L237.093 97.4119Z"/>
+      <circle fill="rgb(7, 8, 11)" [attr.stroke]="'url(#bottom-two-circle-grad--' + uid + ')'" cx="230" cy="101" r="7" stroke-width="2"></circle>
+      <path class="arrow" fill="var(--item-0-color)" d="M223.513 97.4119C222.106 99.5 220.606 100 218.662 100.18L218.689 102.15C220.271 102.15 222.106 102.5 223.65 105.254L223.513 97.4119Z"/>
     </g>
 
     <g class="bottom three" transform="translate(190, 580)">
-      <path class="arc" d="M403.5 136.194C363.292 115.721 316.144 103.158 265.5 101.253" stroke-width="2"/>
-      <path class="arc" d="M100.5 136.194C140.708 115.721 187.856 103.158 238.5 101.253" stroke-width="2"/>
-      <path class="arrow" d="M131.858 128.317C132.878 124.348 136.05 122.041 137.509 121.384L136.687 119.561C135.228 120.218 131.399 121.066 127.75 119.2L131.858 128.317Z"/>
-      <path class="arrow" d="M372.192 128.317C371.173 124.348 368 122.041 366.541 121.384L367.363 119.561C368.822 120.218 372.651 121.066 376.3 119.2L372.192 128.317Z"/>
-      <path class="arrow" d="M222.5 107.5C221.5 105.5 220 103.5 216.117 103.805L216.117 101.802C219 101.5 221.5 99.5 222.5 96.5L222.5 107.5Z"/>
-      <path class="arrow" d="M281.5 107.5C282.5 105.5 284 103.5 287.883 103.805L287.883 101.802C285 101.5 282.5 99.5 281.5 96.5L281.5 107.5Z"/>
+      <defs>
+        <linearGradient [id]="'bottom-three-left-grad--' + uid">
+          <stop offset="30%" stop-color="var(--item-0-color)" />
+          <stop offset="70%" stop-color="var(--item-1-color)" />
+        </linearGradient>
+        <linearGradient [id]="'bottom-three-right-grad--' + uid">
+          <stop offset="30%" stop-color="var(--item-1-color)" />
+          <stop offset="80%" stop-color="var(--item-2-color)" />
+        </linearGradient>
+      </defs>
+      <path class="arc" [attr.stroke]="'url(#bottom-three-left-grad--' + uid + ')'" d="M100.5 136.194C140.708 115.721 187.856 103.158 238.5 101.253" stroke-width="2"/>
+      <path class="arc" [attr.stroke]="'url(#bottom-three-right-grad--' + uid + ')'" d="M403.5 136.194C363.292 115.721 316.144 103.158 265.5 101.253" stroke-width="2"/>
+      <path class="arrow" fill="var(--item-0-color)" d="M131.858 128.317C132.878 124.348 136.05 122.041 137.509 121.384L136.687 119.561C135.228 120.218 131.399 121.066 127.75 119.2L131.858 128.317Z"/>
+      <path class="arrow" fill="var(--item-2-color)" d="M372.192 128.317C371.173 124.348 368 122.041 366.541 121.384L367.363 119.561C368.822 120.218 372.651 121.066 376.3 119.2L372.192 128.317Z"/>
+      <path class="arrow" fill="var(--item-1-color)" d="M222.5 107.5C221.5 105.5 220 103.5 216.117 103.805L216.117 101.802C219 101.5 221.5 99.5 222.5 96.5L222.5 107.5Z"/>
+      <path class="arrow" fill="var(--item-1-color)" d="M281.5 107.5C282.5 105.5 284 103.5 287.883 103.805L287.883 101.802C285 101.5 282.5 99.5 281.5 96.5L281.5 107.5Z"/>
     </g>
 
     <g class="top two" transform="translate(210, -60)">
-      <path class="arc" d="M350 100C350 120.435 296.498 137 230.5 137C164.502 137 111 120.435 111 100" stroke-width="2"/>
-      <path class="arrow" d="M311.029 120.383C311 125 307.5 127.28 305.5 127.78L306 129.7C307.266 129.399 312.5 129 314 132L311.029 120.383Z"/>
-      <path class="arrow" d="M149.971 120.383C150 125 153.5 127.28 155.5 127.78L155 129.7C153.734 129.399 148.5 129 147 132L149.971 120.383Z"/>
-      <path class="arrow" d="M237.093 140.588C238.5 138.5 240 138 241.944 137.82L241.917 135.85C240.335 135.85 238.5 135.5 236.956 132.746L237.093 140.588Z"/>
-      <path class="arrow" d="M223.513 140.588C222.106 138.5 220.606 138 218.662 137.82L218.689 135.85C220.271 135.85 222.106 135.5 223.65 132.746L223.513 140.588Z"/>
+      <defs>
+        <linearGradient [id]="'top-two-grad--' + uid">
+          <stop offset="50%" stop-color="var(--item-0-color)"/>
+          <stop offset="50%" stop-color="var(--item-1-color)" />
+        </linearGradient>
+        <linearGradient [id]="'top-two-circle-grad--' + uid">
+          <stop offset="30%" stop-color="var(--item-0-color)"/>
+          <stop offset="90%" stop-color="var(--item-1-color)" />
+        </linearGradient>
+      </defs>
+      <path class="arc" [attr.stroke]="'url(#top-two-grad--' + uid + ')'"  d="M350 100C350 120.435 296.498 137 230.5 137C164.502 137 111 120.435 111 100" stroke-width="2"/>
+      <path class="arrow" fill="var(--item-1-color)" d="M311.029 120.383C311 125 307.5 127.28 305.5 127.78L306 129.7C307.266 129.399 312.5 129 314 132L311.029 120.383Z"/>
+      <path class="arrow" fill="var(--item-0-color)" d="M149.971 120.383C150 125 153.5 127.28 155.5 127.78L155 129.7C153.734 129.399 148.5 129 147 132L149.971 120.383Z"/>
+      <path class="arrow" fill="var(--item-1-color)" d="M237.093 140.588C238.5 138.5 240 138 241.944 137.82L241.917 135.85C240.335 135.85 238.5 135.5 236.956 132.746L237.093 140.588Z"/>
+      <circle fill="rgb(7, 8, 11)" [attr.stroke]="'url(#top-two-circle-grad--' + uid + ')'" cx="230" cy="137" r="7" stroke-width="2"></circle>
+      <path class="arrow" fill="var(--item-0-color)" d="M223.513 140.588C222.106 138.5 220.606 138 218.662 137.82L218.689 135.85C220.271 135.85 222.106 135.5 223.65 132.746L223.513 140.588Z"/>
     </g>
 
     <g class="top three" transform="translate(188, -55)">
-      <path class="arc" d="M403.5 101.806C363.292 122.279 316.144 134.842 265.5 136.747" stroke-width="2"/>
-      <path class="arc" d="M100.5 101.806C140.708 122.279 187.856 134.842 238.5 136.747" stroke-width="2"/>
-      <path class="arrow" d="M131.858 109.683C132.878 113.652 136.05 115.959 137.509 116.616L136.687 118.439C135.228 117.782 131.399 116.934 127.75 118.8L131.858 109.683Z"/>
-      <path class="arrow" d="M372.192 109.683C371.173 113.652 368 115.959 366.541 116.616L367.363 118.439C368.822 117.782 372.651 116.934 376.3 118.8L372.192 109.683Z"/>
-      <path class="arrow" d="M222.5 130.5C221.5 132.5 220 134.5 216.117 134.195L216.117 136.198C219 136.5 221.5 138.5 222.5 141.5L222.5 130.5Z"/>
-      <path class="arrow" d="M281.5 130.5C282.5 132.5 284 134.5 287.883 134.195L287.883 136.198C285 136.5 282.5 138.5 281.5 141.5L281.5 130.5Z"/>
+      <defs>
+        <linearGradient [id]="'top-three-left-grad--' + uid">
+          <stop offset="30%" stop-color="var(--item-0-color)" />
+          <stop offset="70%" stop-color="var(--item-1-color)" />
+        </linearGradient>
+        <linearGradient [id]="'top-three-right-grad--' + uid">
+          <stop offset="30%" stop-color="var(--item-1-color)" />
+          <stop offset="80%" stop-color="var(--item-2-color)" />
+        </linearGradient>
+      </defs>
+      <path class="arc" [attr.stroke]="'url(#top-three-right-grad--' + uid + ')'"  d="M403.5 101.806C363.292 122.279 316.144 134.842 265.5 136.747" stroke-width="2"/>
+      <path class="arc" [attr.stroke]="'url(#top-three-left-grad--' + uid + ')'"  d="M100.5 101.806C140.708 122.279 187.856 134.842 238.5 136.747" stroke-width="2"/>
+      <path class="arrow" fill="var(--item-0-color)" d="M131.858 109.683C132.878 113.652 136.05 115.959 137.509 116.616L136.687 118.439C135.228 117.782 131.399 116.934 127.75 118.8L131.858 109.683Z"/>
+      <path class="arrow" fill="var(--item-2-color)" d="M372.192 109.683C371.173 113.652 368 115.959 366.541 116.616L367.363 118.439C368.822 117.782 372.651 116.934 376.3 118.8L372.192 109.683Z"/>
+      <path class="arrow" fill="var(--item-1-color)" d="M222.5 130.5C221.5 132.5 220 134.5 216.117 134.195L216.117 136.198C219 136.5 221.5 138.5 222.5 141.5L222.5 130.5Z"/>
+      <path class="arrow" fill="var(--item-1-color)" d="M281.5 130.5C282.5 132.5 284 134.5 287.883 134.195L287.883 136.198C285 136.5 282.5 138.5 281.5 141.5L281.5 130.5Z"/>
     </g>
   </svg>
 
@@ -66,11 +126,9 @@
         {{item.title}}
         <div class="subtitle" *ngIf="item.subtitle">{{item.subtitle}}</div>      
       </div>
-      <div [class]="'ngx-plus-menu--icon ngx-plus-menu--icon-' + i">
+      <div [class]="'ngx-plus-menu--icon ngx-plus-menu--icon-' + i" [class.custom-color]="item.color" style="--itemColor: {{item.color}}">
         <ngx-icon [fontIcon]="item.icon"></ngx-icon>
       </div>
-    </div>
-    <div class="ngx-plus-menu--icon--center">
     </div>
   </div>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
@@ -67,6 +67,10 @@
     > g {
       display: none;
     }
+
+    .dot {
+      fill: rgba(var(--background-color));
+    }
   }
 
   &--items-container {
@@ -97,8 +101,7 @@
       }
     }
 
-    .ngx-plus-menu--icon,
-    .ngx-plus-menu--icon--center {
+    .ngx-plus-menu--icon {
       position: absolute;
       text-align: center;
       font-size: 25px;
@@ -285,12 +288,6 @@
         text-align: center;
         height: 50px;
       }
-
-      .ngx-plus-menu--icon--center {
-        display: unset;
-        top: 157px;
-        left: 242px;
-      }
     }
 
     .ngx-plus-menu--menu-title {
@@ -345,10 +342,6 @@
           display: unset;
         }
       }
-    }
-
-    .ngx-plus-menu--icon--center {
-      display: none;
     }
 
     .ngx-plus-menu--item {
@@ -446,12 +439,6 @@
         text-align: center;
         height: 50px;
       }
-
-      .ngx-plus-menu--icon--center {
-        display: unset;
-        top: 69px;
-        left: 242px;
-      }
     }
 
     &.open {
@@ -533,38 +520,34 @@
         right: 72px;
       }
     }
-
-    .ngx-plus-menu--icon--center {
-      display: none;
-    }
   }
 
   .arrow {
     fill: var(--menu-color);
 
-    &-0 {
+    &--color-0 {
       fill: var(--item-0-color, var(--menu-color, #9fce36));
     }
 
-    &-1 {
+    &--color-1 {
       fill: var(--item-1-color, var(--menu-color, #9fce36));
     }
 
-    &-2 {
+    &--color-2 {
       fill: var(--item-2-color, var(--menu-color, #9fce36));
     }
   }
 
   .stop {
-    &-0 {
+    &--color-0 {
       stop-color: var(--item-0-color, var(--menu-color, #9fce36));
     }
 
-    &-1 {
+    &--color-1 {
       stop-color: var(--item-1-color, var(--menu-color, #9fce36));
     }
 
-    &-2 {
+    &--color-2 {
       stop-color: var(--item-2-color, var(--menu-color, #9fce36));
     }
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
@@ -67,14 +67,6 @@
     > g {
       display: none;
     }
-
-    .arrow {
-      fill: var(--menu-color);
-    }
-
-    .arc {
-      stroke: var(--menu-color);
-    }
   }
 
   &--items-container {
@@ -116,6 +108,12 @@
       border: 2px solid var(--menu-color);
       color: var(--menu-color);
       box-shadow: 0 0 10px 0 var(--menu-color);
+
+      &.custom-color {
+        color: var(--itemColor);
+        border-color: var(--itemColor);
+        box-shadow: 0 0 10px 0 var(--itemColor);
+      }
     }
 
     .ngx-plus-menu--icon {
@@ -123,14 +121,6 @@
       height: var(--icon-size);
       line-height: 65px;
       cursor: pointer;
-    }
-
-    .ngx-plus-menu--icon--center {
-      display: none;
-      width: 16px;
-      height: 16px;
-      font-size: 16px;
-      line-height: 16px;
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
@@ -538,4 +538,34 @@
       display: none;
     }
   }
+
+  .arrow {
+    fill: var(--menu-color);
+
+    &-0 {
+      fill: var(--item-0-color, var(--menu-color, #9fce36));
+    }
+
+    &-1 {
+      fill: var(--item-1-color, var(--menu-color, #9fce36));
+    }
+
+    &-2 {
+      fill: var(--item-2-color, var(--menu-color, #9fce36));
+    }
+  }
+
+  .stop {
+    &-0 {
+      stop-color: var(--item-0-color, var(--menu-color, #9fce36));
+    }
+
+    &-1 {
+      stop-color: var(--item-1-color, var(--menu-color, #9fce36));
+    }
+
+    &-2 {
+      stop-color: var(--item-2-color, var(--menu-color, #9fce36));
+    }
+  }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
@@ -32,7 +32,7 @@ export interface PlusMenuItem {
 export class PlusMenuComponent implements OnInit, OnDestroy {
   @Input() items: PlusMenuItem[] = [];
   @Input() position = PlusMenuPosition.Right;
-  @Input() menuColor = '#9fce36';
+
   @Input() menuTitle = '';
   @Input() closeOnClickOutside = true;
 
@@ -40,6 +40,10 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
   @Output() toggleMenu = new EventEmitter<boolean>();
 
   readonly PlusMenuPosition = PlusMenuPosition;
+
+  @HostBinding('style.--menu-color')
+  @Input()
+  menuColor = '#9fce36';
 
   @HostBinding('class')
   get p() {
@@ -55,6 +59,21 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
     return this.items.length > 2;
   }
 
+  @HostBinding('style.--item-0-color')
+  get itemColor0() {
+    return this.items[0].color || this.menuColor;
+  }
+
+  @HostBinding('style.--item-1-color')
+  get itemColor1() {
+    return this.items[1].color || this.menuColor;
+  }
+
+  @HostBinding('style.--item-2-color')
+  get itemColor2() {
+    return this.items[2]?.color || this.menuColor;
+  }
+
   uid: string = '';
 
   private documentClickEvent: () => void;
@@ -66,12 +85,6 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.elementRef.nativeElement.style.setProperty('--menu-color', this.menuColor);
-    this.elementRef.nativeElement.style.setProperty('--item-0-color', this.items[0].color || this.menuColor);
-    this.elementRef.nativeElement.style.setProperty('--item-1-color', this.items[1].color || this.menuColor);
-    if (this.hasThree) {
-      this.elementRef.nativeElement.style.setProperty('--item-2-color', this.items[2].color || this.menuColor);
-    }
     this.uid = id(); // for svg linear gradient ids
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
@@ -13,11 +13,13 @@ import {
   OnDestroy
 } from '@angular/core';
 import { PlusMenuPosition } from './plus-menu-position.enum';
+import { id } from '../../utils/id/id.util';
 
 export interface PlusMenuItem {
   title: string;
   subtitle?: string;
   icon: string;
+  color?: string;
 }
 
 @Component({
@@ -48,9 +50,12 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
   open = false;
 
   @HostBinding('class.has-three')
-  get s() {
+  @Input()
+  get hasThree(): boolean {
     return this.items.length > 2;
   }
+
+  uid: string = '';
 
   private documentClickEvent: () => void;
 
@@ -62,6 +67,12 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.elementRef.nativeElement.style.setProperty('--menu-color', this.menuColor);
+    this.elementRef.nativeElement.style.setProperty('--item-0-color', this.items[0].color || this.menuColor);
+    this.elementRef.nativeElement.style.setProperty('--item-1-color', this.items[1].color || this.menuColor);
+    if (this.hasThree) {
+      this.elementRef.nativeElement.style.setProperty('--item-2-color', this.items[2].color || this.menuColor);
+    }
+    this.uid = id(); // for svg linear gradient ids
   }
 
   ngOnDestroy(): void {

--- a/src/app/components/plus-menu-page/plus-menu-page.component.html
+++ b/src/app/components/plus-menu-page/plus-menu-page.component.html
@@ -73,7 +73,7 @@
   </app-prism>
 </ngx-section>
 
-<ngx-section class="shadow" sectionTitle="Plus Menu - Top - Three Items" style="margin-bottom: 300px;">
+<ngx-section class="shadow" sectionTitle="Plus Menu - Top - Three Items">
   <div class="container-top">
     <ngx-plus-menu [items]="[upload, create, search]" position="top" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
   </div>
@@ -88,3 +88,93 @@
   </app-prism>
 </ngx-section>
 
+<h3> Menu Items with Custom Colors </h3>
+
+<ngx-section class="shadow" sectionTitle="Plus Menu - Right - Two Items Custom Color">
+  <div class="container-right">
+    <ngx-plus-menu class="my-class" [items]="[upload, createCustomColor]" (clickItem)="onClick($event)"></ngx-plus-menu>
+  </div>
+  <app-prism>
+    <![CDATA[
+    <ngx-plus-menu
+      [items]="[upload, createCustomColor]"
+      menuTitle="Install a Plugin"
+      (clickItem)="onClick($event)">
+    </ngx-plus-menu> ]]>
+  </app-prism>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Plus Menu - Right - Three Items Custom Color">
+  <div class="container-right">
+    <ngx-plus-menu [items]="[upload, create, searchCustomColor]" menuColor="#01E1B9" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+  </div>
+  <app-prism>
+    <![CDATA[
+    <ngx-plus-menu
+      [items]="[upload, create, searchCustomColor]"
+      menuColor="#01E1B9"
+      menuTitle="Install a Plugin"
+      (clickItem)="onClick($event)">
+    </ngx-plus-menu> ]]>
+  </app-prism>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Plus Menu - Bottom - Two Items Custom Color">
+  <div class="container-bottom">
+    <ngx-plus-menu [items]="[uploadCustomColor, create]" position="bottom" menuColor="#01E1B9" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+  </div>
+  <app-prism>
+    <![CDATA[
+    <ngx-plus-menu
+      [items]="[uploadCustomColor, create]"
+      position="bottom"
+      menuTitle="Install a Plugin"
+      (clickItem)="onClick($event)">
+    </ngx-plus-menu> ]]>
+  </app-prism>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Plus Menu - Bottom - Three Items Custom Colors">
+  <div class="container-bottom">
+    <ngx-plus-menu [items]="[uploadCustomColor, create, searchCustomColor]" position="bottom" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+  </div>
+  <app-prism>
+    <![CDATA[
+    <ngx-plus-menu
+      [items]="[uploadCustomColor, create, searchCustomColor]"
+      position="bottom"
+      menuTitle="Install a Plugin"
+      (clickItem)="onClick($event)">
+    </ngx-plus-menu> ]]>
+  </app-prism>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Plus Menu - Top - Two Items Custom Color">
+  <div class="container-top">
+    <ngx-plus-menu [items]="[upload, createCustomColor]" position="top" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+  </div>
+  <app-prism>
+    <![CDATA[
+    <ngx-plus-menu
+      [items]="[upload, createCustomColor]"
+      position="top"
+      menuTitle="Install a Plugin"
+      (clickItem)="onClick($event)">
+    </ngx-plus-menu> ]]>
+  </app-prism>
+</ngx-section>
+
+<ngx-section class="shadow" sectionTitle="Plus Menu - Top - Three Items Custom Color" style="margin-bottom: 300px;">
+  <div class="container-top">
+    <ngx-plus-menu [items]="[uploadCustomColor, createCustomColor, searchCustomColor]" position="top" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+  </div>
+  <app-prism>
+    <![CDATA[
+    <ngx-plus-menu
+      [items]="[uploadCustomColor, createCustomColor, searchCustomColor]"
+      position="top"
+      menuTitle="Install a Plugin"
+      (clickItem)="onClick($event)">
+    </ngx-plus-menu> ]]>
+  </app-prism>
+</ngx-section>

--- a/src/app/components/plus-menu-page/plus-menu-page.component.ts
+++ b/src/app/components/plus-menu-page/plus-menu-page.component.ts
@@ -14,15 +14,36 @@ export class PlusMenuPageComponent {
     icon: 'upload-outline-small'
   };
 
+  uploadCustomColor = {
+    title: 'Upload a plugin',
+    subtitle: 'ctrl+alt+u',
+    icon: 'upload-outline-small',
+    color: '#CDD2DD'
+  };
+
   create = {
     title: 'Create',
     subtitle: 'ctrl+alt+n',
     icon: 'add-circle-medium'
   };
 
+  createCustomColor = {
+    title: 'Create',
+    subtitle: 'ctrl+alt+n',
+    icon: 'add-circle-medium',
+    color: '#01E1B9'
+  };
+
   search = {
     title: 'Search',
     icon: 'search'
+  };
+
+  searchCustomColor = {
+    title: 'Search',
+    subtitle: 'ctrl+alt+f',
+    icon: 'search',
+    color: '#E200B6'
   };
 
   onClick($event) {


### PR DESCRIPTION
## Summary

A little hacky, but we needed a way to apply gradient on the svg for a seamless color transition.

<img width="516" alt="Screen Shot 2021-02-19 at 3 04 32 PM" src="https://user-images.githubusercontent.com/12345416/108566532-d143c200-72c3-11eb-8f35-d40b91ec249e.png">

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
