### PR TITLE
Fix hostbinding issue

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # HEAD (unreleased)
 
+- Fix(ngx-card/ngx-section): User supplied classes are not preserved in some cases using `HostBinding`
+
 ## 35.0.0 (2021-02-22)
 
 - Feature: Add an option to add `color` to `items` in `PlusMenuComponent`

--- a/projects/swimlane/ngx-ui/src/lib/components/card/card.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/card/card.component.ts
@@ -17,12 +17,11 @@ import { CardAppearance } from './card-appearance.enum';
   selector: 'ngx-card',
   templateUrl: './card.component.html',
   styleUrls: ['./card.component.scss'],
+  host: { class: 'ngx-card' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class CardComponent {
-  @HostBinding('class') class = 'ngx-card';
-
   @HostBinding('class.ngx-card-horizontal')
   get horizontal() {
     return this.orientation === CardOrientation.Horizontal;

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
@@ -17,13 +17,12 @@ import { TogglePosition } from './section-toggle-position.enum';
   selector: 'ngx-section',
   exportAs: 'ngxSection',
   templateUrl: './section.component.html',
+  host: { class: 'ngx-section' },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./section.component.scss']
 })
 export class SectionComponent {
-  @HostBinding('class') class = 'ngx-section';
-
   @HostBinding('class.outline')
   get outline() {
     return this.appearance === SectionApperance.Outline;

--- a/src/app/components/card-page/card-page.component.html
+++ b/src/app/components/card-page/card-page.component.html
@@ -4,6 +4,7 @@
   <ngx-section class="shadow" sectionTitle="Card Horizontal">
     <h3> Basic Cards </h3>
     <ngx-card
+      class="my-custom-card-class"
       status="success"
       statusTooltip="success"
       (click)="onClick()"


### PR DESCRIPTION
## Summary

HostBinding wipes out other class definitions when Ivy is off:

![image](https://user-images.githubusercontent.com/509946/108926888-834cf800-75fc-11eb-87c9-16fed6f85919.png)


## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
