### PR TITLE
fix collapse, add toogle position none

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # HEAD (unreleased)
 
+- Bug(ngx-section): Make toggle on header click optional
+- Feature(ngx-section): Add `None` toogle position
 - Feature: Add `appearance` to `ProgressSpinnerComponent` where default is no icon
 - Feature: Add failure state and failure icon to `ProgressSpinnerComponent`
 - Feature: Add an option to add label to `ProgressSpinnerComponent`

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section-toggle-position.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section-toggle-position.enum.ts
@@ -1,4 +1,5 @@
 export enum TogglePosition {
   Left = 'left',
-  Right = 'right'
+  Right = 'right',
+  None = 'none'
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.html
@@ -4,18 +4,20 @@
     [class.ngx-section-collapsible]="sectionCollapsible"
     [class.section-collapsed]="sectionCollapsed"
     [class.toggle-right]="togglePosition === TogglePosition.Right"
+    [class.header-toggle]="headerToggle"
     class="ngx-section-header"
-    (click)="sectionCollapsible && onSectionClicked()"
+    (click)="headerToggle && sectionCollapsible && onSectionClicked()"
   >
     <button
-      *ngIf="sectionCollapsible"
+      *ngIf="sectionCollapsible && togglePosition !== TogglePosition.None"
       class="ngx-section-toggle"
       type="button"
       title="Toggle Content Visibility"
+      (click)="sectionCollapsible && onSectionClicked()"
     >
-    <ngx-icon 
-      [fontIcon]="sectionCollapsed ? 'chevron-bold-right' : 'chevron-bold-down'">
-    </ngx-icon>
+      <ngx-icon 
+        [fontIcon]="sectionCollapsed ? 'chevron-bold-right' : 'chevron-bold-down'">
+      </ngx-icon>
     </button>
     <ng-content select="ngx-section-header"></ng-content>
     <h1 *ngIf="sectionTitle" [innerHTML]="sectionTitle"></h1>

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.scss
@@ -46,7 +46,10 @@ $section-shadow: $shadow-3;
 
     &.ngx-section-collapsible {
       padding: 0 20px 0 35px;
-      cursor: pointer;
+
+      &.header-toggle {
+        cursor: pointer;
+      }
     }
 
     &.toggle-right {

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
@@ -30,6 +30,7 @@ export class SectionComponent {
 
   @Input() sectionCollapsed: boolean = false;
   @Input() sectionCollapsible: boolean = true;
+  @Input() headerToggle: boolean = false;
   @Input() sectionTitle: string;
   @Input() padding: any = '1.8em';
   @Input() appearance: SectionApperance = SectionApperance.Legacy;

--- a/src/app/components/sections-page/sections-page.component.html
+++ b/src/app/components/sections-page/sections-page.component.html
@@ -112,3 +112,21 @@
 </ngx-section>]]>
     </app-prism>
 </ngx-section>
+
+<ngx-section [sectionTitle]="'Hide toggle use Header'">
+  <ngx-section sectionTitle="Attack Details" togglePosition="none" [headerToggle]="true">
+    Hash rm -rf gc Starcraft continue *.* d00dz deadlock snarf endif wannabee tera perl less bar strlen tarball
+    bytes ban headers
+    gnu brute force. All your base are belong to us semaphore exception giga highjack system mailbomb eaten by a
+    grue
+    error fopen null. James T. Kirk firewall recursively hello world man pages protected.
+  </ngx-section>
+  <app-prism>
+<![CDATA[<ngx-section
+  sectionTitle="Attack Details"
+  [showToggle]="false"
+  [headerToggle]="true">
+  Some Content
+</ngx-section>]]>
+    </app-prism>
+</ngx-section>


### PR DESCRIPTION
## Summary

- Bug(ngx-section): Make toggle on header click optional
- Feature(ngx-section): Add `None` toggle position

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
