### PR TITLE
Provide services in root injector

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HEAD (unreleased)
 
 - Bug(ngx-progress-spinner): Fix issue with later versions of SASS
-- Enhancement: Provide services in root injector (`DialogService`, `AlertService`, `NotificationService`)
+- Enhancement: Provide services in root injector (`DialogService`, `AlertService`, `NotificationService`, `OverlayService`)
 
 ## 35.1.0 (2021-02-26)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HEAD (unreleased)
 
 - Bug(ngx-progress-spinner): Fix issue with later versions of SASS
-- Enhancement: Provide services in root injector (`DialogService`, `AlertService`, `NotificationService`, `OverlayService`)
+- Enhancement: Provide services in root injector
 
 ## 35.1.0 (2021-02-26)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD (unreleased)
 
 - Bug(ngx-progress-spinner): Fix issue with later versions of SASS
+- Enhancement: Provide services in root injector (`DialogService`, `AlertService`, `NotificationService`)
 
 ## 35.1.0 (2021-02-26)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/alert/alert.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/alert/alert.service.ts
@@ -15,7 +15,9 @@ const classMap = {
   [AlertStyles.Info]: 'ngx-alert-info'
 };
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class AlertService extends DialogService<AlertComponent> {
   readonly defaults: DialogOptions = {
     inputs: {

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.module.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 
 import { InjectionService } from '../../services/injection/injection.service';
 import { OverlayModule } from '../overlay/overlay.module';
-import { OverlayService } from '../overlay/overlay.service';
 import { InputModule } from '../input/input.module';
 
 import { AlertComponent } from './alert/alert.component';
@@ -14,7 +13,7 @@ import { LongPressButtonModule } from '../long-press/long-press-button.module';
 @NgModule({
   declarations: [DialogComponent, AlertComponent],
   exports: [DialogComponent, AlertComponent],
-  providers: [InjectionService, OverlayService],
+  providers: [InjectionService],
   imports: [CommonModule, OverlayModule, InputModule, FormsModule, LongPressButtonModule],
   entryComponents: [DialogComponent, AlertComponent]
 })

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.module.ts
@@ -8,15 +8,13 @@ import { OverlayService } from '../overlay/overlay.service';
 import { InputModule } from '../input/input.module';
 
 import { AlertComponent } from './alert/alert.component';
-import { AlertService } from './alert/alert.service';
 import { DialogComponent } from './dialog.component';
-import { DialogService } from './dialog.service';
 import { LongPressButtonModule } from '../long-press/long-press-button.module';
 
 @NgModule({
   declarations: [DialogComponent, AlertComponent],
   exports: [DialogComponent, AlertComponent],
-  providers: [DialogService, AlertService, InjectionService, OverlayService],
+  providers: [InjectionService, OverlayService],
   imports: [CommonModule, OverlayModule, InputModule, FormsModule, LongPressButtonModule],
   entryComponents: [DialogComponent, AlertComponent]
 })

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.service.ts
@@ -7,7 +7,9 @@ import { OverlayService } from '../overlay/overlay.service';
 import { DialogComponent } from './dialog.component';
 import { DialogOptions } from './dialog-options.interface';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class DialogService<T = DialogComponent> extends InjectionRegistryService<T> {
   readonly defaults: DialogOptions = {
     inputs: {

--- a/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { OverlayModule } from '../overlay/overlay.module';
-import { OverlayService } from '../overlay/overlay.service';
 import { InjectionService } from '../../services/injection/injection.service';
 import { DrawerComponent } from './drawer.component';
 import { DrawerService } from './drawer.service';
@@ -11,7 +10,7 @@ import { DrawerContainerDirective } from './drawer-container.directive';
 @NgModule({
   declarations: [DrawerComponent, DrawerContainerDirective],
   exports: [DrawerComponent, DrawerContainerDirective],
-  providers: [DrawerService, InjectionService, OverlayService],
+  providers: [DrawerService, InjectionService],
   imports: [CommonModule, OverlayModule],
   entryComponents: [DrawerComponent]
 })

--- a/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.module.ts
@@ -4,13 +4,12 @@ import { CommonModule } from '@angular/common';
 import { OverlayModule } from '../overlay/overlay.module';
 import { InjectionService } from '../../services/injection/injection.service';
 import { DrawerComponent } from './drawer.component';
-import { DrawerService } from './drawer.service';
 import { DrawerContainerDirective } from './drawer-container.directive';
 
 @NgModule({
   declarations: [DrawerComponent, DrawerContainerDirective],
   exports: [DrawerComponent, DrawerContainerDirective],
-  providers: [DrawerService, InjectionService],
+  providers: [InjectionService],
   imports: [CommonModule, OverlayModule],
   entryComponents: [DrawerComponent]
 })

--- a/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.service.ts
@@ -8,7 +8,9 @@ import { OverlayService } from '../overlay/overlay.service';
 import { DrawerDirection } from './drawer-direction.enum';
 import { DrawerOptions } from './drawer-options.interface';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class DrawerService extends InjectionRegistryService<DrawerComponent> {
   type: any = DrawerComponent;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.module.ts
@@ -2,12 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { HotkeysComponent } from './hotkeys.component';
-import { HotkeysService } from './hotkeys.service';
 
 @NgModule({
   declarations: [HotkeysComponent],
   exports: [HotkeysComponent],
-  providers: [HotkeysService],
   imports: [CommonModule]
 })
 export class HotkeysModule {}

--- a/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
@@ -188,7 +188,9 @@ export function Hotkey(key: string, description: string, options?: Partial<Hotke
   };
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class HotkeysService {
   readonly suspend = _suspend;
   readonly activate = _activate;

--- a/projects/swimlane/ngx-ui/src/lib/components/icon/icon.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/icon/icon.module.ts
@@ -2,12 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { IconComponent } from './icon.component';
-import { IconRegistryService } from '../../services/icon-registry/icon-registry.service';
 
 @NgModule({
   declarations: [IconComponent],
   exports: [IconComponent],
-  imports: [CommonModule],
-  providers: [IconRegistryService]
+  imports: [CommonModule]
 })
 export class IconModule {}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.module.ts
@@ -14,7 +14,6 @@ import { TabsModule } from '../tabs/tabs.module';
 import { ToggleModule } from '../toggle/toggle.module';
 import { CheckboxModule } from '../checkbox/checkbox.module';
 import { SelectModule } from '../select/select.module';
-import { SchemaValidatorService } from './schema-validator.service';
 
 import { JsonEditorComponent } from './json-editor/json-editor.component';
 import { JsonEditorNodeComponent } from './json-editor/json-editor-node/json-editor-node.component';
@@ -72,7 +71,6 @@ import { JsonEditorNodeInfoComponent } from './json-editor-flat/json-editor-node
     ToggleModule,
     SelectModule,
     TabsModule
-  ],
-  providers: [SchemaValidatorService]
+  ]
 })
 export class JsonEditorModule {}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
@@ -1,7 +1,9 @@
 import Ajv from 'ajv';
 import { Injectable } from '@angular/core';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class SchemaValidatorService {
   ajv: Ajv.Ajv;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/loading/loading.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/loading/loading.module.ts
@@ -3,11 +3,10 @@ import { CommonModule } from '@angular/common';
 
 import { InjectionService } from '../../services/injection/injection.service';
 import { LoadingComponent } from './loading.component';
-import { LoadingService } from './loading.service';
 
 @NgModule({
   declarations: [LoadingComponent],
-  providers: [LoadingService, InjectionService],
+  providers: [InjectionService],
   exports: [LoadingComponent],
   imports: [CommonModule],
   entryComponents: [LoadingComponent]

--- a/projects/swimlane/ngx-ui/src/lib/components/loading/loading.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/loading/loading.service.ts
@@ -3,7 +3,9 @@ import { Injectable, ComponentRef } from '@angular/core';
 import { InjectionService } from '../../services/injection/injection.service';
 import { LoadingComponent } from './loading.component';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class LoadingService {
   threshold: number = 250;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/notification/notification.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/notification/notification.module.ts
@@ -4,13 +4,12 @@ import { CommonModule } from '@angular/common';
 import { InjectionService } from '../../services/injection/injection.service';
 
 import { NotificationComponent } from './notification.component';
-import { NotificationService } from './notification.service';
 import { NotificationContainerComponent } from './notification-container.component';
 
 @NgModule({
   declarations: [NotificationComponent, NotificationContainerComponent],
   exports: [NotificationComponent, NotificationContainerComponent],
-  providers: [NotificationService, InjectionService],
+  providers: [InjectionService],
   imports: [CommonModule],
   entryComponents: [NotificationComponent, NotificationContainerComponent]
 })

--- a/projects/swimlane/ngx-ui/src/lib/components/notification/notification.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/notification/notification.service.ts
@@ -15,7 +15,9 @@ import { NotificationOptions } from './notification-options.interface';
 
 /** adding dynamic to suppress `Document` type metadata error  */
 /** @dynamic */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class NotificationService extends InjectionRegistryService<NotificationComponent> {
   static readonly limit: number | boolean = 10;
   readonly defaults: NotificationOptions = {

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.module.ts
@@ -6,11 +6,10 @@ import { OverlayComponent } from './overlay.component';
 import { InjectionService } from '../../services/injection/injection.service';
 import { ResizeOverlayComponent } from './resize-overlay.component';
 import { IconModule } from '../icon/icon.module';
-import { HotkeysService } from '../hotkeys/hotkeys.service';
 
 @NgModule({
   declarations: [OverlayComponent, ResizeOverlayComponent],
-  providers: [InjectionService, HotkeysService],
+  providers: [InjectionService],
   exports: [OverlayComponent, ResizeOverlayComponent],
   imports: [CommonModule, IconModule, LayoutModule],
   entryComponents: [OverlayComponent, ResizeOverlayComponent]

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { LayoutModule } from '@angular/cdk/layout';
 
 import { OverlayComponent } from './overlay.component';
-import { OverlayService } from './overlay.service';
 import { InjectionService } from '../../services/injection/injection.service';
 import { ResizeOverlayComponent } from './resize-overlay.component';
 import { IconModule } from '../icon/icon.module';
@@ -11,7 +10,7 @@ import { HotkeysService } from '../hotkeys/hotkeys.service';
 
 @NgModule({
   declarations: [OverlayComponent, ResizeOverlayComponent],
-  providers: [OverlayService, InjectionService, OverlayService, HotkeysService],
+  providers: [InjectionService, HotkeysService],
   exports: [OverlayComponent, ResizeOverlayComponent],
   imports: [CommonModule, IconModule, LayoutModule],
   entryComponents: [OverlayComponent, ResizeOverlayComponent]

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.service.ts
@@ -3,7 +3,9 @@ import { Injectable, ComponentRef, EventEmitter } from '@angular/core';
 import { InjectionService } from '../../services/injection/injection.service';
 import { OverlayComponent } from './overlay.component';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class OverlayService {
   component: ComponentRef<OverlayComponent>;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.module.ts
@@ -3,13 +3,12 @@ import { CommonModule } from '@angular/common';
 
 import { TooltipDirective } from './tooltip.directive';
 import { TooltipContentComponent } from './tooltip.component';
-import { TooltipService } from './tooltip.service';
 
 import { InjectionService } from '../../services/injection/injection.service';
 
 @NgModule({
   declarations: [TooltipContentComponent, TooltipDirective],
-  providers: [InjectionService, TooltipService],
+  providers: [InjectionService],
   exports: [TooltipContentComponent, TooltipDirective],
   imports: [CommonModule],
   entryComponents: [TooltipContentComponent]

--- a/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.service.ts
@@ -4,7 +4,9 @@ import { InjectionService } from '../../services/injection/injection.service';
 import { InjectionRegistryService } from '../../services/injection-registry/injection-registry.service';
 import { TooltipContentComponent } from './tooltip.component';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class TooltipService extends InjectionRegistryService<TooltipContentComponent> {
   type: Type<TooltipContentComponent> = TooltipContentComponent;
 

--- a/projects/swimlane/ngx-ui/src/lib/ngx-ui.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/ngx-ui.module.ts
@@ -7,7 +7,6 @@ import { DrawerService } from './components/drawer/drawer.service';
 import { IconRegistryService } from './services/icon-registry/icon-registry.service';
 import { InjectionService } from './services/injection/injection.service';
 import { LoadingService } from './components/loading/loading.service';
-import { OverlayService } from './components/overlay/overlay.service';
 import { PipesModule } from './pipes/pipes.module';
 import { TooltipService } from './components/tooltip/tooltip.service';
 
@@ -90,7 +89,7 @@ const modules = [
   TreeModule
 ];
 
-const services = [DrawerService, IconRegistryService, InjectionService, LoadingService, OverlayService, TooltipService];
+const services = [DrawerService, IconRegistryService, InjectionService, LoadingService, TooltipService];
 
 @NgModule({
   providers: [...services],

--- a/projects/swimlane/ngx-ui/src/lib/ngx-ui.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/ngx-ui.module.ts
@@ -2,13 +2,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { DialogService } from './components/dialog/dialog.service';
 import { DirectivesModule } from './directives/directives.module';
 import { DrawerService } from './components/drawer/drawer.service';
 import { IconRegistryService } from './services/icon-registry/icon-registry.service';
 import { InjectionService } from './services/injection/injection.service';
 import { LoadingService } from './components/loading/loading.service';
-import { NotificationService } from './components/notification/notification.service';
 import { OverlayService } from './components/overlay/overlay.service';
 import { PipesModule } from './pipes/pipes.module';
 import { TooltipService } from './components/tooltip/tooltip.service';
@@ -92,16 +90,7 @@ const modules = [
   TreeModule
 ];
 
-const services = [
-  DialogService,
-  DrawerService,
-  IconRegistryService,
-  InjectionService,
-  LoadingService,
-  NotificationService,
-  OverlayService,
-  TooltipService
-];
+const services = [DrawerService, IconRegistryService, InjectionService, LoadingService, OverlayService, TooltipService];
 
 @NgModule({
   providers: [...services],

--- a/projects/swimlane/ngx-ui/src/lib/ngx-ui.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/ngx-ui.module.ts
@@ -3,12 +3,8 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { DirectivesModule } from './directives/directives.module';
-import { DrawerService } from './components/drawer/drawer.service';
-import { IconRegistryService } from './services/icon-registry/icon-registry.service';
 import { InjectionService } from './services/injection/injection.service';
-import { LoadingService } from './components/loading/loading.service';
 import { PipesModule } from './pipes/pipes.module';
-import { TooltipService } from './components/tooltip/tooltip.service';
 
 import { ButtonModule } from './components/button/button.module';
 import { CalendarModule } from './components/calendar/calendar.module';
@@ -89,7 +85,7 @@ const modules = [
   TreeModule
 ];
 
-const services = [DrawerService, IconRegistryService, InjectionService, LoadingService, TooltipService];
+const services = [InjectionService];
 
 @NgModule({
   providers: [...services],

--- a/projects/swimlane/ngx-ui/src/lib/services/icon-registry/icon-registry.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/services/icon-registry/icon-registry.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 
 import { convertClass } from './convert-class.util';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class IconRegistryService {
   private _defaultFontSetClass: string = 'ngx';
   private _iconMap: Map<string, string[]> = new Map();


### PR DESCRIPTION
## Summary

Provide singleton services in the root injector.

## Motivation

When singleton services that manage some sort of internal state are added to the module providers list vs the root injector, we can end up with multiple instances of the service (in lazy loaded modules, for example) resulting in an incorrect behavior.

## Example

The `DialogService` holds a collection of all the open dialogs (actually the collection is inherited from the abstract base class `InjectionRegistryService<T>`). The `destroyAll()` method iterates the collection and destroys all dialogs. Obviously having multiple instances of this particular service could be problematic:

```ts
// ...
dialogService__A.create({ /* ... */ });
dialogService__B.destroyAll(); // B's collection is empty, nothing to destroy here!
```

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
