### PR TITLE
feat: add viewport intersection capabilities to the dropdown menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10463,6 +10463,11 @@
         "ipaddr.js": "^1.9.0"
       }
     },
+    "intersection-observer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.0.tgz",
+      "integrity": "sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ=="
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -12394,6 +12399,15 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "ng-in-viewport": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/ng-in-viewport/-/ng-in-viewport-6.1.5.tgz",
+      "integrity": "sha512-1yYwKlJm3i/cTaJn3h8jyPvpXocOPWXXj0xdHN+n25rIzcf1r1YpNmvA2bFELvrEOcIbBGgpuo+oQGb9tBzLmg==",
+      "requires": {
+        "intersection-observer": ">=0.11.0",
+        "tslib": ">=1.9.0"
+      }
     },
     "ng-packagr": {
       "version": "11.0.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "d3-color": "^1.2.3",
     "moment-timezone": "^0.5.28",
     "mousetrap": "^1.6.5",
+    "ng-in-viewport": "^6.1.5",
     "normalize.css": "^8.0.0",
     "prismjs": "^1.21.0",
     "resize-observer-polyfill": "^1.5.1",

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # HEAD (unreleased)
 
+- Enhancement(Dropdown): Add viewport intersection to change the direction of the dropdown menu upwards or downwards.
+
 ## 34.1.0 (2021-01-20)
 
 - Enhancement: Add `blur` and `dateTimeSelected` outputs to `DateTimeComponent`.

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-menu.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-menu.directive.ts
@@ -1,4 +1,5 @@
-import { ElementRef, Directive } from '@angular/core';
+import { ElementRef, Directive, Inject, PLATFORM_ID, EventEmitter } from '@angular/core';
+import { InViewportDirective, InViewportService } from 'ng-in-viewport';
 
 @Directive({
   // tslint:disable-next-line:directive-selector
@@ -6,10 +7,19 @@ import { ElementRef, Directive } from '@angular/core';
   selector: 'ngx-dropdown-menu',
   host: { class: 'ngx-dropdown-menu' }
 })
-export class DropdownMenuDirective {
+export class DropdownMenuDirective extends InViewportDirective {
   readonly element: HTMLElement;
 
-  constructor(private readonly el: ElementRef<HTMLElement>) {
-    this.element = this.el.nativeElement;
+  constructor(
+    @Inject(PLATFORM_ID) private readonly _platformIdentifier: any,
+    private readonly _elementReference: ElementRef,
+    private readonly _insideViewport: InViewportService
+  ) {
+    super(_platformIdentifier, _elementReference, _insideViewport);
+    this.element = this._elementReference.nativeElement;
+  }
+
+  getCallbackFn(): EventEmitter<any> {
+    return this.inViewportAction;
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.scss
@@ -41,6 +41,18 @@ $dropdown-color: $color-grey-100;
     }
   }
 
+  .ngx-dropdown-menu--upwards {
+    bottom: 100%;
+    top: auto !important;
+    margin-bottom: 14px;
+
+    &::before {
+      transform: rotate(225deg) !important;
+      bottom: -7px;
+      top: auto !important;
+    }
+  }
+
   .ngx-dropdown-menu {
     position: absolute;
     clear: left;

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
@@ -84,7 +84,6 @@ export class DropdownComponent implements AfterContentInit, OnDestroy {
   private _closeOnOutsideClick: boolean = true;
   private _closeOnMouseLeave: boolean = false;
   private _leaveTimeout = null;
-  private _visible = true;
 
   constructor(private readonly renderer: Renderer2, private readonly cd: ChangeDetectorRef) {}
 

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.module.ts
@@ -4,10 +4,11 @@ import { CommonModule } from '@angular/common';
 import { DropdownComponent } from './dropdown.component';
 import { DropdownToggleDirective } from './dropdown-toggle.directive';
 import { DropdownMenuDirective } from './dropdown-menu.directive';
+import { InViewportModule } from 'ng-in-viewport';
 
 @NgModule({
   declarations: [DropdownComponent, DropdownToggleDirective, DropdownMenuDirective],
   exports: [DropdownComponent, DropdownToggleDirective, DropdownMenuDirective],
-  imports: [CommonModule]
+  imports: [CommonModule, InViewportModule]
 })
 export class DropdownModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "target": "es2015",
     "typeRoots": ["node_modules/@types"],


### PR DESCRIPTION
## Summary

The dropdown menu now determines if it's being partially hidden by the viewport and change direction upwards or downwards trying to be inside the viewport.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x

https://user-images.githubusercontent.com/24899986/112237853-42a7c500-8c22-11eb-8ca5-e54375678e71.mov


] Included screenshots of visual changes

_\*required_
