### PR TITLE
perf(drawer): reduce change detection cycles

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature(CardComponent): add error outline
 - Fix(DropzoneComponent): addressing minor design review feedback
+- Enhancement(DrawerComponent): keyboard clicks do not trigger change detection anymore except `Escape`
 
 =======
 


### PR DESCRIPTION
This PR reduces change detection cycles for the drawer component by replacing
`HostListener` with `Renderer.listen` outside of the zone. The change detection should
be run only if the `Escape` button is clicked.
Note that the `HostListener` wraps the actual listener under the hood into the internal Angular
function which runs `markDirty()` before running the actual listener (the decorated class method).

The `DrawerService` has been updated to run the change detection only when the parent container is clicked.

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>

## Checklist

- [x] Added unit tests