### PR TITLE
perf(icon): reduce change detection cycles by running HTTP requests in the root zone

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature(CardComponent): add error outline
 - Fix(DropzoneComponent): addressing minor design review feedback
+- Enhancement(IconComponent): HTTP requests do not trigger change detection anymore
 
 =======
 


### PR DESCRIPTION
This PR reduces change detection cycles for the icon component by running HTTP requests
in the root zone.

Any `XMLHttpRequest` will trigger 2 change detection cycles:

1. when the `xhr.onload` macrotask is invoked
2. when the `xhr.send()` is invoked (if the request is asynchronous and by default they are)

We're updating `innerHTML` property at the end and it doesn't require Angular to run
`ApplicationRef.tick()`.

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>