### PR TITLE
perf(loading): reduce change detection cycles by running timers in the root zone

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature(CardComponent): add error outline
 - Fix(DropzoneComponent): addressing minor design review feedback
+- Enhancement(LoadingComponent): timers do not run change detection anymore
 
 =======
 

--- a/projects/swimlane/ngx-ui/src/lib/components/loading/loading.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/loading/loading.component.html
@@ -1,3 +1,3 @@
 <div class="ngx-loading-bar--container" *ngIf="visible">
-  <div class="ngx-loading-bar--bar" [style.width.%]="progress"></div>
+  <div class="ngx-loading-bar--bar" #bar></div>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/loading/loading.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/loading/loading.component.spec.ts
@@ -25,4 +25,9 @@ describe('LoadingComponent', () => {
   it('can load instance', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should change loading bar width 60%', () => {
+    component.progress = 60;
+    expect(component.bar.nativeElement.style.width).toBe('60%');
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/loading/loading.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/loading/loading.component.ts
@@ -1,4 +1,13 @@
-import { Component, Input, ViewEncapsulation, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import {
+  Component,
+  Input,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  ViewChild,
+  ElementRef,
+  Renderer2
+} from '@angular/core';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 
 @Component({
@@ -17,7 +26,10 @@ export class LoadingComponent {
   }
   set visible(visible: boolean) {
     this._visible = coerceBooleanProperty(visible);
-    this.cdr.markForCheck();
+    // `markForCheck` will not run change detection but will change the state of all parent components
+    // to `ChecksEnabled` which means the `ApplicationRef.tick()` will run change detection on all components
+    // down to this one.
+    this.cdr.detectChanges();
   }
 
   @Input()
@@ -26,11 +38,15 @@ export class LoadingComponent {
   }
   set progress(progress: number) {
     this._progress = coerceNumberProperty(progress);
-    this.cdr.markForCheck();
+    if (this.bar) {
+      this.renderer.setStyle(this.bar.nativeElement, 'width', `${this.progress}%`);
+    }
   }
+
+  @ViewChild('bar', { static: false }) bar?: ElementRef<HTMLElement>;
 
   private _visible: boolean = false;
   private _progress: number = 0;
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(private cdr: ChangeDetectorRef, private renderer: Renderer2) {}
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/loading/loading.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/loading/loading.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ComponentRef } from '@angular/core';
+import { Injectable, ComponentRef, NgZone } from '@angular/core';
 
 import { InjectionService } from '../../services/injection/injection.service';
 import { LoadingComponent } from './loading.component';
@@ -34,7 +34,7 @@ export class LoadingService {
   private component: ComponentRef<LoadingComponent>;
   private _progress: number = 0;
 
-  constructor(private readonly injectionService: InjectionService) {}
+  constructor(private readonly ngZone: NgZone, private readonly injectionService: InjectionService) {}
 
   start(autoIncrement: boolean = true): void {
     this.create();
@@ -46,13 +46,17 @@ export class LoadingService {
       const fn = () => {
         this.increment();
         if (this.progress < 100) {
-          this.timeout = setTimeout(fn, this.threshold);
+          this.ngZone.runOutsideAngular(() => {
+            this.timeout = setTimeout(fn, this.threshold);
+          });
         } else {
           this.complete();
         }
       };
 
-      this.timeout = setTimeout(fn, this.threshold);
+      this.ngZone.runOutsideAngular(() => {
+        this.timeout = setTimeout(fn, this.threshold);
+      });
     }
   }
 


### PR DESCRIPTION
This PR reduces change detection cycles for the loading component by running timers
in the root zone. Timers change `width` style property on the element, such properties can
be updated through `Renderer` class which won't require Angular to run `ApplicationRef.tick()`.

Signed-off-by: Artur Androsovych <arthurandrosovich@gmail.com>

Before (each timer caused Angular to run the whole change detection):

![image](https://user-images.githubusercontent.com/7337691/114767683-9d8b9280-9d70-11eb-81d9-e22aa87229d0.png)

After:

![image](https://user-images.githubusercontent.com/7337691/114767720-a9775480-9d70-11eb-8fb9-d15142e44817.png)


## Checklist

- [*] Added unit tests