### PR TITLE
Updating btn-link color

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix(TipComponent): change error color
 - Enhancement: Add `$color-error` css var
 - Feat(LargeFormatDialogContentComponent): add new component as wrapper for Dialog content
+- Enhancement: Changed color for `btn-link` to be `$color-blue-400`.
 
 ## 35.3.1 (2021-03-29)
 

--- a/projects/swimlane/ngx-ui/src/lib/styles/components/buttons.scss
+++ b/projects/swimlane/ngx-ui/src/lib/styles/components/buttons.scss
@@ -97,14 +97,11 @@ button {
 
     &.btn-link {
       background-color: transparent;
+      color: $color-blue-200;
     }
 
     &.btn-bordered {
       border-color: $color-blue-200;
-      color: $color-blue-200;
-    }
-
-    &.btn-link {
       color: $color-blue-200;
     }
   }

--- a/projects/swimlane/ngx-ui/src/lib/styles/components/buttons.scss
+++ b/projects/swimlane/ngx-ui/src/lib/styles/components/buttons.scss
@@ -103,6 +103,10 @@ button {
       border-color: $color-blue-200;
       color: $color-blue-200;
     }
+
+    &.btn-link {
+      color: $color-blue-200;
+    }
   }
 
   &:hover,
@@ -139,6 +143,7 @@ button {
   &.btn-link {
     background-color: transparent;
     box-shadow: none;
+    color: $color-blue-400;
   }
 
   &.btn-bordered,


### PR DESCRIPTION
## Summary

Updating `btn-link` color to be `$color-blue-400`.
![image](https://user-images.githubusercontent.com/74981795/115039160-6fe83b80-9e8d-11eb-8fc4-d2efe3fd288d.png)

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
