### PR TITLE
Add validation when change on minDate or maxDate occurs

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Enhancement: Add validation when change on `minDate` or `maxDate` occurs.
+- Enhancement: Add validation when change on `minDate` or `maxDate` occurs to the `date-time` component.
 
 ## 35.6.3 (2021-05-03)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Enhancement: Add validation when change on `minDate` or `maxDate` occurs.
+
 ## 35.6.3 (2021-05-03)
 
 - Fix: Adjust `line-height` on `LargeFormatDialogContent#dialogTitle` to prevent cut off from overflow for truncating

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -617,4 +617,32 @@ describe('DateTimeComponent', () => {
       expect(component.change.emit).not.toHaveBeenCalled();
     });
   });
+
+  describe('error messages', () => {
+    it('should update Date out of range error when minDate is changed', () => {
+      const today = new Date();
+      let yesterday = new Date();
+      yesterday.setDate(today.getDate() - 1);
+      component.minDate = today;
+      component.writeValue(yesterday);
+      expect(component.errorMsg).toEqual('Date out of range');
+      const newMinDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+      debugger;
+      component.minDate = newMinDate;
+      expect(component.errorMsg).toEqual('');
+    });
+
+    it('should update Date out of range error when maxDate is changed', () => {
+      const today = new Date();
+      let yesterday = new Date();
+      yesterday.setDate(today.getDate() - 1);
+      component.maxDate = yesterday;
+      component.writeValue(today);
+      expect(component.errorMsg).toEqual('Date out of range');
+      const newMaxDate = new Date(today.setDate(today.getDate() + 1));
+      debugger;
+      component.maxDate = newMaxDate;
+      expect(component.errorMsg).toEqual('');
+    });
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -621,26 +621,24 @@ describe('DateTimeComponent', () => {
   describe('error messages', () => {
     it('should update Date out of range error when minDate is changed', () => {
       const today = new Date();
-      let yesterday = new Date();
+      const yesterday = new Date();
       yesterday.setDate(today.getDate() - 1);
       component.minDate = today;
       component.writeValue(yesterday);
       expect(component.errorMsg).toEqual('Date out of range');
       const newMinDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
-      debugger;
       component.minDate = newMinDate;
       expect(component.errorMsg).toEqual('');
     });
 
     it('should update Date out of range error when maxDate is changed', () => {
       const today = new Date();
-      let yesterday = new Date();
+      const yesterday = new Date();
       yesterday.setDate(today.getDate() - 1);
       component.maxDate = yesterday;
       component.writeValue(today);
       expect(component.errorMsg).toEqual('Date out of range');
       const newMaxDate = new Date(today.setDate(today.getDate() + 1));
-      debugger;
       component.maxDate = newMaxDate;
       expect(component.errorMsg).toEqual('');
     });

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -63,11 +63,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   @Input() size: Size = Size.Small;
   @Input() appearance: Appearance = Appearance.Legacy;
   @Input() withMargin = true;
-
-  @Input() minDate: string | Date;
-  @Input() maxDate: string | Date;
   @Input() precision: moment.unitOfTime.StartOf;
-
   @Input() timezone: string;
   @Input() inputFormats: any[] = ['L', `LT`, 'L LT', moment.ISO_8601];
 
@@ -196,6 +192,24 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
     this._autosize = coerceBooleanProperty(v);
   }
 
+  @Input()
+  get minDate() {
+    return this._minDate;
+  }
+  set minDate(val: Date | string) {
+    this._minDate = val;
+    this.validate(this.parseDate(this._value));
+  }
+
+  @Input()
+  get maxDate() {
+    return this._maxDate;
+  }
+  set maxDate(val: Date | string) {
+    this._maxDate = val;
+    this.validate(this.parseDate(this._value));
+  }
+
   /**
    * this output will emit only when the input value is valid or cleared.
    * @see inputChange for always emitting the value
@@ -234,6 +248,8 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor {
   private _autosize: boolean = false;
   private _minWidth: number = MIN_WIDTH;
   private _required: boolean = false;
+  private _maxDate: Date | string;
+  private _minDate: Date | string;
 
   constructor(private readonly dialogService: DialogService, private readonly cdr: ChangeDetectorRef) {}
 


### PR DESCRIPTION
## Summary

Add validation when change on minDate or maxDate occurs.

In this particular example we are using the value of the first component to be the value for the `[minDate]` input on the second component. 

When the first component value is changed, then the error message on the second component should go away, because now it is a valid date. 

That behavior was missing, because we did not have any validation happening after any change on the `minDate` or `maxDate`, the error message was always displayed, even if it was a valid date after the `minDate` value was changed.
![image](https://user-images.githubusercontent.com/74981795/119199850-0b4e6c80-ba49-11eb-95fe-c4b01d873d2f.png)

![image](https://user-images.githubusercontent.com/74981795/119199885-1f926980-ba49-11eb-9f56-7181ec0c2588.png)


## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
