### PR TITLE
Add warning status to tip component, add ability to display a custom icon

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Enhancement: Add `warning` status to `tip` component
+- Enhancement: Add ability to display custom icon on `tip` component
+
 ## 35.6.4 (2021-05-25)
 
 - Enhancement: Add validation when change on `minDate` or `maxDate` occurs to the `date-time` component.

--- a/projects/swimlane/ngx-ui/src/lib/components/tip/tip-status.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tip/tip-status.enum.ts
@@ -1,5 +1,6 @@
 export enum TipStatus {
   Success = 'success',
   Error = 'error',
-  Notice = 'notice'
+  Notice = 'notice',
+  Warning = 'warning'
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.scss
@@ -85,4 +85,18 @@ $color-border: $color-blue-grey-650;
       }
     }
   }
+
+  &.ngx-tip--warning {
+    .tip-container {
+      &::before {
+        background: $color-orange-400;
+      }
+
+      .tip-content {
+        &--icon .ngx-icon {
+          color: $color-orange-400;
+        }
+      }
+    }
+  }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.spec.ts
@@ -23,6 +23,7 @@ describe('TipComponent', () => {
     expect(component.TipStatus.Success).toEqual('success');
     expect(component.TipStatus.Error).toEqual('error');
     expect(component.TipStatus.Notice).toEqual('notice');
+    expect(component.TipStatus.Warning).toEqual('warning');
   });
   it('default icon', () => {
     const defaultIcon = 'info-filled-small';
@@ -34,6 +35,21 @@ describe('TipComponent', () => {
     (component.status as any) = 'error';
     component.ngOnInit();
     expect(component.icon).toEqual(errorIcon);
+  });
+  it('warning icon', () => {
+    const warningIcon = 'alert';
+    (component.status as any) = 'warning';
+    component.ngOnInit();
+    expect(component.icon).toEqual(warningIcon);
+  });
+  it('dislay custom icon', () => {
+    const warningIcon = 'alert';
+    const customIcon = 'smiley-frown';
+    (component.status as any) = 'warning';
+    component.icon = customIcon;
+    component.ngOnInit();
+    expect(component.icon).not.toEqual(warningIcon);
+    expect(component.icon).toEqual(customIcon);
   });
   it('emits close', () => {
     spyOn(component.close, 'emit');

--- a/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.spec.ts
@@ -27,19 +27,19 @@ describe('TipComponent', () => {
   });
   it('default icon', () => {
     const defaultIcon = 'info-filled-small';
-    component.ngOnInit();
+    component.ngOnChanges();
     expect(component.icon).toEqual(defaultIcon);
   });
   it('error icon', () => {
     const errorIcon = 'warning-filled-sm';
     (component.status as any) = 'error';
-    component.ngOnInit();
+    component.ngOnChanges();
     expect(component.icon).toEqual(errorIcon);
   });
   it('warning icon', () => {
     const warningIcon = 'alert';
     (component.status as any) = 'warning';
-    component.ngOnInit();
+    component.ngOnChanges();
     expect(component.icon).toEqual(warningIcon);
   });
   it('dislay custom icon', () => {
@@ -47,7 +47,7 @@ describe('TipComponent', () => {
     const customIcon = 'smiley-frown';
     (component.status as any) = 'warning';
     component.icon = customIcon;
-    component.ngOnInit();
+    component.ngOnChanges();
     expect(component.icon).not.toEqual(warningIcon);
     expect(component.icon).toEqual(customIcon);
   });

--- a/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.ts
@@ -1,6 +1,15 @@
 import { Component, Input, Output, EventEmitter, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
 import { TipStatus } from './tip-status.enum';
 
+function getIcon(status: TipStatus): string {
+  const icons = {
+    [TipStatus.Error]: 'warning-filled-sm',
+    [TipStatus.Warning]: 'alert',
+    default: 'info-filled-small'
+  };
+  return icons[status] || icons['default'];
+}
+
 @Component({
   selector: 'ngx-tip',
   exportAs: 'ngxTip',
@@ -27,9 +36,9 @@ export class TipComponent {
   close = new EventEmitter();
   readonly TipStatus = TipStatus;
 
-  ngOnInit() {
+  ngOnChanges() {
     if (!this.icon) {
-      this.icon = this.getIcon(this.status);
+      this.icon = getIcon(this.status);
     }
   }
 
@@ -39,14 +48,5 @@ export class TipComponent {
 
   onClose() {
     this.close.emit();
-  }
-
-  private getIcon(status: TipStatus): string {
-    const icons = {
-      [TipStatus.Error]: 'warning-filled-sm',
-      [TipStatus.Warning]: 'alert',
-      default: 'info-filled-small'
-    };
-    return icons[status] || icons['default'];
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.ts
@@ -12,7 +12,8 @@ import { TipStatus } from './tip-status.enum';
     class: 'ngx-tip',
     '[class.ngx-tip--success]': 'status === TipStatus.Success',
     '[class.ngx-tip--error]': 'status === TipStatus.Error',
-    '[class.ngx-tip--notice]': 'status === TipStatus.Notice'
+    '[class.ngx-tip--notice]': 'status === TipStatus.Notice',
+    '[class.ngx-tip--warning]': 'status === TipStatus.Warning'
   }
 })
 export class TipComponent {
@@ -20,13 +21,16 @@ export class TipComponent {
   status: TipStatus;
   @Input()
   isCloseable: boolean = false;
+  @Input()
+  icon: string;
   @Output()
   close = new EventEmitter();
-  icon: string;
   readonly TipStatus = TipStatus;
 
   ngOnInit() {
-    this.icon = this.status === TipStatus.Error ? 'warning-filled-sm' : 'info-filled-small';
+    if (!this.icon) {
+      this.icon = this.getIcon(this.status);
+    }
   }
 
   ngOnDestroy() {
@@ -35,5 +39,14 @@ export class TipComponent {
 
   onClose() {
     this.close.emit();
+  }
+
+  private getIcon(status: TipStatus): string {
+    const icons = {
+      [TipStatus.Error]: 'warning-filled-sm',
+      [TipStatus.Warning]: 'alert',
+      default: 'info-filled-small'
+    };
+    return icons[status] || icons['default'];
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tip/tip.component.ts
@@ -1,13 +1,14 @@
 import { Component, Input, Output, EventEmitter, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
 import { TipStatus } from './tip-status.enum';
 
+const ICONS = {
+  [TipStatus.Error]: 'warning-filled-sm',
+  [TipStatus.Warning]: 'alert',
+  default: 'info-filled-small'
+};
+
 function getIcon(status: TipStatus): string {
-  const icons = {
-    [TipStatus.Error]: 'warning-filled-sm',
-    [TipStatus.Warning]: 'alert',
-    default: 'info-filled-small'
-  };
-  return icons[status] || icons['default'];
+  return ICONS[status] || ICONS['default'];
 }
 
 @Component({

--- a/src/app/components/tip-page/tip-page.component.html
+++ b/src/app/components/tip-page/tip-page.component.html
@@ -12,6 +12,9 @@
       <ngx-tip [status]="TipStatus.Notice">
         {{text}}
       </ngx-tip>
+      <ngx-tip [status]="TipStatus.Warning">
+        {{text}}
+      </ngx-tip>
     </div>
     <app-prism>
 <![CDATA[<ngx-tip [status]="TipStatus.Success">
@@ -21,6 +24,37 @@
   {{text}}
 </ngx-tip>
 <ngx-tip [status]="TipStatus.Notice">
+  {{text}}
+</ngx-tip>]]>
+    </app-prism>
+  </ngx-section>
+
+  <ngx-section class="shadow" sectionTitle="Custom Icons">
+    <div class="tip-example">
+      <ngx-tip [status]="TipStatus.Success" icon="check-filled-sm">
+        {{text}}
+      </ngx-tip>
+      <ngx-tip [status]="TipStatus.Error" icon="smiley-frown">
+        {{text}}
+      </ngx-tip>
+      <ngx-tip [status]="TipStatus.Notice" icon="eye-disabled">
+        {{text}}
+      </ngx-tip>
+      <ngx-tip [status]="TipStatus.Warning" icon="pause-circle">
+        {{text}}
+      </ngx-tip>
+    </div>
+    <app-prism>
+<![CDATA[<ngx-tip [status]="TipStatus.Success" icon="check-filled-sm">
+  {{text}}
+</ngx-tip>
+<ngx-tip [status]="TipStatus.Error" icon="smiley-frown">
+  {{text}}
+</ngx-tip>
+<ngx-tip [status]="TipStatus.Notice" icon="eye-disabled">
+  {{text}}
+</ngx-tip>
+<ngx-tip [status]="TipStatus.Warning" icon="pause-circle">
   {{text}}
 </ngx-tip>]]>
     </app-prism>

--- a/src/app/components/tip-page/tip-page.component.html
+++ b/src/app/components/tip-page/tip-page.component.html
@@ -25,6 +25,9 @@
 </ngx-tip>
 <ngx-tip [status]="TipStatus.Notice">
   {{text}}
+</ngx-tip>
+<ngx-tip [status]="TipStatus.Warning">
+  {{text}}
 </ngx-tip>]]>
     </app-prism>
   </ngx-section>

--- a/src/app/components/tip-page/tip-page.component.ts
+++ b/src/app/components/tip-page/tip-page.component.ts
@@ -3,7 +3,8 @@ import { Component, ChangeDetectionStrategy, ViewEncapsulation } from '@angular/
 enum TipStatus {
   Success = 'success',
   Error = 'error',
-  Notice = 'notice'
+  Notice = 'notice',
+  Warning = 'warning'
 }
 const text = 'Validate and submit the form to the left to view the method’s response.';
 @Component({


### PR DESCRIPTION
## Summary

- Add `Warning Status` to Tip Component
- Add ability to display a custom icon
- Updated demo page to display these two new enhancements

![image](https://user-images.githubusercontent.com/62297014/120848887-9bed7800-c532-11eb-96d2-3779a42e7f17.png)


## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
