### PR TITLE
fix(ngx-toggle): toggle going out of bounds when disabled

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enhancement: Improve semantic HTML in `ngx-input` and `ngx-select`
 - Enhancement: Added `for` attribute to `ngx-input` labels
 - Enhancement: Added ARIA role attribute to `ngx-plus-menu`
+- Fix: Toggle going out of bounds when disabled in `ngx-toggle`
 
 ## 35.6.7 (2021-06-29)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.scss
@@ -27,7 +27,7 @@
       background: $color-blue-700;
 
       &:after {
-        left: 15px;
+        left: 16px;
         background: $color-blue;
       }
     }
@@ -37,7 +37,7 @@
     position: relative;
     display: block;
     height: 14px;
-    width: 34px;
+    width: 36px;
     background: $color-blue-grey-900;
     border-radius: 100px;
     cursor: pointer;
@@ -49,12 +49,12 @@
 
     &:after {
       position: absolute;
-      left: -2px;
+      left: 0;
       top: -3px;
       display: block;
       height: 20px;
       width: 20px;
-      border-radius: 100px;
+      border-radius: 100%;
       background: $color-blue-grey-400;
       box-shadow: 0px 3px 3px $color-blue-grey-900;
       content: '';
@@ -67,7 +67,7 @@
       &.ngx-check {
         opacity: 0.5;
         color: $color-white;
-        padding: 2.5px 4px;
+        padding: 2.5px 3.5px;
         font-size: 9px;
       }
 
@@ -75,7 +75,7 @@
         flex-direction: row-reverse;
         opacity: 0.7;
         color: $color-blue-grey-400;
-        padding: 4px 5px;
+        padding: 3.5px 4.5px;
         font-size: 7px;
         font-weight: 900;
       }


### PR DESCRIPTION
## Summary

When the toggle is disabled it overflows to the left side of the component. Not by much, but when the parent has an `overflow: hidden` then the cropped circle is very noticeable.

**Before**

![image](https://user-images.githubusercontent.com/19226858/128424747-548ba271-f495-40c3-98cc-82dae6cb9dba.png)
![image](https://user-images.githubusercontent.com/19226858/128424639-49b25981-f1e3-41f4-be9d-4180a094ed63.png)

**After**

![image](https://user-images.githubusercontent.com/19226858/128424775-c778aca0-6932-467c-bb60-7c1bf7d0f4ea.png)
![image](https://user-images.githubusercontent.com/19226858/128424599-1843e53d-440b-496d-b2d7-7b4f36836268.png)

## Checklist

- [ ] ~\*Added unit tests~
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] ~Updated the demo page~
- [x] Included screenshots of visual changes

_\*required_
