### PR TITLE
fix tab buttons (fixes #661)

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enhancement: Added `for` attribute to `ngx-input` labels
 - Enhancement: Added ARIA role attribute to `ngx-plus-menu`
 - Fix: Toggle going out of bounds when disabled in `ngx-toggle`
+- Fix: Tabs in `ngx-tabs` are now `type="button"`
 
 ## 35.6.8 (2021-07-16)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.html
@@ -1,7 +1,7 @@
 <section>
   <ul class="ngx-tabs-list list-reset" [class.tabs-vertical]="vertical" [class.tabs-horizontal]="!vertical">
     <li *ngFor="let tab of tabs" class="ngx-tab" [class.disabled]="tab.disabled" [class.active]="tab.active">
-      <button (click)="tabClicked(tab)" [disabled]="tab.disabled">
+      <button type="button" (click)="tabClicked(tab)" [disabled]="tab.disabled">
         <ng-container *ngTemplateOutlet="tab.labelTemplate; context: { $implicit: tab }"> </ng-container>
       </button>
     </li>


### PR DESCRIPTION
## Summary

Tabs in `ngx-tabs` are now `type="button"`

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
