### PR TITLE
Improve active tab contrast (fixes #659)

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enhancement: Added `for` attribute to `ngx-input` labels
 - Enhancement: Added ARIA role attribute to `ngx-plus-menu`
 - Fix: Toggle going out of bounds when disabled in `ngx-toggle`
+- Enhancement: Improve active tab contrast in `ngx-tabs`
 
 ## 35.6.8 (2021-07-16)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.scss
@@ -22,7 +22,6 @@ $tabs-active-text-color: $color-white;
         button:hover {
           color: $tabs-active-text-color;
           border-width: 0;
-          font-weight: bold;
         }
       }
 
@@ -49,6 +48,7 @@ $tabs-active-text-color: $color-white;
         user-select: none;
         font: inherit;
         font-size: 1em;
+        font-weight: bold;
         outline: none;
         bottom: -1px;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/tabs/tabs.component.scss
@@ -2,8 +2,8 @@
 
 $tabs-border-fill: $color-blue-grey-700;
 $tabs-active-border-fill: $color-blue;
-$tabs-text-color: $color-blue-grey-100;
-$tabs-active-text-color: $color-grey-100;
+$tabs-text-color: $color-blue-grey-250;
+$tabs-active-text-color: $color-white;
 
 .ngx-tabs {
   margin-bottom: 2em;
@@ -22,6 +22,7 @@ $tabs-active-text-color: $color-grey-100;
         button:hover {
           color: $tabs-active-text-color;
           border-width: 0;
+          font-weight: bold;
         }
       }
 


### PR DESCRIPTION
## Summary

Improve active tab contrast in `ngx-tabs`

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_

Was:
![image](https://user-images.githubusercontent.com/509946/133313331-287d948e-9f6d-4ccf-836d-0ebaca12768b.png)


Now:

![image](https://user-images.githubusercontent.com/509946/133313273-8e46b685-1e91-4c19-889e-d827e5d7d079.png)

