### PR TITLE
fix(json-editor): use password type for password fields

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enhancement: Added `for` attribute to `ngx-input` labels
 - Enhancement: Added ARIA role attribute to `ngx-plus-menu`
 - Fix: Toggle going out of bounds when disabled in `ngx-toggle`
+- Fix: Use input password type for password fields in JSON editor.
 
 ## 35.6.8 (2021-07-16)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD (unreleased)
 
 - Feature: Added focus rings to buttons
+- Feature: Add `passwordToggleEnabled` input to JSON editor.
 - Enhancement: Improve semantic HTML in `ngx-input` and `ngx-select`
 - Enhancement: Added `for` attribute to `ngx-input` labels
 - Enhancement: Added ARIA role attribute to `ngx-plus-menu`

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
@@ -12,6 +12,7 @@
     [formats]="customFormats"
     [schemaBuilderMode]="schemaBuilderMode"
     [showKnownProperties]="showKnownProperties"
+    [passwordToggleEnabled]="passwordToggleEnabled"
     (schemaUpdate)="schemaUpdate.emit($event)"
   >
     <div class="node-options" node-options>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
@@ -46,6 +46,8 @@ export class JsonEditorFlatComponent extends JsonEditor implements OnInit, OnCha
 
   @Input() showKnownProperties = false;
 
+  @Input() passwordToggleEnabled = false;
+
   @ContentChildren(JsonEditorNodeFlatComponent) nodeElms: QueryList<JsonEditorNodeFlatComponent>;
 
   @ViewChild('propertyConfigTmpl') propertyConfigTmpl: TemplateRef<PropertyConfigComponent>;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -98,7 +98,7 @@
                 [requiredIndicator]="false"
                 [required]="required"
                 [disabled]="isDuplicated"
-                [passwordToggleEnabled]="true"
+                [passwordToggleEnabled]="passwordToggleEnabled"
               ></ngx-input>
             </div>
 
@@ -210,6 +210,7 @@
       [schemaBuilderMode]="schemaBuilderMode"
       [formats]="formats"
       [showKnownProperties]="showKnownProperties"
+      [passwordToggleEnabled]="passwordToggleEnabled"
       (schemaUpdate)="schemaUpdate.emit(schemaRef)"
     >
     </ngx-json-object-node-flat>
@@ -233,6 +234,7 @@
       [isDuplicated]="isDuplicated"
       [schemaBuilderMode]="schemaBuilderMode"
       [showKnownProperties]="showKnownProperties"
+      [passwordToggleEnabled]="passwordToggleEnabled"
       (schemaUpdate)="schemaUpdate.emit(schemaRef)"
     >
     </ngx-json-array-node-flat>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -98,6 +98,7 @@
                 [requiredIndicator]="false"
                 [required]="required"
                 [disabled]="isDuplicated"
+                [passwordToggleEnabled]="true"
               ></ngx-input>
             </div>
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
@@ -55,6 +55,8 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
 
   @Input() isDuplicated = false;
 
+  @Input() passwordToggleEnabled = false;
+
   @Output() updatePropertyNameEvent = new EventEmitter<{ id: string | number; name: string }>();
 
   requiredIndicator: SafeHtml;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
@@ -22,6 +22,7 @@
       [indentationArray]="indentationArray"
       [showKnownProperties]="showKnownProperties"
       [isDuplicated]="isDuplicated"
+      [passwordToggleEnabled]="passwordToggleEnabled"
     >
       <div class="node-options" node-options>
         <button

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
@@ -36,6 +36,8 @@ export class ArrayNodeFlatComponent extends ArrayNode implements OnInit, OnChang
 
   @Input() isDuplicated = false;
 
+  @Input() passwordToggleEnabled = false;
+
   indentationArray: number[] = [];
 
   constructor(private dialogService: DialogService) {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -28,6 +28,7 @@
       [compressed]="compressed"
       [indentationArray]="indentationArray"
       [showKnownProperties]="showKnownProperties"
+      [passwordToggleEnabled]="passwordToggleEnabled"
       [isDuplicated]="duplicatedFields.has(prop.id)"
       (schemaUpdate)="schemaUpdate.emit(schemaRef)"
       (updatePropertyNameEvent)="onUpdatePropertyName($event)"
@@ -121,7 +122,6 @@
                 <span>Include</span>
               </button>
             </div>
-
           </div>
         </div>
       </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -43,6 +43,8 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnCha
 
   @Input() isDuplicated = false;
 
+  @Input() passwordToggleEnabled = false;
+
   indentationArray: number[] = [];
 
   duplicatedFields = new Map<string, string>();

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
@@ -41,6 +41,7 @@
         [errors]="childrenErrors"
         [typeCheckOverrides]="typeCheckOverrides"
         [showKnownProperties]="showKnownProperties"
+        [passwordToggleEnabled]="passwordToggleEnabled"
       ></ngx-json-object-node>
     </div>
 
@@ -56,6 +57,7 @@
         [errors]="childrenErrors"
         [typeCheckOverrides]="typeCheckOverrides"
         [showKnownProperties]="showKnownProperties"
+        [passwordToggleEnabled]="passwordToggleEnabled"
       ></ngx-json-array-node>
     </div>
 
@@ -113,7 +115,7 @@
           [disabled]="isDuplicated"
           (ngModelChange)="updateModel($event)"
           [required]="required"
-          [passwordToggleEnabled]="true"
+          [passwordToggleEnabled]="passwordToggleEnabled"
         ></ngx-input>
       </div>
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
@@ -105,7 +105,7 @@
 
       <!-- Password -->
       <div *ngIf="schema.format === 'password'">
-        <input
+        <ngx-input
           class="value-input"
           type="password"
           [placeholder]="placeholder"
@@ -113,7 +113,8 @@
           [disabled]="isDuplicated"
           (ngModelChange)="updateModel($event)"
           [required]="required"
-        />
+          [passwordToggleEnabled]="true"
+        ></ngx-input>
       </div>
 
       <!-- Date -->

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.scss
@@ -228,6 +228,7 @@
   ngx-input.value-input {
     margin: 0;
 
+    .ngx-input-label,
     .ngx-input-underline,
     .ngx-input-hint {
       display: none;

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.scss
@@ -171,7 +171,8 @@
     color: $color-error;
   }
 
-  .value-input {
+  *:not(ngx-input).value-input,
+  ngx-input.value-input .ngx-input-wrap .ngx-input-box-wrap .ngx-input-box {
     border: 1px solid $color-node-item-border;
     background: $color-node-item-bg;
     color: $color-blue-grey-150;
@@ -179,6 +180,7 @@
     height: 30px;
     padding: 5px;
     border-radius: 0;
+    margin: 0;
 
     &.select * {
       background-color: $color-blue-grey-700;
@@ -220,6 +222,15 @@
           display: inline;
         }
       }
+    }
+  }
+
+  ngx-input.value-input {
+    margin: 0;
+
+    .ngx-input-underline,
+    .ngx-input-hint {
+      display: none;
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
@@ -24,6 +24,8 @@ export class JsonEditorNodeComponent extends JsonEditorNode implements OnInit {
 
   @Input() isDuplicated = false;
 
+  @Input() passwordToggleEnabled = false;
+
   placeholder = '';
 
   constructor(public dialogMngr: DialogService) {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
@@ -32,6 +32,7 @@
       [isDuplicated]="isDuplicated"
       [typeCheckOverrides]="typeCheckOverrides"
       [showKnownProperties]="showKnownProperties"
+      [passwordToggleEnabled]="passwordToggleEnabled"
     >
     </ngx-json-editor-node>
   </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.ts
@@ -8,4 +8,6 @@ import { ArrayNode } from '../../../../node-types/array-node.component';
 })
 export class ArrayNodeComponent extends ArrayNode {
   @Input() isDuplicated = false;
+
+  @Input() passwordToggleEnabled = false;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
@@ -61,6 +61,7 @@
       [errors]="errors"
       [typeCheckOverrides]="typeCheckOverrides"
       [showKnownProperties]="showKnownProperties"
+      [passwordToggleEnabled]="passwordToggleEnabled"
     >
     </ngx-json-editor-node>
   </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.ts
@@ -10,6 +10,8 @@ import { ObjectNode } from '../../../../node-types/object-node.component';
 export class ObjectNodeComponent extends ObjectNode {
   @Input() isDuplicated = false;
 
+  @Input() passwordToggleEnabled = false;
+
   constructor(protected cdr: ChangeDetectorRef) {
     super(cdr);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.html
@@ -16,6 +16,7 @@
     [errors]="errors"
     [typeCheckOverrides]="typeCheckOverrides"
     [showKnownProperties]="showKnownProperties"
+    [passwordToggleEnabled]="passwordToggleEnabled"
   >
   </ngx-json-editor-node>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.ts
@@ -26,6 +26,8 @@ export class JsonEditorComponent extends JsonEditor {
 
   @Input() typeCheckOverrides?: any;
 
+  @Input() passwordToggleEnabled = false;
+
   @ContentChildren(JsonEditorNodeComponent)
   nodeElms: QueryList<JsonEditorNodeComponent>;
 

--- a/src/app/components/json-editor-page/json-editor-page.component.html
+++ b/src/app/components/json-editor-page/json-editor-page.component.html
@@ -70,6 +70,11 @@
     label="Show Known Object Properties">
   </ngx-toggle>
 
+  <ngx-toggle
+    [(ngModel)]="passwordToggleEnabled"
+    label="Enable Password Toggle">
+  </ngx-toggle>
+
   <ngx-json-editor-flat
     [(model)]="jsonEditorModelFlat"
     [schema]="jsonEditorSchema"
@@ -78,6 +83,7 @@
     [compressed]="compressed"
     [hideRoot]="hideRoot"
     [showKnownProperties]="showKnownProperties"
+    [passwordToggleEnabled]="passwordToggleEnabled"
     (schemaUpdate)="modelschemaUpdate($event)"
   >
   </ngx-json-editor-flat>
@@ -99,6 +105,7 @@
   [compressed]="compressed"
   [hideRoot]="hideRoot"
   [showKnownProperties]="showKnownProperties"
+  [passwordToggleEnabled]="showKnownProperties"
   (schemaUpdate)="modelschemaUpdate($event)">
 </ngx-json-editor-flat>]]>
       </app-prism>

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -85,14 +85,20 @@ export class JsonEditorPageComponent {
             maximum: 180
           }
         }
+      },
+      userApiKey: {
+        title: 'User API key',
+        type: 'string',
+        format: 'password'
       }
     },
-    required: ['productId', 'productName', 'price', 'availability', 'onSale', 'dimensions']
+    required: ['productId', 'productName', 'price', 'availability', 'onSale', 'dimensions', 'userApiKey']
   };
 
   compressed = false;
   hideRoot = false;
   showKnownProperties = false;
+  passwordToggleEnabled = false;
 
   _jsonEditorSchema: any = {};
 


### PR DESCRIPTION
## Summary

Fixes #651 

![image](https://user-images.githubusercontent.com/19226858/133324762-937cb9d6-6f6c-4506-99c2-24665a17989e.png)

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
