### PR TITLE
Implement setDisabledState method to `ngx-select`

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -463,6 +463,10 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     };
   }
 
+  setDisabledState(isDisabled: boolean): void {
+    this._disabled = isDisabled;
+  }
+
   private checkInvalidValue(value: any): boolean {
     if (Array.isArray(value)) {
       return !this.value.length || this.checkInvalidValue(value[0]);


### PR DESCRIPTION
## Summary

This PR implements a missing method from the Angular's `ControlValueAccessor` interface that's needed to change the enabled state of the element using its `FormControl` when using this inside a reactive form.

### Demo
https://user-images.githubusercontent.com/66797479/135691523-d4454dc9-370a-41bc-9b43-a68c3366899e.mov

### Demo source files:

![Screen Shot 2021-10-01 at 16 07 06](https://user-images.githubusercontent.com/66797479/135691552-32cce640-8a24-4227-b4c5-ecc2cb1f023d.png)
![Screen Shot 2021-10-01 at 16 06 54](https://user-images.githubusercontent.com/66797479/135691556-98432678-5fcc-42fb-b225-73a5394b16a0.png)

## Checklist

- [ ] \*Added unit tests
- [X] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [X] Included screenshots of visual changes

_\*required_
