### PR TITLE
Add support for unlockable password inputs (#652)

### DIFF
--- a/cypress/integration/forms/inputs.spec.ts
+++ b/cypress/integration/forms/inputs.spec.ts
@@ -354,10 +354,20 @@ describe('Inputs', () => {
       cy.get('@CUT').ngxFindLabel().contains('Secret');
     });
 
+    it('should show lock icon when locked', () => {
+      cy.get('@CUT').find('.icon-lock').should('be.visible');
+      cy.get('@CUT').find('.icon-eye').should('not.exist');
+    });
+
     it('should clear the password on unlock', () => {
       cy.get('@CUT').find('.icon-lock').click();
       cy.get('@CUT').ngxFindNativeInput().ngxGetValue().should('equal', '');
       cy.get('@CUT').ngxFindNativeInput().should('not.be.disabled');
+    });
+
+    it('should show visibility icon when unlocked', () => {
+      cy.get('@CUT').find('.icon-lock').should('not.exist');
+      cy.get('@CUT').find('.icon-eye').should('be.visible');
     });
   });
 });

--- a/cypress/integration/forms/inputs.spec.ts
+++ b/cypress/integration/forms/inputs.spec.ts
@@ -336,4 +336,28 @@ describe('Inputs', () => {
       cy.get('@CUT').ngxFindNativeInput().first().should('have.attr', 'type', 'text');
     });
   });
+
+  describe('Unlockable password', () => {
+    beforeEach(() => {
+      cy.getByName('input6b').as('CUT');
+    });
+
+    it('has no detectable a11y violations on load', () => {
+      cy.get('@CUT')
+        .find('.ngx-input-flex-wrap-inner')
+        .then($el => {
+          cy.checkA11y($el);
+        });
+    });
+
+    it('has a label', () => {
+      cy.get('@CUT').ngxFindLabel().contains('Secret');
+    });
+
+    it('should clear the password on unlock', () => {
+      cy.get('@CUT').find('.icon-lock').click();
+      cy.get('@CUT').ngxFindNativeInput().ngxGetValue().should('equal', '');
+      cy.get('@CUT').ngxFindNativeInput().should('not.be.disabled');
+    });
+  });
 });

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix: Use input password type for password fields in JSON editor.
 - Fix: Call to `onTouchedCallback()` should be executed on blur, per `ControlValueAccessor.registerOnTouched` docs
 - Fix: Tabs in `ngx-tabs` are now `type="button"`
+- Enhancement: Add ability to unlock `ngx-input` for passwords
 
 ## 35.6.8 (2021-07-16)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
@@ -78,11 +78,12 @@
         >
         </button>
         <button
-          *ngIf="type === inputTypes.text && unlockable && disabled"
+          *ngIf="(type === inputTypes.text || type === inputTypes.password) && unlockable && disabled"
           class="btn btn-link icon-lock"
-          (click)="disabled = false"
+          (click)="unlock()"
           ngx-tooltip
           [tooltipTitle]="unlockableTooltip"
+          [attr.aria-label]="unlockableTooltip"
         >
         </button>
       </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.html
@@ -71,7 +71,7 @@
           ></i>
         </div>
         <button
-          *ngIf="type === inputTypes.password && passwordToggleEnabled"
+          *ngIf="type === inputTypes.password && passwordToggleEnabled && (!unlockable || !disabled)"
           class="btn btn-link icon-eye"
           title="Toggle Text Visibility"
           (click)="togglePassword()"

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.scss
@@ -180,10 +180,8 @@ $input-placeholder-color: $color-blue-grey-350;
 
       .icon-eye,
       .icon-lock {
-        line-height: 25px;
         top: 0;
         bottom: 0;
-        position: absolute;
         right: 10px;
         cursor: pointer;
         font-size: 0.8rem;

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.spec.ts
@@ -98,6 +98,15 @@ describe('InputComponent', () => {
       component.input.togglePassword();
       expect(component.input.type$.value).toEqual(InputTypes.text);
     });
+
+    it('should clear password on unlock', () => {
+      component.value = 'password';
+      fixture.detectChanges();
+      expect(component.input.type$.value).toEqual(InputTypes.password);
+      component.input.unlock();
+      expect(component.input.value).toEqual('');
+      expect(component.input.disabled).toEqual(false);
+    });
   });
 
   describe('validate', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -343,6 +343,14 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
     this.disabled = coerceBooleanProperty(isDisabled);
   }
 
+  unlock(): void {
+    if (this.type === InputTypes.password) {
+      this.value = '';
+    }
+    this.disabled = false;
+    this.updateInputType();
+  }
+
   incrementValue(event: MouseEvent): void {
     this.increment(event);
     if (!this._spinnerInterval) {

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -220,7 +220,7 @@
   <button class="btn" type="submit">Login</button>
 </form>]]>
   </app-prism>
-  <ngx-input type="password" [label]="'Unlockable Secret'" [(ngModel)]="secretValue" [unlockable]="true" name="input6b">
+  <ngx-input type="password" [label]="'Unlockable Secret'" [(ngModel)]="secretValue" [unlockable]="true" [passwordToggleEnabled]="true" name="input6b">
   </ngx-input>
   <app-prism>
 <![CDATA[<ngx-input
@@ -228,6 +228,7 @@
   [label]="'Unlockable Secret'"
   [(ngModel)]="secretValue"
   [unlockable]="true"
+  [passwordToggleEnabled]="true"
   name="input6b">]]>
   </app-prism>
 </ngx-section>

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -220,6 +220,16 @@
   <button class="btn" type="submit">Login</button>
 </form>]]>
   </app-prism>
+  <ngx-input type="password" [label]="'Unlockable Secret'" [(ngModel)]="secretValue" [unlockable]="true" name="input6b">
+  </ngx-input>
+  <app-prism>
+<![CDATA[<ngx-input
+  type="password"
+  [label]="'Unlockable Secret'"
+  [(ngModel)]="secretValue"
+  [unlockable]="true"
+  name="input6b">]]>
+  </app-prism>
 </ngx-section>
 
 <ngx-section class="shadow" [sectionTitle]="'Numeric'">

--- a/src/app/forms/inputs-page/inputs-page.component.ts
+++ b/src/app/forms/inputs-page/inputs-page.component.ts
@@ -17,6 +17,7 @@ export class InputsPageComponent {
   numericValue: any;
   usernameValue: any;
   passwordValue: any;
+  secretValue = 'secret';
   output: any;
   patternValue = 'Has space';
 


### PR DESCRIPTION
## Summary

Hello there.

I saw #652 and thought I'd have a go at implementing the functionality.

I leveraged the existing `unlockable` input that was already on the `ngx-input` component.

I did make some adjustments to the styles related to toggling password visibility and unlocking input such that both inputs can be used in conjunction if the need arises (i.e. `[unlockable]="true" [passwordToggleEnabled]="true"`). I don't believe these adjustments actually introduce a visual change either.

![image](https://user-images.githubusercontent.com/43751307/136041452-ce928a99-0d93-49bb-bb56-b2b730458de1.png)

![image](https://user-images.githubusercontent.com/43751307/136041472-f7f9e97c-4e62-4c85-8f5c-b6d2c861b9a4.png)


## Checklist

- [x] Added unit tests
- [ ] Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes