### PR TITLE
Fix error thrown from ngx-select on destroy

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enhancement: Add optional forceDownwardOpening option to `ngx-select`
 - Enhancement: Keep `ngx-select` opening downwards when intersecting viewport top
+- Fix: Fix error thrown from `ngx-select` on destroy
 
 ## 35.7.2 (2021-10-14)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -434,16 +434,19 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     if (this.toggleListener) this.toggleListener();
     this.toggle.emit(this.dropdownActive);
 
-    if (state && this.closeOnBodyClick) {
-      this.toggleListener = this._renderer.listen(document.body, 'click', this.onBodyClick.bind(this));
-    }
+    if (this.dropdownActive) {
+      // if open
+      if (this.closeOnBodyClick) {
+        this.toggleListener = this._renderer.listen(document.body, 'click', this.onBodyClick.bind(this));
+      }
 
-    this._cdr.detectChanges();
+      this._cdr.detectChanges();
 
-    if (this.dropdownActive && this.selectDropdown?.inViewport) {
-      this.selectDropdown.inViewport.inViewportAction
-        .pipe(take(1))
-        .subscribe({ next: this.adjustMenuDirection.bind(this) });
+      if (this.selectDropdown?.inViewport) {
+        this.selectDropdown.inViewport.inViewportAction
+          .pipe(take(1))
+          .subscribe({ next: this.adjustMenuDirection.bind(this) });
+      }
     }
 
     this._cdr.markForCheck();


### PR DESCRIPTION
## Summary

- Fix error thrown from `ngx-select` on destroy

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
