### PR TITLE
force dropdowns down for now

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Feature: add `forceDownwardOpening` input to `ngx-dropdown`
+- Fix: set default `forceDownwardOpening` on `ngx-dropdown` to false
+
 ## 35.8.1 (2021-10-26)
 
 - Fix: prevent `ngx-input` buttons from submitting forms

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
@@ -17,6 +17,7 @@ import { DropdownToggleDirective } from './dropdown-toggle.directive';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { InViewportMetadata } from 'ng-in-viewport';
+import { CoerceBooleanProperty } from '../../utils/coerce/coerce-boolean';
 
 @Component({
   exportAs: 'ngxDropdown',
@@ -79,6 +80,8 @@ export class DropdownComponent implements AfterContentInit, OnDestroy {
     this._closeOnMouseLeave = coerceBooleanProperty(val);
   }
 
+  @Input() @CoerceBooleanProperty() forceDownwardOpening = true;
+
   @ContentChild(DropdownToggleDirective) readonly dropdownToggle: DropdownToggleDirective;
   @ContentChild(DropdownMenuDirective) readonly dropdownMenu: DropdownMenuDirective;
 
@@ -113,7 +116,7 @@ export class DropdownComponent implements AfterContentInit, OnDestroy {
     visible: boolean;
   }): void {
     if (!event.visible && this.open) {
-      if (this.isIntersectingBottom(event[InViewportMetadata].entry)) {
+      if (!this.forceDownwardOpening && this.isIntersectingBottom(event[InViewportMetadata].entry)) {
         this.renderer.addClass(this.dropdownMenu.element, 'ngx-dropdown-menu--upwards');
       } else {
         this.renderer.removeClass(this.dropdownMenu.element, 'ngx-dropdown-menu--upwards');


### PR DESCRIPTION
## Summary

- added `forceDownwardOpening` input to `ngx-dropdown`
- set default `forceDownwardOpening` on `ngx-dropdown` to false until #690 

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
