### PR TITLE
emit numbers when using form controls

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -212,7 +212,8 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
   }
 
   get valueAsString(): string {
-    return this._value ? String(this._value) : '';
+    if (this._value == null || typeof this._value === 'undefined') return '';
+    return String(this._value);
   }
 
   get valueAsNumber(): number {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -20,7 +20,8 @@ import {
   NG_VALIDATORS,
   NgModel,
   FormControl,
-  Validators
+  Validators,
+  ValidationErrors
 } from '@angular/forms';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 import { BehaviorSubject } from 'rxjs';
@@ -327,7 +328,7 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
     this.onTouchedCallback();
   }
 
-  validate(c: FormControl) {
+  validate(c: FormControl): ValidationErrors | null {
     if (this.type !== InputTypes.number) {
       return null;
     }

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -207,7 +207,7 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
   set value(val: string | number) {
     if (val !== this._value) {
       this._value = val;
-      this.onChangeCallback(this._value);
+      this.onChangeCallback(this.value);
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -236,7 +236,6 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
     return typeof this.value !== 'undefined' && this.value !== null;
   }
 
-  @HostBinding('class.ng-invalid')
   get isBadInput() {
     const validity = (this.inputControl?.nativeElement as HTMLInputElement)?.validity;
     return validity && validity.badInput;
@@ -333,6 +332,7 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
     }
 
     return {
+      ...(this.isBadInput ? { badInput: true } : null),
       ...Validators.max(this.max)(c),
       ...Validators.min(this.min)(c)
     };


### PR DESCRIPTION
## Summary

* When using ngx-input with form controls the emitted value was a string.... numeric inputs now emit numbers (again).
* Stop `0` values from being emitted as empty string
* Move bad input check to validators to avoid `ExpressionChangedAfterItHasBeenCheckedError`

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
