### PR TITLE
fix default formats

### DIFF
--- a/cypress/integration/forms/date-inputs.spec.ts
+++ b/cypress/integration/forms/date-inputs.spec.ts
@@ -223,7 +223,7 @@ describe('Date/Time', () => {
         .find('.selected-header h1')
         .should('contain.text', 'Thu, Mar 10 2011')
         .should('contain.text', '9:46 pm');
-      cy.get('.day').contains('17').click();  // Note: local
+      cy.get('.day').contains('17').click(); // Note: local
       cy.get('.ngx-date-time-dialog')
         .should('exist')
         .find('.selected-header h1')

--- a/cypress/integration/forms/date-inputs.spec.ts
+++ b/cypress/integration/forms/date-inputs.spec.ts
@@ -151,12 +151,12 @@ describe('Date/Time', () => {
     });
 
     it('has current values', () => {
-      cy.get('@output').should('contain.text', 'Thu Mar 10 2011 21:46:24 GMT-0800 (Pacific Standard Time)'); // Timezone set by env var
+      cy.get('@output').should('contain.text', '2011-03-11T05:46:24.000Z'); // Timezone set by env var
 
       cy.get('@SUT').within(() => {
-        cy.get('ngx-date-time').eq(0).ngxGetValue().should('equal', '03/10/2011 9:46 PM (PST)');
-        cy.get('ngx-date-time').eq(1).ngxGetValue().should('equal', '03/11/2011 5:46 AM (UTC)');
-        cy.get('ngx-date-time').eq(2).ngxGetValue().should('equal', '03/11/2011 2:46 PM (JST)');
+        cy.get('ngx-date-time').eq(0).ngxGetValue().should('equal', '03/10/2011 9:46 PM -08:00');
+        cy.get('ngx-date-time').eq(1).ngxGetValue().should('equal', '03/11/2011 5:46 AM +00:00');
+        cy.get('ngx-date-time').eq(2).ngxGetValue().should('equal', '03/11/2011 2:46 PM +09:00');
       });
     });
 
@@ -169,8 +169,8 @@ describe('Date/Time', () => {
               .closest('body')
               .find('.date-tip-tooltip')
               .should('be.visible')
-              .should('contain.text', '03/10/2011 9:46 PM (PST)')
-              .should('contain.text', '03/11/2011 5:46 AM (UTC)');
+              .should('contain.text', 'Mar 10, 2011 9:46 PM -08:00 (PST)')
+              .should('contain.text', 'Mar 11, 2011 5:46 AM +00:00 (UTC)');
           });
         });
     });

--- a/cypress/integration/forms/date-inputs.spec.ts
+++ b/cypress/integration/forms/date-inputs.spec.ts
@@ -223,10 +223,15 @@ describe('Date/Time', () => {
         .find('.selected-header h1')
         .should('contain.text', 'Thu, Mar 10 2011')
         .should('contain.text', '9:46 pm');
-      cy.get('.day').contains('17').click();
+      cy.get('.day').contains('17').click();  // Note: local
+      cy.get('.ngx-date-time-dialog')
+        .should('exist')
+        .find('.selected-header h1')
+        .should('contain.text', 'Thu, Mar 17 2011')
+        .should('contain.text', '9:46 pm');
       cy.get('.apply-btn').click();
       cy.get('.ngx-date-time-dialog').should('not.exist');
-      cy.get('@output').should('contain.text', 'Mar 17 2011');
+      cy.get('@output').should('contain.text', '2011-03-18T05:46:24.000Z'); // Note: UTC
     });
 
     it('handles invalid input', () => {

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD (unreleased)
 
+- Enhancement: `ngx-date-time` now sets default formats based on precision
 - Enhancement: Improved keyboard accessibility for `ngx-radiobutton` and `ngx-radiobutton-group`
 - Fix: Fixed issues on `ngx-radiobutton` and `ngx-radiobutton-group` with form controls
 - Fix: `ngx-date-time` now works with form controls

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -80,8 +80,8 @@ describe('DateTimeComponent', () => {
       expect(component.appearance).toEqual('legacy');
       expect(component.inputType).toEqual('date');
       expect(component.displayMode).toEqual('timezone');
-      expect(component.format).toEqual('L [(]zz[)]');
-      expect(component.clipFormat).toEqual('L [(]zz[)]');
+      expect(component.format).toEqual('MMM D, YYYY');
+      expect(component.clipFormat).toEqual('MMM D, YYYY');
     });
 
     it('should have reasonable defaults when mode is provided', () => {
@@ -91,8 +91,8 @@ describe('DateTimeComponent', () => {
       expect(component.appearance).toEqual('legacy');
       expect(component.inputType).toEqual('date');
       expect(component.displayMode).toEqual('timezone');
-      expect(component.format).toEqual('L [(]zz[)]');
-      expect(component.clipFormat).toEqual('L [(]zz[)]');
+      expect(component.format).toEqual('MMM D, YYYY');
+      expect(component.clipFormat).toEqual('MMM D, YYYY');
     });
 
     it('should have reasonable defaults when mode is provided', () => {
@@ -147,7 +147,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual(`01/01/${LOCAL_YEAR}`);
+        expect(component.displayValue).toEqual(LOCAL_YEAR);
       });
 
       it('should support month mode', () => {
@@ -158,7 +158,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual(`${LOCAL_MONTH}/01/${LOCAL_YEAR}`);
+        expect(component.displayValue).toEqual(`Jul 1969`);
       });
     });
 
@@ -171,7 +171,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('07/20/1969 (UTC)');
+        expect(component.displayValue).toEqual('Jul 20, 1969');
       });
 
       it('should support Asia/Tokyo', () => {
@@ -182,7 +182,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('07/21/1969 (JST)');
+        expect(component.displayValue).toEqual('Jul 21, 1969');
       });
     });
   });
@@ -256,7 +256,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('07/20/1969 8:17 PM (UTC)');
+        expect(component.displayValue).toEqual('Jul 20, 1969 8:17 PM +00:00');
       });
 
       it('should support Asia/Tokyo', () => {
@@ -267,7 +267,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('07/21/1969 5:17 AM (JST)');
+        expect(component.displayValue).toEqual('Jul 21, 1969 5:17 AM +09:00');
       });
     });
 
@@ -343,7 +343,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('8:17 PM (UTC)');
+        expect(component.displayValue).toEqual('8:17 PM +00:00');
       });
 
       it('should support timezone', () => {
@@ -354,7 +354,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('5:17 AM (JST)');
+        expect(component.displayValue).toEqual('5:17 AM +09:00');
       });
     });
   });
@@ -563,10 +563,11 @@ describe('DateTimeComponent', () => {
     });
 
     it('should complete timezone dates', () => {
+      component.inputType = 'datetime';
       component.timezone = 'America/Los_Angeles';
       component.inputChanged('7/20/1969');
       component.onBlur();
-      expect(component.input.value).toEqual('07/20/1969 (PDT)');
+      expect(component.input.value).toEqual('Jul 20, 1969 12:00 AM -07:00');
       expect(component.value).toBeInstanceOf(Date);
     });
 

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -80,22 +80,22 @@ describe('DateTimeComponent', () => {
       expect(component.appearance).toEqual('legacy');
       expect(component.inputType).toEqual('date');
       expect(component.displayMode).toEqual('timezone');
-      expect(component.format).toEqual('MMM D, YYYY');
-      expect(component.clipFormat).toEqual('MMM D, YYYY');
+      expect(component.format).toEqual('L Z');
+      expect(component.clipFormat).toEqual('L Z');
     });
 
-    it('should have reasonable defaults when mode is provided', () => {
+    it('should have reasonable defaults when mode is timezone', () => {
       component.displayMode = DATE_DISPLAY_TYPES.TIMEZONE;
       fixture.detectChanges();
 
       expect(component.appearance).toEqual('legacy');
       expect(component.inputType).toEqual('date');
       expect(component.displayMode).toEqual('timezone');
-      expect(component.format).toEqual('MMM D, YYYY');
-      expect(component.clipFormat).toEqual('MMM D, YYYY');
+      expect(component.format).toEqual('L Z');
+      expect(component.clipFormat).toEqual('L Z');
     });
 
-    it('should have reasonable defaults when mode is provided', () => {
+    it('should have reasonable defaults when mode is custom', () => {
       component.displayMode = DATE_DISPLAY_TYPES.CUSTOM;
       fixture.detectChanges();
 
@@ -104,6 +104,39 @@ describe('DateTimeComponent', () => {
       expect(component.displayMode).toEqual('custom');
       expect(component.format).toEqual('MMM D, YYYY');
       expect(component.clipFormat).toEqual('MMM D, YYYY');
+    });
+
+    it('should have reasonable defaults when precision is month', () => {
+      component.precision = 'month';
+      fixture.detectChanges();
+
+      expect(component.appearance).toEqual('legacy');
+      expect(component.inputType).toEqual('date');
+      expect(component.displayMode).toEqual('local');
+      expect(component.format).toEqual('MMM YYYY');
+      expect(component.clipFormat).toEqual('MMM YYYY');
+    });
+
+    it('should have reasonable defaults when precision is year', () => {
+      component.precision = 'year';
+      fixture.detectChanges();
+
+      expect(component.appearance).toEqual('legacy');
+      expect(component.inputType).toEqual('date');
+      expect(component.displayMode).toEqual('local');
+      expect(component.format).toEqual('YYYY');
+      expect(component.clipFormat).toEqual('YYYY');
+    });
+
+    it('should have reasonable defaults when precision is hour', () => {
+      component.precision = 'hour';
+      fixture.detectChanges();
+
+      expect(component.appearance).toEqual('legacy');
+      expect(component.inputType).toEqual('datetime');
+      expect(component.displayMode).toEqual('local');
+      expect(component.format).toEqual('L LT');
+      expect(component.clipFormat).toEqual('L LT');
     });
   });
 
@@ -171,7 +204,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('Jul 20, 1969');
+        expect(component.displayValue).toEqual('07/20/1969 +00:00');
       });
 
       it('should support Asia/Tokyo', () => {
@@ -182,7 +215,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('Jul 21, 1969');
+        expect(component.displayValue).toEqual('07/21/1969 +09:00');
       });
     });
   });
@@ -256,7 +289,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('Jul 20, 1969 8:17 PM +00:00');
+        expect(component.displayValue).toEqual('07/20/1969 8:17 PM +00:00');
       });
 
       it('should support Asia/Tokyo', () => {
@@ -267,7 +300,7 @@ describe('DateTimeComponent', () => {
         expect(component.value).toBeTruthy();
         expect(component.value instanceof Date).toBeTruthy();
         expect(typeof component.displayValue === 'string').toBeTruthy();
-        expect(component.displayValue).toEqual('Jul 21, 1969 5:17 AM +09:00');
+        expect(component.displayValue).toEqual('07/21/1969 5:17 AM +09:00');
       });
     });
 
@@ -538,19 +571,19 @@ describe('DateTimeComponent', () => {
 
     it('should round to precision [hour]', () => {
       component.precision = 'hour';
-      component.format = 'shortDateTimeSeconds';
+      component.inputType = 'datetime';
       component.inputChanged(MOON_LANDING);
       component.onBlur();
-      expect(component.input.value).toEqual('Jul 20, 1969 1:00:00 PM');
+      expect(component.input.value).toEqual('07/20/1969 1:00 PM');
       expect(component.value).toBeInstanceOf(Date);
     });
 
     it('should round to precision [minute]', () => {
       component.precision = 'minute';
-      component.format = 'shortDateTimeSeconds';
+      component.inputType = 'datetime';
       component.inputChanged(MOON_LANDING);
       component.onBlur();
-      expect(component.input.value).toEqual('Jul 20, 1969 1:17:00 PM');
+      expect(component.input.value).toEqual('07/20/1969 1:17 PM');
       expect(component.value).toBeInstanceOf(Date);
     });
 
@@ -567,7 +600,7 @@ describe('DateTimeComponent', () => {
       component.timezone = 'America/Los_Angeles';
       component.inputChanged('7/20/1969');
       component.onBlur();
-      expect(component.input.value).toEqual('Jul 20, 1969 12:00 AM -07:00');
+      expect(component.input.value).toEqual('07/20/1969 12:00 AM -07:00');
       expect(component.value).toBeInstanceOf(Date);
     });
 

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -153,10 +153,9 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
   // date, time, dateTime
   @Input()
   get inputType(): string {
-    if (!this._inputType) {
-      return DateTimeType.date;
-    }
-    return this._inputType;
+    if (this._inputType) return this._inputType;
+    if (this.precision === 'hour' || this.precision === 'minute') return DateTimeType.datetime;
+    return DateTimeType.date;
   }
   set inputType(val: string) {
     this._inputType = val;
@@ -197,15 +196,15 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
           case DateTimeType.date:
             switch (this.precision) {
               case 'month':
-                return DATE_DISPLAY_FORMATS.dateMonth;
+                return DATE_DISPLAY_FORMATS.timezoneDateMonth;
               case 'year':
-                return DATE_DISPLAY_FORMATS.dateYear;
+                return DATE_DISPLAY_FORMATS.timezoneDateYear;
             }
-            return DATE_DISPLAY_FORMATS.date;
+            return DATE_DISPLAY_FORMATS.timezoneDate;
           case DateTimeType.time:
-            return DATE_DISPLAY_FORMATS.time;
+            return DATE_DISPLAY_FORMATS.timezoneTime;
         }
-        return DATE_DISPLAY_FORMATS.dateTime;
+        return DATE_DISPLAY_FORMATS.timezoneDateTime;
       case DATE_DISPLAY_TYPES.LOCAL:
         switch (this.inputType) {
           case DateTimeType.date:
@@ -240,6 +239,20 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
   set format(val: string) {
     this._format = val;
     this.update();
+  }
+
+  @Input()
+  set displayFormat(val: string) {
+    this._displayFormat = val;
+  }
+  get displayFormat(): string {
+    return (
+      DATE_DISPLAY_FORMATS[this._displayFormat] ||
+      this._displayFormat ||
+      DATE_DISPLAY_FORMATS[this._format] ||
+      this._format ||
+      DATE_DISPLAY_FORMATS.fullDateTime
+    );
   }
 
   @Input()
@@ -351,6 +364,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
   private _value: Date | string;
   private _displayValue = '';
   private _format: string;
+  private _displayFormat: string;
   private _inputType: string;
   private _maxDate: Date | string;
   private _minDate: Date | string;
@@ -559,7 +573,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
     }
     const timezone =
       this.timezone || (this.displayMode === DATE_DISPLAY_TYPES.TIMEZONE ? moment.tz.guess() : undefined);
-    let m = timezone ? moment.tz(date, inputFormats, this.timezone) : moment(date, inputFormats);
+    let m = timezone ? moment.tz(date, inputFormats, timezone) : moment(date, inputFormats);
     m = this.precision ? this.roundTo(m, this.precision) : m;
     return m;
   }
@@ -595,7 +609,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
       const tz = this.timezones[key] || localTimezone;
       const date = mdate.clone().tz(tz);
       const clip = date.format(this.clipFormat);
-      const display = date.format(this.format);
+      const display = date.format(this.displayFormat);
       this.timeValues[key] = {
         key,
         clip,

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -96,7 +96,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
   @Input()
   set value(val: Date | string) {
     if (!val && !this._value) {
-      val = this._value = null; // Match falsey values
+      val = this._value = null; // Match falsely values
     }
 
     let isSame = val === this._value;
@@ -191,28 +191,48 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
   get format(): string {
     if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
 
-    if (this.displayMode === DATE_DISPLAY_TYPES.LOCAL) {
-      if (this.inputType === DateTimeType.date) {
-        return DATE_DISPLAY_FORMATS.localeDate;
-      } else if (this.inputType === DateTimeType.time) {
-        return DATE_DISPLAY_FORMATS.localeTime;
-      }
-      return DATE_DISPLAY_FORMATS.localeDateTime;
+    switch (this.displayMode) {
+      case DATE_DISPLAY_TYPES.TIMEZONE:
+        switch (this.inputType) {
+          case DateTimeType.date:
+            switch (this.precision) {
+              case 'month':
+                return DATE_DISPLAY_FORMATS.dateMonth;
+              case 'year':
+                return DATE_DISPLAY_FORMATS.dateYear;
+            }
+            return DATE_DISPLAY_FORMATS.date;
+          case DateTimeType.time:
+            return DATE_DISPLAY_FORMATS.time;
+        }
+        return DATE_DISPLAY_FORMATS.dateTime;
+      case DATE_DISPLAY_TYPES.LOCAL:
+        switch (this.inputType) {
+          case DateTimeType.date:
+            switch (this.precision) {
+              case 'month':
+                return DATE_DISPLAY_FORMATS.dateMonth;
+              case 'year':
+                return DATE_DISPLAY_FORMATS.dateYear;
+            }
+            return DATE_DISPLAY_FORMATS.localeDate;
+          case DateTimeType.time:
+            return DATE_DISPLAY_FORMATS.localeTime;
+        }
+        return DATE_DISPLAY_FORMATS.localeDateTime;
     }
 
-    if (this.displayMode === DATE_DISPLAY_TYPES.TIMEZONE) {
-      if (this.inputType === DateTimeType.date) {
-        return DATE_DISPLAY_FORMATS.userDate;
-      } else if (this.inputType === DateTimeType.time) {
-        return DATE_DISPLAY_FORMATS.userTime;
-      }
-      return DATE_DISPLAY_FORMATS.userDateTime;
-    }
-
-    if (this.inputType === DateTimeType.date) {
-      return DATE_DISPLAY_FORMATS.date;
-    } else if (this.inputType === DateTimeType.time) {
-      return DATE_DISPLAY_FORMATS.time;
+    switch (this.inputType) {
+      case DateTimeType.date:
+        switch (this.precision) {
+          case 'month':
+            return DATE_DISPLAY_FORMATS.dateMonth;
+          case 'year':
+            return DATE_DISPLAY_FORMATS.dateYear;
+        }
+        return DATE_DISPLAY_FORMATS.date;
+      case DateTimeType.time:
+        return DATE_DISPLAY_FORMATS.time;
     }
 
     return DATE_DISPLAY_FORMATS.dateTime;
@@ -532,6 +552,7 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
       /* istanbul ignore next */
       date = isNaN(date.getTime()) ? date.toString() : date.toISOString();
     }
+    // Ensures that the input formats includes the display format
     const inputFormats = [...this.inputFormats];
     if (this.format && !inputFormats.includes(this.format)) {
       inputFormats.unshift(this.format);

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -96,6 +96,10 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
 
   @Input()
   set value(val: Date | string) {
+    if (typeof val === 'string') {
+      val = val.trim();
+    }
+
     if (!val && !this._value) {
       val = this._value = null; // Match falsely values
     }
@@ -107,12 +111,15 @@ export class DateTimeComponent implements OnDestroy, ControlValueAccessor, Valid
     const date = this.parseDate(val);
     if (val && date.isValid()) {
       isDate = true;
-      const sameDiff: moment.unitOfTime.StartOf = this.precision
-        ? this.precision
-        : this.inputType === DateTimeType.date
-        ? 'day'
-        : 'second';
-      isSame = this._value ? date.isSame(this._value, sameDiff) : false;
+      if (this._value instanceof Date) {
+        // only compare precision if old values is a date
+        const sameDiff: moment.unitOfTime.StartOf = this.precision
+          ? this.precision
+          : this.inputType === DateTimeType.date
+          ? 'day'
+          : 'second';
+        isSame = this._value ? date.isSame(this._value, sameDiff) : false;
+      }
     }
 
     if (!isSame) {

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/date-formats.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/date-formats.enum.ts
@@ -2,23 +2,22 @@ import moment from 'moment';
 
 export const DATE_DISPLAY_FORMATS = {
   // for input
-  shortDate: 'MMM D, YYYY', // Jan 1, 2000
+  shortDate: 'M/D/YYYY', // 1/1/2020
   shortTime: 'h:mm A', // 9:00 PM
-  shortDateTime: 'MMM D, YYYY h:mm A', // Jan 1, 2000 9:00 PM
-  shortDateTimeSeconds: 'MMM D, YYYY h:mm:ss A', // Jan 1, 2000 9:00 PM
+  shortDateTime: 'M/D/YYYY h:mm A', // Jan 1, 2000 9:00 PM
+  shortDateTimeSeconds: 'M/D/YYYY h:mm:ss A', // Jan 1, 2000 9:00 PM
 
-  // for display
   date: 'MMM D, YYYY', // Jan 1, 2000
-  time: 'h:mm A Z', // 9:00 PM -07:00
-  dateTime: 'MMM D, YYYY h:mm A Z', // Jan 1, 2000 9:00 PM -07:00
-  dateTimeSeconds: 'MMM D, YYYY h:mm:ss A Z', // Jan 1, 2000 9:00 PM -07:00
+  time: 'h:mm A', // 9:00 PM
+  dateTime: 'MMM D, YYYY h:mm A', // Jan 1, 2000 9:00 PM
+  dateTimeSeconds: 'MMM D, YYYY h:mm:ss A', // Jan 1, 2000 9:00 PM
 
   // Date min-modes
   dateMonth: 'MMM YYYY', // Jan 2000
   dateYear: 'YYYY', // 2000
 
   // full display
-  fullDate: 'ddd, MMM D, YYYY', // Sat, Jan 1, 2000
+  fullDate: 'ddd, MMM D, YYYY Z [(]zz[)]', // Sat, Jan 1, 2000 -07:00 (MST)
   fullTime: 'h:mm A Z [(]zz[)]', // 9:00 PM -07:00 (MST)
   fullDateTime: 'ddd, MMM D, YYYY h:mm A Z [(]zz[)]', // Tue, Jan 1, 2000 9:00 PM -07:00 (MST)
 
@@ -28,9 +27,13 @@ export const DATE_DISPLAY_FORMATS = {
   localeTime: 'LT', // 8:30 PM
 
   // Timezone
-  userDate: 'L [(]zz[)]', // 09/04/1986
-  userDateTime: 'L LT [(]zz[)]', // 09/04/1986 8:30 PM
-  userTime: 'LT [(]zz[)]', // 8:30 PM
+  timezoneDate: 'L Z', // 09/04/1986 -07:00
+  timezoneDateTime: 'L LT Z', // 09/04/1986 8:30 PM -07:00
+  timezoneTime: 'LT Z', // 8:30 PM -07:00
+
+  // Date min-modes
+  timezoneDateMonth: 'MMM YYYY Z', // Jan 2000 -07:00
+  timezoneDateYear: 'YYYY Z', // 2000 -07:00
 
   // Locale (civil) time
   locale: 'LLL',
@@ -46,6 +49,12 @@ export const DATE_DISPLAY_INPUT_FORMATS: Array<string | moment.MomentBuiltinForm
   DATE_DISPLAY_FORMATS.shortDateTimeSeconds,
   DATE_DISPLAY_FORMATS.shortDate,
   DATE_DISPLAY_FORMATS.shortTime,
+  DATE_DISPLAY_FORMATS.timezoneDateTime,
+  DATE_DISPLAY_FORMATS.timezoneDate,
+  DATE_DISPLAY_FORMATS.timezoneTime,
+  DATE_DISPLAY_FORMATS.localeDateTime,
+  DATE_DISPLAY_FORMATS.localeDate,
+  DATE_DISPLAY_FORMATS.localeTime,
   'MM/DD',
   'MM/DD/YYYY',
   'M/DD/YYYY',

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/date-formats.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/date-formats.enum.ts
@@ -43,6 +43,7 @@ export const DATE_DISPLAY_FORMATS = {
 
 export const DATE_DISPLAY_INPUT_FORMATS: Array<string | moment.MomentBuiltinFormat> = [
   DATE_DISPLAY_FORMATS.dateTime,
+  DATE_DISPLAY_FORMATS.dateTimeSeconds,
   DATE_DISPLAY_FORMATS.date,
   DATE_DISPLAY_FORMATS.time,
   DATE_DISPLAY_FORMATS.shortDateTime,

--- a/src/app/components/time-display-page/time-display-page.component.html
+++ b/src/app/components/time-display-page/time-display-page.component.html
@@ -31,6 +31,8 @@
 </ngx-section>
 
 <ngx-section sectionTitle="Time Zones">
+  <output>{{ localString | json }}</output>
+  
   <div class="example">
     <h4>By default inputs are assumed local date/time, display TZ can be defined</h4>
     <ngx-time [datetime]="localString" displayTimeZone="Asia/Tokyo"></ngx-time>

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -97,7 +97,8 @@
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Date/Time Input">
-  Value: {{ dateTime }}
+  <label>Value: </label>
+  <output>{{ date | json }}</output>
 
   <ngx-date-time
     name="datetime-input"
@@ -119,7 +120,8 @@
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="TimeZones">
-  <label>Current Value:</label> <output>{{ eventDate }}</output>
+  <label>Current Value:</label>
+  <output>{{ eventDate | json }}</output>
 
   <ngx-date-time
     name="timezone-local"
@@ -196,13 +198,22 @@
 >
 </ngx-date-time>]]>
   </app-prism>
+
+  <ngx-date-time
+  name="time-input2"
+  inputType="time"
+  displayMode="timezone"
+  label="Time of attack"
+  [(value)]="time"
+  >
+  </ngx-date-time>
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Precision">
-  Current Value: {{ precisionDate | json }}
+  <label>Current Value:</label>
+  <output>{{ precisionDate | json }}</output>
 
   <ngx-date-time
-    inputType="date"
     label="Year"
     precision="year"
     [(value)]="precisionDate"
@@ -210,7 +221,6 @@
   </ngx-date-time>
 
   <ngx-date-time
-    inputType="date"
     label="Month"
     precision="month"
     [(value)]="precisionDate"
@@ -218,7 +228,6 @@
   </ngx-date-time>
 
   <ngx-date-time
-    inputType="datetime"
     label="Hour"
     precision="hour"
     [(value)]="precisionDate"
@@ -226,7 +235,6 @@
   </ngx-date-time>
 
   <ngx-date-time
-    inputType="datetime"
     label="Minutes"
     precision="minute"
     [(value)]="precisionDate"
@@ -235,7 +243,6 @@
 
   <app-prism>
 <![CDATA[<ngx-date-time
-  inputType="date"
   label="Year"
   precision="year"
   [(value)]="precisionDate"
@@ -243,7 +250,6 @@
 </ngx-date-time>
 
   <ngx-date-time
-  inputType="date"
   label="Month"
   precision="month"
   [(value)]="precisionDate"
@@ -251,7 +257,6 @@
 </ngx-date-time>
 
   <ngx-date-time
-  inputType="datetime"
   label="Hour"
   precision="hour"
   [(value)]="precisionDate"
@@ -259,7 +264,6 @@
 </ngx-date-time>
 
   <ngx-date-time
-  inputType="datetime"
   label="Minutes"
   precision="minute"
   [(value)]="precisionDate"
@@ -269,7 +273,8 @@
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Autosize">
-  Current Value: {{ curDate2 | json }}
+  <label>Current Value:</label>
+  <output>{{ curDate2 | json }}</output>
 
   <br />
 

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -206,7 +206,6 @@
     label="Year"
     precision="year"
     [(value)]="precisionDate"
-    format="dateYear"
   >
   </ngx-date-time>
 
@@ -215,7 +214,6 @@
     label="Month"
     precision="month"
     [(value)]="precisionDate"
-    format="dateMonth"
   >
   </ngx-date-time>
 
@@ -224,7 +222,6 @@
     label="Hour"
     precision="hour"
     [(value)]="precisionDate"
-    format="shortDateTime"
   >
   </ngx-date-time>
 
@@ -233,7 +230,6 @@
     label="Minutes"
     precision="minute"
     [(value)]="precisionDate"
-    format="shortDateTimeSeconds"
   >
   </ngx-date-time>
 
@@ -243,7 +239,6 @@
   label="Year"
   precision="year"
   [(value)]="precisionDate"
-  format="dateYear"
 >
 </ngx-date-time>
 
@@ -252,7 +247,6 @@
   label="Month"
   precision="month"
   [(value)]="precisionDate"
-  format="dateMonth"
 >
 </ngx-date-time>
 
@@ -261,7 +255,6 @@
   label="Hour"
   precision="hour"
   [(value)]="precisionDate"
-  format="shortDateTime"
 >
 </ngx-date-time>
 
@@ -270,7 +263,6 @@
   label="Minutes"
   precision="minute"
   [(value)]="precisionDate"
-  format="shortDateTimeSeconds"
 >
 </ngx-date-time>]]>
   </app-prism>


### PR DESCRIPTION
## Summary

* change default format for timezone date/time to be parsable
* all default formats based on precision

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
