### PR TITLE
consistant formats for ngx-time

### DIFF
--- a/cypress/integration/components/time-display.spec.ts
+++ b/cypress/integration/components/time-display.spec.ts
@@ -2,11 +2,6 @@ describe('Date/Time Display', () => {
   const UTC = '2011-03-11T05:46:24.000Z';
 
   const LA_LOCAL = '03/10/2011 9:46 PM';
-  const TOKYO_LOCAL = '03/11/2011 2:46 PM';
-
-  // const TOKYO = '03/11/2011 2:46 PM +09:00';
-  // const GMT = '03/11/2011 5:46 AM +00:00';
-  const LA = `${LA_LOCAL} -08:00`; // America/Los_Angeles should be passed as TZ env var to cypress
 
   const TOKYO_DISPLAY = 'Fri, Mar 11, 2011 2:46 PM +09:00 (JST)';
   const GMT_DISPLAY = 'Fri, Mar 11, 2011 5:46 AM +00:00 (UTC)';
@@ -27,7 +22,7 @@ describe('Date/Time Display', () => {
       cy.get('@CUT')
         .first()
         .whileHovering(() => {
-          cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
+          cy.get('time').should('contain.text', LA_DISPLAY).should('have.attr', 'datetime', UTC);
           cy.root()
             .closest('body')
             .find('ngx-tooltip-content')
@@ -75,7 +70,7 @@ describe('Date/Time Display', () => {
       cy.get('@CUT')
         .first()
         .whileHovering(() => {
-          cy.get('time').should('contain.text', TOKYO_LOCAL).should('have.attr', 'datetime', UTC);
+          cy.get('time').should('contain.text', TOKYO_DISPLAY).should('have.attr', 'datetime', UTC);
           cy.root()
             .closest('body')
             .find('ngx-tooltip-content')
@@ -88,7 +83,7 @@ describe('Date/Time Display', () => {
       cy.get('@CUT')
         .eq(1)
         .whileHovering(() => {
-          cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
+          cy.get('time').should('contain.text', LA_DISPLAY).should('have.attr', 'datetime', UTC);
           cy.root()
             .closest('body')
             .find('ngx-tooltip-content')
@@ -101,7 +96,7 @@ describe('Date/Time Display', () => {
       cy.get('@CUT')
         .eq(2)
         .whileHovering(() => {
-          cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
+          cy.get('time').should('contain.text', LA_DISPLAY).should('have.attr', 'datetime', UTC);
           cy.root()
             .closest('body')
             .find('ngx-tooltip-content')
@@ -121,7 +116,7 @@ describe('Date/Time Display', () => {
       cy.get('@CUT')
         .first()
         .whileHovering(() => {
-          cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
+          cy.get('time').should('contain.text', LA_DISPLAY).should('have.attr', 'datetime', UTC);
           cy.get('.ngx-time__container')
             .invoke('attr', 'title')
             .should('contain', LA_DISPLAY)
@@ -133,7 +128,7 @@ describe('Date/Time Display', () => {
       cy.get('@CUT')
         .eq(1)
         .whileHovering(() => {
-          cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
+          cy.get('time').should('contain.text', LA_DISPLAY).should('have.attr', 'datetime', UTC);
           cy.root()
             .closest('body')
             .find('ngx-tooltip-content')

--- a/cypress/integration/components/time-display.spec.ts
+++ b/cypress/integration/components/time-display.spec.ts
@@ -28,7 +28,11 @@ describe('Date/Time Display', () => {
         .first()
         .whileHovering(() => {
           cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
+          cy.root()
+            .closest('body')
+            .find('ngx-tooltip-content')
+            .should('contain.text', LA_DISPLAY)
+            .and('contain.text', GMT_DISPLAY);
         });
     });
   });
@@ -44,7 +48,11 @@ describe('Date/Time Display', () => {
         .eq(0)
         .whileHovering(() => {
           cy.get('time').should('contain.text', 'years ago').should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
+          cy.root()
+            .closest('body')
+            .find('ngx-tooltip-content')
+            .should('contain.text', LA_DISPLAY)
+            .and('contain.text', GMT_DISPLAY);
         });
     });
 
@@ -68,7 +76,11 @@ describe('Date/Time Display', () => {
         .first()
         .whileHovering(() => {
           cy.get('time').should('contain.text', TOKYO_LOCAL).should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
+          cy.root()
+            .closest('body')
+            .find('ngx-tooltip-content')
+            .should('contain.text', LA_DISPLAY)
+            .and('contain.text', GMT_DISPLAY);
         });
     });
 
@@ -77,7 +89,11 @@ describe('Date/Time Display', () => {
         .eq(1)
         .whileHovering(() => {
           cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
+          cy.root()
+            .closest('body')
+            .find('ngx-tooltip-content')
+            .should('contain.text', LA_DISPLAY)
+            .and('contain.text', GMT_DISPLAY);
         });
     });
 
@@ -86,7 +102,11 @@ describe('Date/Time Display', () => {
         .eq(2)
         .whileHovering(() => {
           cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
+          cy.root()
+            .closest('body')
+            .find('ngx-tooltip-content')
+            .should('contain.text', LA_DISPLAY)
+            .and('contain.text', GMT_DISPLAY);
         });
     });
   });
@@ -102,7 +122,10 @@ describe('Date/Time Display', () => {
         .first()
         .whileHovering(() => {
           cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
-          cy.get('.ngx-time__container').invoke('attr', 'title').should('contain', LA_DISPLAY).and('contain', GMT_DISPLAY);
+          cy.get('.ngx-time__container')
+            .invoke('attr', 'title')
+            .should('contain', LA_DISPLAY)
+            .and('contain', GMT_DISPLAY);
         });
     });
 

--- a/cypress/integration/components/time-display.spec.ts
+++ b/cypress/integration/components/time-display.spec.ts
@@ -1,8 +1,16 @@
 describe('Date/Time Display', () => {
   const UTC = '2011-03-11T05:46:24.000Z';
-  const TOKYO = 'Friday, March 11, 2011 2:46 PM';
-  const GMT = 'Friday, March 11, 2011 5:46 AM';
-  const LA = 'Thursday, March 10, 2011 9:46 PM'; // America/Los_Angeles should be passed as TZ env var to cypress
+
+  const LA_LOCAL = '03/10/2011 9:46 PM';
+  const TOKYO_LOCAL = '03/11/2011 2:46 PM';
+
+  // const TOKYO = '03/11/2011 2:46 PM +09:00';
+  // const GMT = '03/11/2011 5:46 AM +00:00';
+  const LA = `${LA_LOCAL} -08:00`; // America/Los_Angeles should be passed as TZ env var to cypress
+
+  const TOKYO_DISPLAY = 'Fri, Mar 11, 2011 2:46 PM +09:00 (JST)';
+  const GMT_DISPLAY = 'Fri, Mar 11, 2011 5:46 AM +00:00 (UTC)';
+  const LA_DISPLAY = 'Thu, Mar 10, 2011 9:46 PM -08:00 (PST)'; // America/Los_Angeles should be passed as TZ env var to cypress
 
   before(() => {
     cy.visit('/time-display');
@@ -20,40 +28,47 @@ describe('Date/Time Display', () => {
         .first()
         .whileHovering(() => {
           cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA).and('contain.text', GMT);
+          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
         });
+    });
+  });
+
+  describe('Modes', () => {
+    beforeEach(() => {
+      cy.get('ngx-section').eq(2).as('SUT');
+      cy.get('@SUT').find('ngx-time').as('CUT');
     });
 
     it('Human', () => {
       cy.get('@CUT')
-        .eq(1)
+        .eq(0)
         .whileHovering(() => {
           cy.get('time').should('contain.text', 'years ago').should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA).and('contain.text', GMT);
+          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
         });
     });
 
     it('Local', () => {
       cy.get('@CUT')
-        .eq(2)
+        .eq(1)
         .whileHovering(() => {
-          cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', '2011-03-10T21:46:24.000');
+          cy.get('time').should('contain.text', LA_LOCAL).should('have.attr', 'datetime', '2011-03-10T21:46:24.000');
         });
     });
   });
 
   describe('Time Zones', () => {
     beforeEach(() => {
-      cy.get('ngx-section').eq(1).as('SUT');
+      cy.get('ngx-section').eq(4).as('SUT');
       cy.get('@SUT').find('ngx-time').as('CUT');
     });
 
-    it('Default Date-Time', () => {
+    it('Specific Timezone', () => {
       cy.get('@CUT')
         .first()
         .whileHovering(() => {
-          cy.get('time').should('contain.text', 'Friday, March 11, 2011 2:46 PM').should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA).and('contain.text', GMT);
+          cy.get('time').should('contain.text', TOKYO_LOCAL).should('have.attr', 'datetime', UTC);
+          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
         });
     });
 
@@ -62,7 +77,7 @@ describe('Date/Time Display', () => {
         .eq(1)
         .whileHovering(() => {
           cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA).and('contain.text', GMT);
+          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
         });
     });
 
@@ -71,14 +86,14 @@ describe('Date/Time Display', () => {
         .eq(2)
         .whileHovering(() => {
           cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
-          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA).and('contain.text', GMT);
+          cy.root().closest('body').find('ngx-tooltip-content').should('contain.text', LA_DISPLAY).and('contain.text', GMT_DISPLAY);
         });
     });
   });
 
   describe('Popups', () => {
     beforeEach(() => {
-      cy.get('ngx-section').eq(2).as('SUT');
+      cy.get('ngx-section').eq(5).as('SUT');
       cy.get('@SUT').find('ngx-time').as('CUT');
     });
 
@@ -87,7 +102,7 @@ describe('Date/Time Display', () => {
         .first()
         .whileHovering(() => {
           cy.get('time').should('contain.text', LA).should('have.attr', 'datetime', UTC);
-          cy.get('.ngx-time__container').invoke('attr', 'title').should('contain', LA).and('contain', GMT);
+          cy.get('.ngx-time__container').invoke('attr', 'title').should('contain', LA_DISPLAY).and('contain', GMT_DISPLAY);
         });
     });
 
@@ -99,9 +114,9 @@ describe('Date/Time Display', () => {
           cy.root()
             .closest('body')
             .find('ngx-tooltip-content')
-            .should('contain.text', TOKYO)
-            .should('contain.text', LA)
-            .and('contain.text', GMT);
+            .should('contain.text', TOKYO_DISPLAY)
+            .should('contain.text', LA_DISPLAY)
+            .and('contain.text', GMT_DISPLAY);
         });
     });
   });

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -102,8 +102,8 @@ describe('DateTimeComponent', () => {
       expect(component.appearance).toEqual('legacy');
       expect(component.inputType).toEqual('date');
       expect(component.displayMode).toEqual('custom');
-      expect(component.format).toEqual('MMM D, YYYY');
-      expect(component.clipFormat).toEqual('MMM D, YYYY');
+      expect(component.format).toEqual('ll');
+      expect(component.clipFormat).toEqual('ll');
     });
 
     it('should have reasonable defaults when precision is month', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -3,10 +3,10 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import moment from 'moment-timezone';
 import { MomentModule } from 'ngx-moment';
+import { DATE_DISPLAY_TYPES } from '../../enums/date-formats.enum';
 import { PipesModule } from '../../pipes/pipes.module';
 import { InjectionService } from '../../services/injection/injection.service';
 import { DialogModule } from '../dialog/dialog.module';
-import { DATE_DISPLAY_TYPES } from '../time-display/date-formats.enum';
 
 import { DateTimeComponent } from './date-time.component';
 

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -200,11 +200,11 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
   }
 
   @Input()
-  set displayFormat(val: string) {
-    this._displayFormat = val;
+  set tooltipFormat(val: string) {
+    this._tooltipFormat = val;
   }
-  get displayFormat(): string {
-    if (this._displayFormat) return DATE_DISPLAY_FORMATS[this._displayFormat] || this._displayFormat;
+  get tooltipFormat(): string {
+    if (this._tooltipFormat) return DATE_DISPLAY_FORMATS[this._tooltipFormat] || this._tooltipFormat;
     if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
 
     return defaultDisplayFormat(this.displayMode, this.inputType as DateTimeType, this.precision);
@@ -310,7 +310,7 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
   private _value: Date | string;
   private _displayValue = '';
   private _format: string;
-  private _displayFormat: string;
+  private _tooltipFormat: string;
   private _inputType: string;
   private _displayMode: DATE_DISPLAY_TYPES;
   private _clipFormat: string;
@@ -559,7 +559,7 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
       const tz = this.timezones[key] || localTimezone;
       const date = mdate.clone().tz(tz);
       const clip = date.format(this.clipFormat);
-      const display = date.format(this.displayFormat);
+      const display = date.format(this.tooltipFormat);
       this.timeValues[key] = {
         key,
         clip,

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -12,7 +12,8 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   HostBinding,
-  OnChanges
+  OnChanges,
+  SimpleChanges
 } from '@angular/core';
 import {
   ControlValueAccessor,
@@ -245,7 +246,8 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
     this._clipFormat = val;
   }
   get clipFormat(): string {
-    return DATE_DISPLAY_FORMATS[this._clipFormat] || this._clipFormat || this.format;
+    if (this._clipFormat) return DATE_DISPLAY_FORMATS[this._clipFormat] || this._clipFormat;
+    return this.format;
   }
 
   @Input() requiredIndicator: string | boolean = '*';
@@ -326,8 +328,10 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
     this.close();
   }
 
-  ngOnChanges() {
-    this.update();
+  ngOnChanges(changes: SimpleChanges) {
+    if (!('value' in changes)) {
+      this.update();
+    }
   }
 
   writeValue(val: any): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.html
@@ -10,12 +10,12 @@
   [attr.title]="tooltipDisabled && hasPopup ? titleValue : null"
 >
   <ng-container *ngIf="!dateInvalid">
-    <ng-container [ngSwitch]="displayMode">
+    <ng-container [ngSwitch]="mode">
       <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.HUMAN">
         {{ internalDatetime | amTimeAgo }}
       </ng-container>
       <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.TIMEZONE">
-        {{ internalDatetime | amTimeZone: displayTimeZone | amDateFormat: format  }}
+        {{ internalDatetime | amTimeZone: timezone | amDateFormat: format  }}
       </ng-container>
       <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.CUSTOM">{{ datetime | amDateFormat: format }}</ng-container>
       <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.LOCAL">{{ datetime | amDateFormat: format }}</ng-container>

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.html
@@ -15,10 +15,10 @@
         {{ internalDatetime | amTimeAgo }}
       </ng-container>
       <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.TIMEZONE">
-        {{ internalDatetime | amTimeZone: displayTimeZone | amDateFormat: displayFormat  }}
+        {{ internalDatetime | amTimeZone: displayTimeZone | amDateFormat: format  }}
       </ng-container>
-      <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.CUSTOM">{{ datetime | amDateFormat: displayFormat }}</ng-container>
-      <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.LOCAL">{{ datetime | amDateFormat: displayFormat }}</ng-container>
+      <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.CUSTOM">{{ datetime | amDateFormat: format }}</ng-container>
+      <ng-container *ngSwitchCase="DATE_DISPLAY_TYPES.LOCAL">{{ datetime | amDateFormat: format }}</ng-container>
     </ng-container>
   </ng-container>
   <ng-container *ngIf="dateInvalid">

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.spec.ts
@@ -386,9 +386,9 @@ describe('NgxTimeDisplayComponent', () => {
   it('should set defaults', () => {
     expect(component.datetime).toBeDefined(Date);
     expect(component.defaultInputTimeZone).toBeUndefined();
-    expect(component.displayTimeZone).toBeUndefined();
-    expect(component.displayMode).toBe('timezone');
-    expect(component.displayFormat).toBe('LLLL');
+    expect(component.timezone).toBeUndefined();
+    expect(component.mode).toBe('timezone');
+    expect(component.tooltipFormat).toBe('LLLL');
     expect(component.clipFormat).toBe('LLLL');
     expect(component.timezones.UTC).toEqual('Etc/UTC');
     expect(component.timezones.Local).toEqual('');
@@ -428,7 +428,7 @@ describe('NgxTimeDisplayComponent', () => {
     it('when user date provided', () => {
       const date = '2000-02-05 8:30 AM';
       component.datetime = new Date(date); // note: browser timezone
-      component.displayFormat = 'fullDateTime';
+      component.tooltipFormat = 'fullDateTime';
 
       component.ngOnChanges();
       fixture.detectChanges();
@@ -450,7 +450,7 @@ describe('NgxTimeDisplayComponent', () => {
 
     it('when iso date provided', () => {
       component.datetime = new Date(MOON_LANDING); // note: browser UTC
-      component.displayFormat = 'fullDateTime';
+      component.tooltipFormat = 'fullDateTime';
 
       component.ngOnChanges();
       fixture.detectChanges();
@@ -484,7 +484,7 @@ describe('NgxTimeDisplayComponent', () => {
     it('should handle bad timezone', () => {
       (moment as any).suppressDeprecationWarnings = true;
       component.datetime = new Date();
-      component.displayFormat = 'fullDateTime';
+      component.tooltipFormat = 'fullDateTime';
 
       component.timezones = {
         Test: 'Timbuktu'

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.spec.ts
@@ -388,8 +388,8 @@ describe('NgxTimeDisplayComponent', () => {
     expect(component.defaultInputTimeZone).toBeUndefined();
     expect(component.timezone).toBeUndefined();
     expect(component.mode).toBe('timezone');
-    expect(component.tooltipFormat).toBe('LLLL');
-    expect(component.clipFormat).toBe('LLLL');
+    expect(component.tooltipFormat).toBe('ddd, MMM D, YYYY h:mm A Z [(]zz[)]');
+    expect(component.clipFormat).toBe('ddd, MMM D, YYYY h:mm A Z [(]zz[)]');
     expect(component.timezones.UTC).toEqual('Etc/UTC');
     expect(component.timezones.Local).toEqual('');
   });

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.spec.ts
@@ -386,9 +386,9 @@ describe('NgxTimeDisplayComponent', () => {
   it('should set defaults', () => {
     expect(component.datetime).toBeDefined(Date);
     expect(component.defaultInputTimeZone).toBeUndefined();
-    expect(component.timezone).toBeUndefined();
+    expect(component.timezone).toEqual('America/Los_Angeles');
     expect(component.mode).toBe('timezone');
-    expect(component.tooltipFormat).toBe('ddd, MMM D, YYYY h:mm A Z [(]zz[)]');
+    expect(component.tooltipFormat).toBe('llll Z [(]zz[)]');
     expect(component.clipFormat).toBe('L LT Z');
     expect(component.timezones.UTC).toEqual('Etc/UTC');
     expect(component.timezones.Local).toEqual('');

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.spec.ts
@@ -389,7 +389,7 @@ describe('NgxTimeDisplayComponent', () => {
     expect(component.timezone).toBeUndefined();
     expect(component.mode).toBe('timezone');
     expect(component.tooltipFormat).toBe('ddd, MMM D, YYYY h:mm A Z [(]zz[)]');
-    expect(component.clipFormat).toBe('ddd, MMM D, YYYY h:mm A Z [(]zz[)]');
+    expect(component.clipFormat).toBe('L LT Z');
     expect(component.timezones.UTC).toEqual('Etc/UTC');
     expect(component.timezones.Local).toEqual('');
   });

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
@@ -83,7 +83,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   }
   get clipFormat(): string {
     if (this._clipFormat) return DATE_DISPLAY_FORMATS[this._clipFormat] || this._clipFormat;
-    return this.tooltipFormat;
+    return this.format;
   }
 
   @Input()

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
@@ -22,33 +22,38 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   @Input()
   datetime: Datelike = new Date();
 
-  @Input()
-  defaultInputTimeZone: string;
-
   @Input() precision: moment.unitOfTime.StartOf;
 
   @Input()
-  displayTimeZone: string;
+  timezone: string;
 
   @Input()
-  set displayMode(val: DATE_DISPLAY_TYPES) {
-    this._displayMode = val;
+  set defaultInputTimeZone(val: string) {
+    this._defaultInputTimeZone = val;
   }
-  get displayMode(): DATE_DISPLAY_TYPES {
-    if (typeof this._displayMode === 'string') {
-      return this._displayMode;
+  get defaultInputTimeZone() {
+    return this._defaultInputTimeZone || this.timezone;
+  }
+
+  @Input()
+  set mode(val: DATE_DISPLAY_TYPES) {
+    this._mode = val;
+  }
+  get mode(): DATE_DISPLAY_TYPES {
+    if (typeof this._mode === 'string') {
+      return this._mode;
     }
     return DATE_DISPLAY_TYPES.TIMEZONE;
   }
 
   // date, time, dateTime
   @Input()
+  set type(val: string) {
+    this._type = val;
+  }
   get type(): string {
     if (this._type) return this._type;
     return DateTimeType.datetime;
-  }
-  set inputType(val: string) {
-    this._type = val;
   }
 
   @Input()
@@ -58,18 +63,18 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   get format(): string {
     if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
     // return DATE_DISPLAY_FORMATS.fullLocale;
-    return defaultFormat(this.displayMode, this.type as DateTimeType, this.precision);
+    return defaultFormat(this.mode, this.type as DateTimeType, this.precision);
   }
 
   @Input()
-  set displayFormat(val: string) {
-    this._displayFormat = val;
+  set tooltipFormat(val: string) {
+    this._tooltipFormat = val;
   }
-  get displayFormat(): string {
-    if (this._displayFormat) return DATE_DISPLAY_FORMATS[this._displayFormat] || this._displayFormat;
+  get tooltipFormat(): string {
+    if (this._tooltipFormat) return DATE_DISPLAY_FORMATS[this._tooltipFormat] || this._tooltipFormat;
     if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
     // return DATE_DISPLAY_FORMATS.fullLocale;
-    return defaultDisplayFormat(this.displayMode, this.type as DateTimeType, this.precision);
+    return defaultDisplayFormat(this.mode, this.type as DateTimeType, this.precision);
   }
 
   @Input()
@@ -78,7 +83,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   }
   get clipFormat(): string {
     if (this._clipFormat) return DATE_DISPLAY_FORMATS[this._clipFormat] || this._clipFormat;
-    return this.displayFormat;
+    return this.tooltipFormat;
   }
 
   @Input()
@@ -121,7 +126,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
 
   @HostBinding('class.ngx-time--has-popup')
   get hasPopup() {
-    return !this.dateInvalid && DATE_DISPLAY_TYPES.LOCAL !== this.displayMode;
+    return !this.dateInvalid && DATE_DISPLAY_TYPES.LOCAL !== this.mode;
   }
 
   @HostBinding('class.ngx-time--date-invalid')
@@ -135,12 +140,13 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   readonly DATE_DISPLAY_TYPES = DATE_DISPLAY_TYPES;
   readonly DATE_DISPLAY_FORMATS = DATE_DISPLAY_FORMATS;
 
-  private _displayMode: DATE_DISPLAY_TYPES;
+  private _mode: DATE_DISPLAY_TYPES;
   private _format: string;
-  private _displayFormat: string;
+  private _tooltipFormat: string;
   private _clipFormat: string;
   private _clickable: boolean;
   private _type: string;
+  private _defaultInputTimeZone: string;
 
   constructor(private readonly clipboard: Clipboard, private readonly notificationService: NotificationService) {}
 
@@ -182,7 +188,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
       return;
     }
 
-    if (DATE_DISPLAY_TYPES.LOCAL === this.displayMode) {
+    if (DATE_DISPLAY_TYPES.LOCAL === this.mode) {
       const mdate = momentTimezone(this.datetime);
       this.dateInvalid = !mdate.isValid();
       this.internalDatetime = this.dateInvalid ? undefined : mdate.toDate();
@@ -208,7 +214,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
       const tz = this.timezones[key] || localTimezone;
       const date = mdate.clone().tz(tz);
       const clip = date.format(this.clipFormat);
-      const display = date.format(this.displayFormat);
+      const display = date.format(this.tooltipFormat);
       this.timeValues[key] = {
         key,
         clip,

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
@@ -7,8 +7,10 @@ import { CoerceBooleanProperty } from '../../utils/coerce/coerce-boolean';
 import { NotificationService } from '../notification/notification.service';
 import { NotificationStyleType } from '../notification/notification-style-type.enum';
 
-import { DATE_DISPLAY_TYPES, DATE_DISPLAY_INPUT_FORMATS, DATE_DISPLAY_FORMATS } from './date-formats.enum';
+import { DATE_DISPLAY_TYPES, DATE_DISPLAY_INPUT_FORMATS, DATE_DISPLAY_FORMATS } from '../../enums/date-formats.enum';
 import { Datelike } from '../date-time/date-like.type';
+import { DateTimeType } from '../date-time/date-time-type.enum';
+import { defaultDisplayFormat, defaultFormat } from '../../utils/date-formats/default-formats';
 
 @Component({
   selector: 'ngx-time',
@@ -22,6 +24,8 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
 
   @Input()
   defaultInputTimeZone: string;
+
+  @Input() precision: moment.unitOfTime.StartOf;
 
   @Input()
   displayTimeZone: string;
@@ -37,12 +41,35 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
     return DATE_DISPLAY_TYPES.TIMEZONE;
   }
 
+  // date, time, dateTime
+  @Input()
+  get type(): string {
+    if (this._type) return this._type;
+    return DateTimeType.datetime;
+  }
+  set inputType(val: string) {
+    this._type = val;
+  }
+
+  @Input()
+  set format(val: string) {
+    this._format = val;
+  }
+  get format(): string {
+    if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
+    // return DATE_DISPLAY_FORMATS.fullLocale;
+    return defaultFormat(this.displayMode, this.type as DateTimeType, this.precision);
+  }
+
   @Input()
   set displayFormat(val: string) {
     this._displayFormat = val;
   }
   get displayFormat(): string {
-    return DATE_DISPLAY_FORMATS[this._displayFormat] || this._displayFormat || DATE_DISPLAY_FORMATS.fullLocale;
+    if (this._displayFormat) return DATE_DISPLAY_FORMATS[this._displayFormat] || this._displayFormat;
+    if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
+    // return DATE_DISPLAY_FORMATS.fullLocale;
+    return defaultDisplayFormat(this.displayMode, this.type as DateTimeType, this.precision);
   }
 
   @Input()
@@ -50,7 +77,8 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
     this._clipFormat = val;
   }
   get clipFormat(): string {
-    return DATE_DISPLAY_FORMATS[this._clipFormat] || this._clipFormat || DATE_DISPLAY_FORMATS.fullLocale;
+    if (this._clipFormat) return DATE_DISPLAY_FORMATS[this._clipFormat] || this._clipFormat;
+    return this.displayFormat;
   }
 
   @Input()
@@ -108,9 +136,11 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   readonly DATE_DISPLAY_FORMATS = DATE_DISPLAY_FORMATS;
 
   private _displayMode: DATE_DISPLAY_TYPES;
+  private _format: string;
   private _displayFormat: string;
   private _clipFormat: string;
   private _clickable: boolean;
+  private _type: string;
 
   constructor(private readonly clipboard: Clipboard, private readonly notificationService: NotificationService) {}
 

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
@@ -10,7 +10,9 @@ import { NotificationStyleType } from '../notification/notification-style-type.e
 import { DATE_DISPLAY_TYPES, DATE_DISPLAY_INPUT_FORMATS, DATE_DISPLAY_FORMATS } from '../../enums/date-formats.enum';
 import { Datelike } from '../date-time/date-like.type';
 import { DateTimeType } from '../date-time/date-time-type.enum';
-import { defaultDisplayFormat, defaultFormat } from '../../utils/date-formats/default-formats';
+import { defaultDisplayFormat, defaultInputFormat } from '../../utils/date-formats/default-formats';
+
+const guessTimeZone = momentTimezone.tz.guess();
 
 @Component({
   selector: 'ngx-time',
@@ -25,15 +27,10 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   @Input() precision: moment.unitOfTime.StartOf;
 
   @Input()
-  timezone: string;
+  timezone: string = guessTimeZone;
 
   @Input()
-  set defaultInputTimeZone(val: string) {
-    this._defaultInputTimeZone = val;
-  }
-  get defaultInputTimeZone() {
-    return this._defaultInputTimeZone || this.timezone;
-  }
+  defaultInputTimeZone: string;
 
   @Input()
   set mode(val: DATE_DISPLAY_TYPES) {
@@ -62,7 +59,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   }
   get format(): string {
     if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
-    return defaultFormat(this.mode, this.type as DateTimeType, this.precision);
+    return defaultDisplayFormat(this.mode, this.type as DateTimeType, this.precision);
   }
 
   @Input()
@@ -71,8 +68,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   }
   get tooltipFormat(): string {
     if (this._tooltipFormat) return DATE_DISPLAY_FORMATS[this._tooltipFormat] || this._tooltipFormat;
-    if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
-    return defaultDisplayFormat(this.mode, this.type as DateTimeType, this.precision);
+    return this.format;
   }
 
   @Input()
@@ -81,7 +77,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   }
   get clipFormat(): string {
     if (this._clipFormat) return DATE_DISPLAY_FORMATS[this._clipFormat] || this._clipFormat;
-    return this.format;
+    return defaultInputFormat(this.mode, this.type as DateTimeType, this.precision);
   }
 
   @Input()
@@ -144,7 +140,6 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   private _clipFormat: string;
   private _clickable: boolean;
   private _type: string;
-  private _defaultInputTimeZone: string;
 
   constructor(private readonly clipboard: Clipboard, private readonly notificationService: NotificationService) {}
 
@@ -194,7 +189,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
       return;
     }
 
-    const localTimezone = momentTimezone.tz.guess();
+    const localTimezone = this.timezone || guessTimeZone;
     const inputTimezone = this.defaultInputTimeZone || localTimezone;
 
     const mdate = momentTimezone.tz(this.datetime as string, DATE_DISPLAY_INPUT_FORMATS, inputTimezone);
@@ -209,7 +204,7 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
     const titleValue = [];
 
     for (const key in this.timezones) {
-      const tz = this.timezones[key] || localTimezone;
+      const tz = this.timezones[key] || guessTimeZone;
       const date = mdate.clone().tz(tz);
       const clip = date.format(this.clipFormat);
       const display = date.format(this.tooltipFormat);

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.ts
@@ -62,7 +62,6 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   }
   get format(): string {
     if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
-    // return DATE_DISPLAY_FORMATS.fullLocale;
     return defaultFormat(this.mode, this.type as DateTimeType, this.precision);
   }
 
@@ -73,7 +72,6 @@ export class NgxTimeDisplayComponent implements OnInit, OnChanges {
   get tooltipFormat(): string {
     if (this._tooltipFormat) return DATE_DISPLAY_FORMATS[this._tooltipFormat] || this._tooltipFormat;
     if (this._format) return DATE_DISPLAY_FORMATS[this._format] || this._format;
-    // return DATE_DISPLAY_FORMATS.fullLocale;
     return defaultDisplayFormat(this.mode, this.type as DateTimeType, this.precision);
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
@@ -21,6 +21,10 @@ export const DATE_DISPLAY_FORMATS = {
   fullTime: 'h:mm A Z [(]zz[)]', // 9:00 PM -07:00 (MST)
   fullDateTime: 'ddd, MMM D, YYYY h:mm A Z [(]zz[)]', // Tue, Jan 1, 2000 9:00 PM -07:00 (MST)
 
+  // Date min-modes
+  fullDateMonth: 'MMM YYYY Z [(]zz[)]', // Jan 2000 -07:00 (MST)
+  fullDateYear: 'YYYY Z [(]zz[)]', // 2000 -07:00 (MST)
+
   // Local (civil) time
   localeDate: 'L', // 09/04/1986
   localeDateTime: 'L LT', // 09/04/1986 8:30 PM

--- a/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
@@ -62,28 +62,29 @@ export const DATE_DISPLAY_INPUT_FORMATS: Array<string | moment.MomentBuiltinForm
   DATE_DISPLAY_FORMATS.localeDateTime,
   DATE_DISPLAY_FORMATS.localeDate,
   DATE_DISPLAY_FORMATS.localeTime,
+  DATE_DISPLAY_FORMATS.locale,
+  DATE_DISPLAY_FORMATS.shortLocale,
+  DATE_DISPLAY_FORMATS.fullLocale,
+
+  // Fall back to some US based formats
   'MM/DD',
   'MM/DD/YYYY',
   'M/DD/YYYY',
   'MM/DD/YY',
   'MM/DD/YYYY, h:mm A',
   'MM/DD/YYYY, h:mm:ss A',
-  moment.HTML5_FMT.DATETIME_LOCAL,
-  'YYYY-MM-DDTHH:mm', // <input type="datetime-local" />
-  moment.HTML5_FMT.DATETIME_LOCAL_SECONDS,
-  'YYYY-MM-DDTHH:mm:ss', // <input type="datetime-local" />
-  moment.HTML5_FMT.DATETIME_LOCAL_MS,
-  'YYYY-MM-DDTHH:mm:ss.SSS', // <input type="datetime-local" />
-  moment.HTML5_FMT.DATE,
-  'YYYY-MM-DD', // <input type="date" />
-  moment.HTML5_FMT.TIME,
-  'HH:mm', // <input type="time" />
-  moment.HTML5_FMT.TIME_SECONDS,
-  'HH:mm:ss', // <input type="time" />
-  moment.HTML5_FMT.TIME_MS,
-  'HH:mm:ss.SSS', // <input type="time" />
-  moment.HTML5_FMT.MONTH,
-  'YYYY-MM', // <input type="month" />
+
+  // Match HTML5 formats
+  moment.HTML5_FMT.DATETIME_LOCAL, // YYYY-MM-DDTHH:mm <input type="datetime-local" />
+  moment.HTML5_FMT.DATETIME_LOCAL_SECONDS, // YYYY-MM-DDTHH:mm:ss <input type="datetime-local" />
+  moment.HTML5_FMT.DATETIME_LOCAL_MS, // YYYY-MM-DDTHH:mm:ss.SSS <input type="datetime-local" />
+  moment.HTML5_FMT.DATE, // YYYY-MM-DD <input type="date" />
+  moment.HTML5_FMT.TIME, // HH:mm <input type="time" />
+  moment.HTML5_FMT.TIME_SECONDS, // HH:mm:ss <input type="time" />
+  moment.HTML5_FMT.TIME_MS, // HH:mm:ss.SSS <input type="time" />
+  moment.HTML5_FMT.MONTH, // YYYY-MM <input type="month" />
+
+  // Finally ISO
   moment.ISO_8601
 ];
 

--- a/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
@@ -4,8 +4,8 @@ export const DATE_DISPLAY_FORMATS = {
   // for input
   shortDate: 'M/D/YYYY', // 1/1/2020
   shortTime: 'h:mm A', // 9:00 PM
-  shortDateTime: 'M/D/YYYY h:mm A', // Jan 1, 2000 9:00 PM
-  shortDateTimeSeconds: 'M/D/YYYY h:mm:ss A', // Jan 1, 2000 9:00 PM
+  shortDateTime: 'M/D/YYYY h:mm A', // 1/1/2020 9:00 PM
+  shortDateTimeSeconds: 'M/D/YYYY h:mm:ss A', // 1/1/2020 9:00 PM
 
   date: 'MMM D, YYYY', // Jan 1, 2000
   time: 'h:mm A', // 9:00 PM

--- a/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
@@ -33,6 +33,7 @@ export const DATE_DISPLAY_FORMATS = {
   // Timezone
   timezoneDate: 'L Z', // 09/04/1986 -07:00
   timezoneDateTime: 'L LT Z', // 09/04/1986 8:30 PM -07:00
+  timezoneDateTimeSeconds: 'L LTS Z', // 09/04/1986 8:30 PM -07:00
   timezoneTime: 'LT Z', // 8:30 PM -07:00
 
   // Date min-modes
@@ -55,6 +56,7 @@ export const DATE_DISPLAY_INPUT_FORMATS: Array<string | moment.MomentBuiltinForm
   DATE_DISPLAY_FORMATS.shortDate,
   DATE_DISPLAY_FORMATS.shortTime,
   DATE_DISPLAY_FORMATS.timezoneDateTime,
+  DATE_DISPLAY_FORMATS.timezoneDateTimeSeconds,
   DATE_DISPLAY_FORMATS.timezoneDate,
   DATE_DISPLAY_FORMATS.timezoneTime,
   DATE_DISPLAY_FORMATS.localeDateTime,

--- a/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
+++ b/projects/swimlane/ngx-ui/src/lib/enums/date-formats.enum.ts
@@ -2,24 +2,24 @@ import moment from 'moment';
 
 export const DATE_DISPLAY_FORMATS = {
   // for input
-  shortDate: 'M/D/YYYY', // 1/1/2020
-  shortTime: 'h:mm A', // 9:00 PM
-  shortDateTime: 'M/D/YYYY h:mm A', // 1/1/2020 9:00 PM
-  shortDateTimeSeconds: 'M/D/YYYY h:mm:ss A', // 1/1/2020 9:00 PM
+  shortDate: 'l', // 1/1/2020
+  shortTime: 'LT', // 9:00 PM
+  shortDateTime: 'l LT', // 1/1/2020 9:00 PM
+  shortDateTimeSeconds: 'l LTS', // 1/1/2020 9:00 PM
 
-  date: 'MMM D, YYYY', // Jan 1, 2000
-  time: 'h:mm A', // 9:00 PM
-  dateTime: 'MMM D, YYYY h:mm A', // Jan 1, 2000 9:00 PM
-  dateTimeSeconds: 'MMM D, YYYY h:mm:ss A', // Jan 1, 2000 9:00 PM
+  date: 'll', // Jan 1, 2000
+  time: 'LT', // 9:00 PM
+  dateTime: 'lll', // Jan 1, 2000 9:00 PM
+  dateTimeSeconds: 'll LTS', // Jan 1, 2000 9:00:00 PM
 
   // Date min-modes
   dateMonth: 'MMM YYYY', // Jan 2000
   dateYear: 'YYYY', // 2000
 
   // full display
-  fullDate: 'ddd, MMM D, YYYY Z [(]zz[)]', // Sat, Jan 1, 2000 -07:00 (MST)
-  fullTime: 'h:mm A Z [(]zz[)]', // 9:00 PM -07:00 (MST)
-  fullDateTime: 'ddd, MMM D, YYYY h:mm A Z [(]zz[)]', // Tue, Jan 1, 2000 9:00 PM -07:00 (MST)
+  fullDate: 'ddd, ll Z [(]zz[)]', // Sat, Jan 1, 2000 -07:00 (MST)
+  fullTime: 'LT Z [(]zz[)]', // 9:00 PM -07:00 (MST)
+  fullDateTime: 'llll Z [(]zz[)]', // Tue, Jan 1, 2000 9:00 PM -07:00 (MST)
 
   // Date min-modes
   fullDateMonth: 'MMM YYYY Z [(]zz[)]', // Jan 2000 -07:00 (MST)

--- a/projects/swimlane/ngx-ui/src/lib/utils/date-formats/default-formats.ts
+++ b/projects/swimlane/ngx-ui/src/lib/utils/date-formats/default-formats.ts
@@ -1,0 +1,108 @@
+import moment from 'moment-timezone';
+
+import { DateTimeType } from '../../components/date-time/date-time-type.enum';
+import { DATE_DISPLAY_FORMATS, DATE_DISPLAY_TYPES } from '../../enums/date-formats.enum';
+
+export function defaultFormat(
+  displayMode: DATE_DISPLAY_TYPES,
+  inputType: DateTimeType,
+  precision: moment.unitOfTime.StartOf
+) {
+  switch (displayMode) {
+    case DATE_DISPLAY_TYPES.TIMEZONE:
+      switch (inputType) {
+        case DateTimeType.date:
+          switch (precision) {
+            case 'month':
+              return DATE_DISPLAY_FORMATS.timezoneDateMonth;
+            case 'year':
+              return DATE_DISPLAY_FORMATS.timezoneDateYear;
+          }
+          return DATE_DISPLAY_FORMATS.timezoneDate;
+        case DateTimeType.time:
+          return DATE_DISPLAY_FORMATS.timezoneTime;
+      }
+      return DATE_DISPLAY_FORMATS.timezoneDateTime;
+    case DATE_DISPLAY_TYPES.LOCAL:
+      switch (inputType) {
+        case DateTimeType.date:
+          switch (precision) {
+            case 'month':
+              return DATE_DISPLAY_FORMATS.dateMonth;
+            case 'year':
+              return DATE_DISPLAY_FORMATS.dateYear;
+          }
+          return DATE_DISPLAY_FORMATS.localeDate;
+        case DateTimeType.time:
+          return DATE_DISPLAY_FORMATS.localeTime;
+      }
+      return DATE_DISPLAY_FORMATS.localeDateTime;
+  }
+
+  switch (inputType) {
+    case DateTimeType.date:
+      switch (precision) {
+        case 'month':
+          return DATE_DISPLAY_FORMATS.dateMonth;
+        case 'year':
+          return DATE_DISPLAY_FORMATS.dateYear;
+      }
+      return DATE_DISPLAY_FORMATS.date;
+    case DateTimeType.time:
+      return DATE_DISPLAY_FORMATS.time;
+  }
+
+  return DATE_DISPLAY_FORMATS.dateTime;
+}
+
+export function defaultDisplayFormat(
+  displayMode: DATE_DISPLAY_TYPES,
+  inputType: DateTimeType,
+  precision: moment.unitOfTime.StartOf
+) {
+  switch (displayMode) {
+    case DATE_DISPLAY_TYPES.TIMEZONE:
+      switch (inputType) {
+        case DateTimeType.date:
+          switch (precision) {
+            case 'month':
+              return DATE_DISPLAY_FORMATS.fullDateMonth;
+            case 'year':
+              return DATE_DISPLAY_FORMATS.fullDateYear;
+          }
+          return DATE_DISPLAY_FORMATS.fullDate;
+        case DateTimeType.time:
+          return DATE_DISPLAY_FORMATS.fullTime;
+      }
+      return DATE_DISPLAY_FORMATS.fullDateTime;
+    case DATE_DISPLAY_TYPES.LOCAL:
+      switch (inputType) {
+        case DateTimeType.date:
+          switch (precision) {
+            case 'month':
+              return DATE_DISPLAY_FORMATS.dateMonth;
+            case 'year':
+              return DATE_DISPLAY_FORMATS.dateYear;
+          }
+          return DATE_DISPLAY_FORMATS.localeDate;
+        case DateTimeType.time:
+          return DATE_DISPLAY_FORMATS.localeTime;
+      }
+      return DATE_DISPLAY_FORMATS.localeDateTime;
+  }
+
+  switch (inputType) {
+    case DateTimeType.date:
+      switch (precision) {
+        case 'month':
+          return DATE_DISPLAY_FORMATS.dateMonth;
+        case 'year':
+          return DATE_DISPLAY_FORMATS.dateYear;
+      }
+      return DATE_DISPLAY_FORMATS.date;
+    case DateTimeType.time:
+      return DATE_DISPLAY_FORMATS.time;
+  }
+
+  return DATE_DISPLAY_FORMATS.dateTime;
+}

--- a/projects/swimlane/ngx-ui/src/lib/utils/date-formats/default-formats.ts
+++ b/projects/swimlane/ngx-ui/src/lib/utils/date-formats/default-formats.ts
@@ -3,12 +3,16 @@ import moment from 'moment-timezone';
 import { DateTimeType } from '../../components/date-time/date-time-type.enum';
 import { DATE_DISPLAY_FORMATS, DATE_DISPLAY_TYPES } from '../../enums/date-formats.enum';
 
-export function defaultFormat(
+/*
+ * Default input format
+ */
+export function defaultInputFormat(
   displayMode: DATE_DISPLAY_TYPES,
   inputType: DateTimeType,
   precision: moment.unitOfTime.StartOf
 ) {
   switch (displayMode) {
+    case DATE_DISPLAY_TYPES.HUMAN:
     case DATE_DISPLAY_TYPES.TIMEZONE:
       switch (inputType) {
         case DateTimeType.date:
@@ -37,30 +41,33 @@ export function defaultFormat(
           return DATE_DISPLAY_FORMATS.localeTime;
       }
       return DATE_DISPLAY_FORMATS.localeDateTime;
-  }
-
-  switch (inputType) {
-    case DateTimeType.date:
-      switch (precision) {
-        case 'month':
-          return DATE_DISPLAY_FORMATS.dateMonth;
-        case 'year':
-          return DATE_DISPLAY_FORMATS.dateYear;
+    case DATE_DISPLAY_TYPES.CUSTOM:
+      switch (inputType) {
+        case DateTimeType.date:
+          switch (precision) {
+            case 'month':
+              return DATE_DISPLAY_FORMATS.dateMonth;
+            case 'year':
+              return DATE_DISPLAY_FORMATS.dateYear;
+          }
+          return DATE_DISPLAY_FORMATS.date;
+        case DateTimeType.time:
+          return DATE_DISPLAY_FORMATS.time;
       }
-      return DATE_DISPLAY_FORMATS.date;
-    case DateTimeType.time:
-      return DATE_DISPLAY_FORMATS.time;
+      return DATE_DISPLAY_FORMATS.dateTime;
   }
-
-  return DATE_DISPLAY_FORMATS.dateTime;
 }
 
+/*
+ * Default display format
+ */
 export function defaultDisplayFormat(
   displayMode: DATE_DISPLAY_TYPES,
   inputType: DateTimeType,
   precision: moment.unitOfTime.StartOf
 ) {
   switch (displayMode) {
+    case DATE_DISPLAY_TYPES.HUMAN:
     case DATE_DISPLAY_TYPES.TIMEZONE:
       switch (inputType) {
         case DateTimeType.date:
@@ -89,20 +96,19 @@ export function defaultDisplayFormat(
           return DATE_DISPLAY_FORMATS.localeTime;
       }
       return DATE_DISPLAY_FORMATS.localeDateTime;
-  }
-
-  switch (inputType) {
-    case DateTimeType.date:
-      switch (precision) {
-        case 'month':
-          return DATE_DISPLAY_FORMATS.dateMonth;
-        case 'year':
-          return DATE_DISPLAY_FORMATS.dateYear;
+    case DATE_DISPLAY_TYPES.CUSTOM:
+      switch (inputType) {
+        case DateTimeType.date:
+          switch (precision) {
+            case 'month':
+              return DATE_DISPLAY_FORMATS.dateMonth;
+            case 'year':
+              return DATE_DISPLAY_FORMATS.dateYear;
+          }
+          return DATE_DISPLAY_FORMATS.date;
+        case DateTimeType.time:
+          return DATE_DISPLAY_FORMATS.time;
       }
-      return DATE_DISPLAY_FORMATS.date;
-    case DateTimeType.time:
-      return DATE_DISPLAY_FORMATS.time;
+      return DATE_DISPLAY_FORMATS.dateTime;
   }
-
-  return DATE_DISPLAY_FORMATS.dateTime;
 }

--- a/projects/swimlane/ngx-ui/src/public_api.ts
+++ b/projects/swimlane/ngx-ui/src/public_api.ts
@@ -244,7 +244,6 @@ export * from './lib/components/plus-menu/plus-menu-position.enum';
 
 export * from './lib/components/time-display/time-display.module';
 export * from './lib/components/time-display/time-display.component';
-export * from './lib/components/time-display/date-formats.enum';
 
 // utils
 export * from './lib/utils/debounce/debounce.util';
@@ -274,6 +273,9 @@ export * from './lib/utils/position/vertical-position/vertical-position.util';
 
 export * from './lib/utils/throttle/throttle-options.interface';
 export * from './lib/utils/throttle/throttle.util';
+
+// enums
+export * from './lib/enums/date-formats.enum';
 
 // decorators
 export * from './lib/decorators/debounceable/debounceable.decorator';

--- a/src/app/components/time-display-page/time-display-page.component.html
+++ b/src/app/components/time-display-page/time-display-page.component.html
@@ -52,21 +52,21 @@
   <output>{{ localString | json }}</output>
   
   <div class="example">
-    <h4>By default inputs are assumed local date/time, display TZ can be defined</h4>
-    <ngx-time [datetime]="localString" timezone="Asia/Tokyo"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="localString" timezone="Asia/Tokyo"></ngx-time>]]></app-prism> 
+    <h4>Input and display TZ can be defined</h4>
+    <ngx-time datetime="March 11, 2011 2:46:24 PM" timezone="Asia/Tokyo"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="'March 11, 2011 2:46:24 PM'" timezone="Asia/Tokyo"></ngx-time>]]></app-prism> 
   </div>
 
   <div class="example">
-    <h4>Default input timezone can be specified</h4>
-    <ngx-time datetime="March 11, 2011 2:46:24 PM" timezone="Asia/Tokyo"></ngx-time>
+    <h4>Default input timezone can be specified separately from display</h4>
+    <ngx-time datetime="March 11, 2011 2:46:24 PM" defaultInputTimeZone="Asia/Tokyo"></ngx-time>
     <app-prism><![CDATA[<ngx-time [datetime]="March 11, 2011 2:46:24 PM" defaultInputTimeZone="Asia/Tokyo"></ngx-time>]]></app-prism>
   </div>
 
   <div class="example">
     <h4>Explicit timezone in input value overrides default input timezone</h4>
-    <ngx-time [datetime]="date" timezone="Asia/Tokyo"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="date" defaultInputTimeZone="Asia/Tokyo"></ngx-time>]]></app-prism>
+    <ngx-time datetime="03/10/2011 9:46:24 PM -08:00" defaultInputTimeZone="Asia/Tokyo"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="Thu, Mar 10, 2011 9:46 PM -08:00" defaultInputTimeZone="Asia/Tokyo"></ngx-time>]]></app-prism>
   </div>
 </ngx-section>
 

--- a/src/app/components/time-display-page/time-display-page.component.html
+++ b/src/app/components/time-display-page/time-display-page.component.html
@@ -19,14 +19,14 @@
 
   <div class="example">
     <h4>Format</h4>
-    <ngx-time [datetime]="date" displayFormat="fullDateTime"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="date" displayFormat="fullDateTime"></ngx-time>]]></app-prism>  
+    <ngx-time [datetime]="date" format="dateTime"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" format="fullDateTime"></ngx-time>]]></app-prism>  
   </div>
   
   <div class="example">
     <h4>Custom format</h4>
-    <ngx-time [datetime]="date" displayFormat="YYYY MMM"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="date" displayFormat="YYYY MMM"></ngx-time>]]></app-prism>    
+    <ngx-time [datetime]="date" format="YYYY MMM"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" format="YYYY MMM"></ngx-time>]]></app-prism>    
   </div>
 </ngx-section>
 
@@ -63,6 +63,18 @@
     <h4>Defined Timezones</h4>
     <ngx-time [datetime]="date" [timezones]="{ 'Local': '', 'GMT': 'Etc/UTC', 'Tokyo': 'Asia/Tokyo' }"></ngx-time>
     <app-prism><![CDATA[<ngx-time [datetime]="date" [timezones]="{ 'Local': '', 'GMT': 'Etc/UTC', 'Tokyo': 'Asia/Tokyo' }"></ngx-time>]]></app-prism>
+  </div>
+
+  <div class="example">
+    <h4>Popup Format</h4>
+    <ngx-time [datetime]="date" displayFormat="localeTime"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" displayFormat="localeTime"></ngx-time>]]></app-prism>
+  </div>
+
+  <div class="example">
+    <h4>Custom Popup Format</h4>
+    <ngx-time [datetime]="date" displayFormat="YYYY MMM"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" displayFormat="YYYY MMM"></ngx-time>]]></app-prism>
   </div>
 </ngx-section>
 

--- a/src/app/components/time-display-page/time-display-page.component.html
+++ b/src/app/components/time-display-page/time-display-page.component.html
@@ -1,22 +1,12 @@
-<ngx-section sectionTitle="Formats">
+<ngx-section sectionTitle="Basic">
   <div class="example">
     <h4>Default Date-Time</h4>
     <ngx-time [datetime]="date"></ngx-time>
     <app-prism><![CDATA[<ngx-time [datetime]="date"></ngx-time>]]></app-prism>
   </div>
+</ngx-section>
 
-  <div class="example">
-    <h4>Human Readable Date-Time</h4>
-    <ngx-time [datetime]="date" displayMode="human"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="date" displayMode="human"></ngx-time>]]></app-prism> 
-  </div>
-
-  <div class="example">
-    <h4>Local</h4>
-    <ngx-time [datetime]="date" displayMode="local"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="date" displayMode="local"></ngx-time>]]></app-prism> 
-  </div>
-
+<ngx-section sectionTitle="Formats">
   <div class="example">
     <h4>Format</h4>
     <ngx-time [datetime]="date" format="dateTime"></ngx-time>
@@ -30,25 +20,53 @@
   </div>
 </ngx-section>
 
+<ngx-section sectionTitle="Modes">
+  <div class="example">
+    <h4>Human Readable Date-Time</h4>
+    <ngx-time [datetime]="date" mode="human"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" mode="human"></ngx-time>]]></app-prism> 
+  </div>
+
+  <div class="example">
+    <h4>Local</h4>
+    <ngx-time [datetime]="date" mode="local"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" mode="local"></ngx-time>]]></app-prism> 
+  </div>
+</ngx-section>
+
+<ngx-section sectionTitle="Types">
+  <div class="example">
+    <h4>Time</h4>
+    <ngx-time [datetime]="date" type="time"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" type="time"></ngx-time>]]></app-prism> 
+  </div>
+
+  <div class="example">
+    <h4>Date</h4>
+    <ngx-time [datetime]="date" type="date"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" type="date"></ngx-time>]]></app-prism> 
+  </div>
+</ngx-section>
+
 <ngx-section sectionTitle="Time Zones">
   <output>{{ localString | json }}</output>
   
   <div class="example">
     <h4>By default inputs are assumed local date/time, display TZ can be defined</h4>
-    <ngx-time [datetime]="localString" displayTimeZone="Asia/Tokyo"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="localString" displayTimeZone="Asia/Tokyo"></ngx-time>]]></app-prism> 
+    <ngx-time [datetime]="localString" timezone="Asia/Tokyo"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="localString" timezone="Asia/Tokyo"></ngx-time>]]></app-prism> 
   </div>
 
   <div class="example">
     <h4>Default input timezone can be specified</h4>
-    <ngx-time datetime="March 11, 2011 2:46:24 PM" defaultInputTimeZone="Asia/Tokyo"></ngx-time>
-    <app-prism><![CDATA[<ngx-time date="March 11, 2011 2:46:24 PM" defaultInputTimeZone="Asia/Tokyo"></ngx-time>]]></app-prism>
+    <ngx-time datetime="March 11, 2011 2:46:24 PM" timezone="Asia/Tokyo"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="March 11, 2011 2:46:24 PM" defaultInputTimeZone="Asia/Tokyo"></ngx-time>]]></app-prism>
   </div>
 
   <div class="example">
     <h4>Explicit timezone in input value overrides default input timezone</h4>
-    <ngx-time [datetime]="date" defaultInputTimeZone="Asia/Tokyo"></ngx-time>
-    <app-prism><![CDATA[<ngx-time date="date" defaultInputTimeZone="Asia/Tokyo"></ngx-time>]]></app-prism>
+    <ngx-time [datetime]="date" timezone="Asia/Tokyo"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" defaultInputTimeZone="Asia/Tokyo"></ngx-time>]]></app-prism>
   </div>
 </ngx-section>
 
@@ -67,14 +85,14 @@
 
   <div class="example">
     <h4>Popup Format</h4>
-    <ngx-time [datetime]="date" displayFormat="localeTime"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="date" displayFormat="localeTime"></ngx-time>]]></app-prism>
+    <ngx-time [datetime]="date" tooltipFormat="localeTime"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" tooltipFormat="localeTime"></ngx-time>]]></app-prism>
   </div>
 
   <div class="example">
     <h4>Custom Popup Format</h4>
-    <ngx-time [datetime]="date" displayFormat="YYYY MMM"></ngx-time>
-    <app-prism><![CDATA[<ngx-time [datetime]="date" displayFormat="YYYY MMM"></ngx-time>]]></app-prism>
+    <ngx-time [datetime]="date" tooltipFormat="YYYY MMM"></ngx-time>
+    <app-prism><![CDATA[<ngx-time [datetime]="date" tooltipFormat="YYYY MMM"></ngx-time>]]></app-prism>
   </div>
 </ngx-section>
 

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -207,6 +207,24 @@
   [(value)]="time"
   >
   </ngx-date-time>
+
+  <ngx-date-time
+  name="time-input2"
+  inputType="time"
+  timezone="utc"
+  label="Time of attack (UTC)"
+  [(value)]="time"
+  >
+  </ngx-date-time>
+
+  <ngx-date-time
+  name="time-input2"
+  inputType="time"
+  timezone="Asia/Tokyo"
+  label="Time of attack (JST)"
+  [(value)]="time"
+  >
+  </ngx-date-time>
 </ngx-section>
 
 <ngx-section class="shadow" sectionTitle="Precision">


### PR DESCRIPTION
## Summary

* consistent formats for `ngx-time`
* react to changes in timezone/precision on ngx-date-time
* simplified and consistent inputs

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
