### PR TITLE
fix wide calendar

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
@@ -68,7 +68,7 @@ $calendar-month-current: $color-blue-grey-750;
     display: flex;
 
     .day-name {
-      flex: 0 0 30px;
+      flex: 1 0 30px;
     }
   }
 
@@ -83,12 +83,13 @@ $calendar-month-current: $color-blue-grey-750;
 
   .day-container {
     margin-top: 0;
+    width: 100%;
 
     .day-row {
       display: flex;
 
       .day-cell {
-        flex: 0 0 30px;
+        flex: 1 0 30px;
       }
     }
 

--- a/src/app/forms/calendar-page/calendar-page.component.html
+++ b/src/app/forms/calendar-page/calendar-page.component.html
@@ -114,4 +114,8 @@
   </app-prism>
   <br />
 
+  <h3>Flexible Width</h3>
+
+  <ngx-calendar style="width: 100%" name="calendar1" [(ngModel)]="curDate1" (change)="dateChanged($event)"></ngx-calendar>
+
 </ngx-section>


### PR DESCRIPTION
## Summary

* fixed new issue where wide calendar became misaligned

Was:

![image](https://user-images.githubusercontent.com/509946/149012395-fe5f347e-c7d4-4135-9874-f43166536d6c.png)

Is:

![image](https://user-images.githubusercontent.com/509946/149012428-b7425c0a-3c05-4b79-ab98-cb61b1de12fd.png)


## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
