### PR TITLE
remove underline when tooltip is disabled

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
@@ -130,6 +130,7 @@ $input-invalid-color: $color-red;
     input {
       text-decoration-line: underline;
       text-decoration-style: dashed;
+      text-decoration-thickness: from-font;
     }
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -220,7 +220,9 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
 
   @HostBinding('class.ngx-date-time--has-popup')
   get hasPopup() {
-    return !!this.value && !this.dateInvalid && DATE_DISPLAY_TYPES.LOCAL !== this.displayMode;
+    if (DATE_DISPLAY_TYPES.LOCAL === this.displayMode) return false;
+    if (this.tooltipDisabled) return false;
+    return !!this.value && !this.dateInvalid;
   }
 
   @HostBinding('class.ngx-date-time--date-invalid')

--- a/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/time-display/time-display.component.scss
@@ -18,6 +18,7 @@ ngx-time {
   &.ngx-time--has-popup .ngx-time__container {
     text-decoration-line: underline;
     text-decoration-style: dashed;
+    text-decoration-thickness: from-font;
     cursor: copy;
     color: inherit;
   }

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -428,6 +428,11 @@
       <td><ngx-date-time [ngModel]="curDate2" inputType="datetime" displayMode="timezone" appearance="fill" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text"></ngx-date-time></td>
     </tr>
     <tr>
+      <td>Timezone w/ tooltip disabled</td>
+      <td><ngx-date-time [ngModel]="curDate2" [tooltipDisabled]="true" inputType="datetime" displayMode="timezone" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text"></ngx-date-time></td>
+      <td><ngx-date-time [ngModel]="curDate2" [tooltipDisabled]="true" inputType="datetime" displayMode="timezone" appearance="fill" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text"></ngx-date-time></td>
+    </tr>
+    <tr>
       <td>Empty Timezone w/ placeholder</td>
       <td><ngx-date-time inputType="datetime" displayMode="timezone" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text"></ngx-date-time></td>
       <td><ngx-date-time inputType="datetime" displayMode="timezone" appearance="fill" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text"></ngx-date-time></td>


### PR DESCRIPTION
## Summary

* When `[tooltipDisabled]="true"` remove `ngx-date-time--has-popup`
* Use `from-font` for underline thickness

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

was:
![image](https://user-images.githubusercontent.com/509946/150393781-357f75c4-affb-4c0d-a01e-23cb6e429ab4.png)

now:
![image](https://user-images.githubusercontent.com/509946/150393808-027c9bb1-9864-49aa-9741-4dbff0ae9bf1.png)


