### PR TITLE
(release): 37.1.1

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD (unreleased)
 
+## 37.1.1 (2022-2-8)
+
+- Fix: Revert Mousetrap import in HotKeys service
+
 ## 37.1.0 (2022-2-1)
 
 - Enhancement: add ability to display an image in `ngx-large-format-dialog` header

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "37.1.0",
+  "version": "37.1.1",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/hotkeys/hotkeys.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone } from '@angular/core';
-import * as Mousetrap from 'mousetrap';
+import Mousetrap from 'mousetrap';
 import { Subject } from 'rxjs';
 
 import { Hotkey } from './hotkey.interface';


### PR DESCRIPTION
## Summary

Release 37.1.1
Reverting Mousetrap import in HotKeys service

## Checklist

- [ ] \*Added unit tests
- [X] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
