### PR TITLE
another fix for datetime

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Fix: `ngx-date-time` input updates when when focused causing user input to be lost
+- Fix: `ngx-date-time` input changes when focused causing partial user input to be lost
 - Enhancement: `ngx-date-time` disable popup when input has focus
 
 ## 38.0.0 (2022-2-16)

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Fix: `ngx-date-time` input updates when when focused causing user input to be lost
+- Enhancement: `ngx-date-time` disable popup when input has focus
+
 ## 38.0.0 (2022-2-16)
 
 - Breaking: escape HTML in labels of input, select and date time components

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -24,6 +24,7 @@
     [requiredIndicator]="requiredIndicator"
     [hint]="hint"
     (ngModelChange)="inputChanged($event)"
+    (focus)="onFocus($event)"
     (blur)="onBlur($event)"
     (keydown)="onInputKeyDown($event)"
   >

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -353,13 +353,13 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
     this.value = val;
   }
 
-  onFocus(event: Event) {
+  onFocus(event?: Event) {
     this.tooltip.hideTooltip();
     this._focused = true;
     this.focus.emit(event);
   }
 
-  onBlur(event: Event) {
+  onBlur(event?: Event) {
     this.onTouchedCallback();
     this._focused = false;
 


### PR DESCRIPTION
## Summary

* When a user is typing a date and an input value changes (e.g. `[hint]`) the display is refresh and user loses current input
* Disable popups when input element has focus.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
