### PR TITLE
Add logic to display proper message when only one allowed file format is provided on dropzone component

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix: Display proper supports message with only one allowed file format on `Dropzone` component
+
 ## 39.0.0 (2022-2-28)
 
 - Breaking: Updated json-editor-flat component styles. Removed the `compact` input

--- a/projects/swimlane/ngx-ui/src/lib/components/dropzone/dropzone.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropzone/dropzone.component.spec.ts
@@ -8,6 +8,7 @@ import { FileUploader } from '@swimlane/ng2-file-upload';
 
 const uploader = new FileUploader({});
 const acceptedFileFormats = ['.txt', '.json'];
+const oneAcceptedFileFormat = ['.csv'];
 
 describe('DropzoneComponent', () => {
   let shallow: Shallow<DropzoneComponent>;
@@ -38,6 +39,12 @@ describe('DropzoneComponent', () => {
       rendering.instance.acceptedFileFormats = acceptedFileFormats;
       rendering.instance.ngOnInit();
       expect(rendering.instance.acceptedFileFormatsTextDisplay).toEqual('.txt and .json');
+    });
+
+    it('display proper message when only one file format is added ', () => {
+      rendering.instance.acceptedFileFormats = oneAcceptedFileFormat;
+      rendering.instance.ngOnInit();
+      expect(rendering.instance.acceptedFileFormatsTextDisplay).toEqual('.csv');
     });
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/dropzone/dropzone.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropzone/dropzone.component.ts
@@ -43,8 +43,12 @@ export class DropzoneComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.acceptedFileFormats && this.acceptedFileFormats.length) {
-      this.acceptedFileFormatsTextDisplay =
-        this.acceptedFileFormats.slice(0, -1).join(', ') + ' and ' + this.acceptedFileFormats.slice(-1);
+      if (this.acceptedFileFormats.length === 1) {
+        this.acceptedFileFormatsTextDisplay = this.acceptedFileFormats[0];
+      } else {
+        this.acceptedFileFormatsTextDisplay =
+          this.acceptedFileFormats.slice(0, -1).join(', ') + ' and ' + this.acceptedFileFormats.slice(-1);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add logic to display proper message when only one allowed file format is provided on dropzone component `acceptedFileFormats` input

Before:
![image (7)](https://user-images.githubusercontent.com/62297014/156266718-27492430-4e57-40d0-9337-ba8d5df0f7d7.png)

With fix:
![image](https://user-images.githubusercontent.com/62297014/156266752-06ef0128-7814-4eea-8368-88b302ac6983.png)

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
