### PR TITLE
Make json-editor models immutable

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -151,7 +151,7 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnCha
       delete this.schema.properties[propName];
       delete this.schemaRef.properties[propName];
       this.toggleRequiredValue(false, propName);
-    } else if (!this.schema.required.includes(propName) && !(propName in this.schema.properties)) {
+    } else if (!this.schema.required?.includes(propName) && !(propName in this.schema.properties)) {
       delete this.schemaRef.properties[propName];
     }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/array-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/array-node.component.ts
@@ -64,6 +64,7 @@ export class ArrayNode implements OnChanges {
    * @param value
    */
   updateArrayItem(index: number, value: any): void {
+    this.model = [...this.model];
     this.model[index] = value;
     this.modelChange.emit(this.model);
   }
@@ -96,8 +97,8 @@ export class ArrayNode implements OnChanges {
     const value: any = createValueForSchema(schema);
 
     if (value !== undefined) {
-      this.model.push(value);
-      this.schemas.push(schema);
+      this.model = [...this.model, value];
+      this.schemas = [...this.schemas, schema];
     }
 
     this.modelChange.emit(this.model);
@@ -110,9 +111,9 @@ export class ArrayNode implements OnChanges {
    * @param index
    */
   deleteArrayItem(index: number): void {
+    this.model = [...this.model];
     this.model.splice(index, 1);
     this.schemas.splice(index, 1);
-    this.model = [...this.model];
     this.schemas = [...this.schemas];
     this.modelChange.emit(this.model);
   }
@@ -145,6 +146,7 @@ export class ArrayNode implements OnChanges {
     }
 
     const value: any = createValueForSchema(schema);
+    this.model = [...this.model];
     this.model[index] = value;
 
     this.modelChange.emit(this.model);

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -112,6 +112,7 @@ export class ObjectNode implements OnInit, OnChanges {
    */
   updateProp(id: number | string, value: any): void {
     const propName = this.propertyIndex[id].propertyName;
+    this.model = { ...this.model };
     this.model[propName] = value;
     this.modelChange.emit(this.model);
   }
@@ -129,6 +130,7 @@ export class ObjectNode implements OnInit, OnChanges {
     this.duplicatedFields.delete(id as string);
 
     if (existingPropertyValue === undefined) {
+      this.model = { ...this.model };
       this.model[name] = this.model[oldName];
       this.propertyIndex[id].propertyName = name;
       delete this.model[oldName];
@@ -147,6 +149,7 @@ export class ObjectNode implements OnInit, OnChanges {
     this.propertyCounter++;
     const schema = JSON.parse(JSON.stringify(dataType.schema));
 
+    this.model = { ...this.model };
     this.model[propName] = createValueForSchema(dataType.schema as JSONEditorSchema);
     schema.nameEditable = !this.schemaBuilderMode;
     schema.propertyName = propName;
@@ -173,6 +176,7 @@ export class ObjectNode implements OnInit, OnChanges {
     }
 
     const value: any = createValueForSchema(schema);
+    this.model = { ...this.model };
     this.model[propName] = value;
 
     schema.nameEditable = false;
@@ -201,6 +205,7 @@ export class ObjectNode implements OnInit, OnChanges {
     }
 
     const value: any = createValueForSchema(schema);
+    this.model = { ...this.model };
     this.model[newPropName] = value;
 
     schema.nameEditable = true;
@@ -217,6 +222,7 @@ export class ObjectNode implements OnInit, OnChanges {
    * Deletes a property
    */
   deleteProperty(propName: string): void {
+    this.model = { ...this.model };
     delete this.model[propName];
     for (const id in this.propertyIndex) {
       if (this.propertyIndex[id].propertyName === propName) {
@@ -224,7 +230,6 @@ export class ObjectNode implements OnInit, OnChanges {
         break;
       }
     }
-    this.model = { ...this.model };
     this.propertyIndex = { ...this.propertyIndex };
     this.modelChange.emit(this.model);
   }
@@ -359,6 +364,7 @@ export class ObjectNode implements OnInit, OnChanges {
     }
 
     const value: any = createValueForSchema(property);
+    this.model = { ...this.model };
     this.model[property.propertyName] = value;
 
     this.modelChange.emit(this.model);


### PR DESCRIPTION
## Summary

Changes json editor model update functions to not mutate the existing model, so they can be compatible with ngrx component stores.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
