### PR TITLE
fix fill appearance blocking pointer events in select options

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -167,6 +167,23 @@ $color-chip-text: #fff;
     }
   }
 
+  .ngx-select-input-option {
+    // Specific style for links in tagging options
+    > a {
+      color: $color-blue-grey-050;
+      > .ngx-icon {
+        color: $color-blue-grey-200;
+        font-size: 0.55em;
+      }
+      &:hover {
+        color: #fff;
+        > .ngx-icon {
+          color: #fff;
+        }
+      }
+    }
+  }
+
   // multi-select
   &.tagging-selection,
   &.multi-selection {
@@ -188,21 +205,6 @@ $color-chip-text: #fff;
       top: 0;
       padding: 0 0.5em;
       font-size: 1em;
-
-      // Specific style for links in tagging options
-      > a {
-        color: $color-blue-grey-050;
-        > .ngx-icon {
-          color: $color-blue-grey-200;
-          font-size: 0.55em;
-        }
-        &:hover {
-          color: #fff;
-          > .ngx-icon {
-            color: #fff;
-          }
-        }
-      }
 
       .ngx-select-input-name {
         text-shadow: 2px 4px 2px rgba(0, 0, 0, 0.1);
@@ -588,6 +590,7 @@ $color-chip-text: #fff;
         bottom: 0;
         background-color: $color-fill-input-bg;
         mix-blend-mode: exclusion;
+        pointer-events: none;
       }
     }
 

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -808,6 +808,37 @@
       </ngx-select></td>
     </tr>
     <tr>
+      <td>Select With Links</td>
+      <td><ngx-select label="Label" [ngModel]="['Physical']" placeholder="Placeholder Text" hint="A brief bit of help text">
+        <ngx-select-option
+          *ngFor="let option of ['Breach', 'DDOS', 'Physical']"
+          [name]="option"
+          [value]="option"
+        >
+          <ng-template ngx-select-option-input-template>
+            <a href="#">
+              <i class="ngx-icon ngx-link"></i>
+              {{ option }}
+            </a>
+          </ng-template>
+        </ngx-select-option>
+      </ngx-select></td>
+      <td><ngx-select label="Label" [ngModel]="['Physical']" appearance="fill" placeholder="Placeholder Text" hint="A brief bit of help text">
+        <ngx-select-option
+          *ngFor="let option of ['Breach', 'DDOS', 'Physical']"
+          [name]="option"
+          [value]="option"
+        >
+          <ng-template ngx-select-option-input-template>
+            <a href="#">
+              <i class="ngx-icon ngx-link"></i>
+              {{ option }}
+            </a>
+          </ng-template>
+        </ngx-select-option>
+      </ngx-select></td>
+    </tr>
+    <tr>
       <td>Tagging With Links</td>
       <td><ngx-select label="Label" [ngModel]="['DDOS', 'Physical']" placeholder="Placeholder Text" hint="A brief bit of help text"  [tagging]="true">
         <ngx-select-option


### PR DESCRIPTION
## Summary

* fix issues were fill appearance was blocking hover and click events for anchors in single selects
* Move special anchor styles to apply to single selects
* Add demo

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
