### PR TITLE
allow drawer with parent container to have overlay

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer-options.interface.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer-options.interface.ts
@@ -3,15 +3,17 @@ import { TemplateRef } from '@angular/core';
 import { DrawerDirection } from './drawer-direction.enum';
 
 export interface DrawerOptions {
-  readonly cssClass?: string;
-  readonly direction?: DrawerDirection;
-  readonly template?: TemplateRef<any>;
-  readonly context?: any;
-  readonly size?: number;
-  readonly zIndex?: number;
-  readonly closeOnOutsideClick?: boolean;
-  readonly isRoot?: boolean;
-  readonly inputs?: {
+  cssClass?: string;
+  direction?: DrawerDirection;
+  template?: TemplateRef<any>;
+  context?: any;
+  size?: number;
+  zIndex?: number;
+  closeOnOutsideClick?: boolean;
+  isRoot?: boolean;
+  showOverlay?: boolean;
+  parentContainer?: any;
+  inputs?: {
     cssClass?: string;
     direction?: DrawerDirection;
     template?: TemplateRef<any>;
@@ -21,5 +23,4 @@ export interface DrawerOptions {
     closeOnOutsideClick?: boolean;
     isRoot?: boolean;
   };
-  readonly parentContainer?: any;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.component.html
@@ -1,3 +1,0 @@
-<div (click)="click.emit(true)" [style.zIndex]="zIndex" [@overlayTransition]="animationState" class="ngx-overlay">
-  <ng-content></ng-content>
-</div>

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.component.scss
@@ -1,5 +1,5 @@
 .ngx-overlay {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   bottom: 0;
@@ -12,4 +12,8 @@
   visibility: hidden;
   text-align: center;
   line-height: 100vh;
+}
+
+.ngx-overlay.root {
+  position: fixed;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.component.ts
@@ -4,6 +4,8 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  HostBinding,
+  HostListener,
   Input,
   Output,
   ViewEncapsulation
@@ -16,7 +18,7 @@ import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coerci
 @Component({
   exportAs: 'ngxOverlay',
   selector: 'ngx-overlay',
-  templateUrl: './overlay.component.html',
+  template: '<ng-content></ng-content>',
   styleUrls: ['./overlay.component.scss'],
   animations: [
     trigger('overlayTransition', [
@@ -50,6 +52,10 @@ import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coerci
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OverlayComponent {
+  @HostBinding('class.ngx-overlay')
+  overlay = true;
+
+  @HostBinding('class.root')
   @Input()
   get visible() {
     return this._visible;
@@ -59,6 +65,7 @@ export class OverlayComponent {
     this.cdr.markForCheck();
   }
 
+  @HostBinding('style.zIndex')
   @Input()
   get zIndex() {
     return this._zIndex;
@@ -68,8 +75,13 @@ export class OverlayComponent {
     this.cdr.markForCheck();
   }
 
+  @HostBinding('class.root')
+  @Input()
+  isRoot = true;
+
   @Output() click = new EventEmitter<boolean>();
 
+  @HostBinding('@overlayTransition')
   get animationState(): string {
     return this.visible ? 'active' : 'inactive';
   }
@@ -78,4 +90,9 @@ export class OverlayComponent {
   private _zIndex = 990;
 
   constructor(private readonly cdr: ChangeDetectorRef) {}
+
+  @HostListener('click')
+  onClick() {
+    this.click.emit(true);
+  }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/overlay/overlay.service.ts
@@ -24,7 +24,7 @@ export class OverlayService {
       throw new Error('ngx-ui OverlayService.show: triggerComponent missing ');
     }
     if (!this.component) {
-      this.component = this.injectComponent();
+      this.component = this.injectComponent(options.location);
       this.instance.click.subscribe(this.onClick.bind(this));
     }
 
@@ -61,8 +61,9 @@ export class OverlayService {
     }
   }
 
-  injectComponent(): ComponentRef<OverlayComponent> {
-    return this.injectionService.appendComponent(OverlayComponent);
+  injectComponent(location?: any): ComponentRef<OverlayComponent> {
+    const isRoot = location === undefined;
+    return this.injectionService.appendComponent(OverlayComponent, { inputs: { isRoot } }, location);
   }
 
   onClick() {

--- a/src/app/dialogs/drawer-page/drawer-container-example/drawer-container-example.component.ts
+++ b/src/app/dialogs/drawer-page/drawer-container-example/drawer-container-example.component.ts
@@ -21,7 +21,8 @@ export class DrawerContainerExampleComponent {
       context: 'Alert Everyone!',
       closeOnOutsideClick: true,
       parentContainer: this.el.nativeElement,
-      isRoot: false
+      isRoot: false,
+      showOverlay: true
     });
   }
 }

--- a/src/app/dialogs/drawer-page/drawer-page.component.html
+++ b/src/app/dialogs/drawer-page/drawer-page.component.html
@@ -199,7 +199,8 @@ export class DrawerContainerExampleComponent {
       context: 'Alert Everyone!',
       closeOnOutsideClick: true,
       parentContainer: this.el.nativeElement,
-      isRoot: false
+      isRoot: false,
+      showOverlay: true
     });
   }
 }]]>


### PR DESCRIPTION
## Summary

* Add `showOverlay` option to drawer service
* Drawer service passes parent container to overlay service when not root
* Allow overlay component to fill container

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
