### PR TITLE
add type to ngx-buttons

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Feature: `ngx-button` now accepts a `type` input
+- Breaking: `ngx-button` now defaults to `type="button"`
+
 ## 39.2.0 (2022-3-11)
 
 - Feature: Add small style variant to Dropzone component

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.html
@@ -1,4 +1,4 @@
-<button [disabled]="disabled">
+<button [disabled]="disabled" [attr.type]="type">
   <span class="content"><ng-content></ng-content></span>
   <span class="state-icon">
     <span *ngIf="inProgress$ | async" class="ngx-icon ngx-loading icon-fx-spinning"></span>

--- a/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/button/button.component.ts
@@ -38,6 +38,9 @@ export class ButtonComponent implements OnInit, OnChanges {
   disabled = false;
 
   @Input()
+  type = 'button';
+
+  @Input()
   get state() {
     return this._state;
   }


### PR DESCRIPTION
## Summary

- Feature: `ngx-button` now accepts a `type` input
- Breaking: `ngx-button` now defaults to `type="button"`

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
