### PR TITLE
Supporting custom templates for subtitle in large dialog component

### DIFF
--- a/cypress/integration/dialogs/large-format-dialog.spec.ts
+++ b/cypress/integration/dialogs/large-format-dialog.spec.ts
@@ -45,4 +45,18 @@ describe('Large Format Dialog', () => {
     cy.get('ngx-large-format-dialog-content').ngxClose();
     cy.get('ngx-large-format-dialog-content').should('not.exist');
   });
+
+  it('should open dialog with custom template for subTitle', () => {
+    cy.get('button').contains('Open Dialog with Custom Template for SubTitle').click();
+
+    cy.get('ngx-large-format-dialog-content').within(() => {
+      cy.get('.dialog-container__header h1').should('contain', 'Title');
+      cy.get('.dialog-container__header span').should('contain', 'Hi ');
+      cy.get('.dialog-container__header span i.ngx-icon.ngx-trend-level').should('exist');
+      cy.get('.dialog-container__header span i.ngx-icon.ngx-hand').should('exist');
+    });
+
+    cy.get('ngx-large-format-dialog-content').ngxClose();
+    cy.get('ngx-large-format-dialog-content').should('not.exist');
+  });
 });

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD (unreleased)
 
 - Fix (`ngx-select`): More overflow issues
+- Feature (`ngx-large-format-dialog-content`): Custom template support for subtitle
 
 ## 40.1.0 (2022-3-30)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.html
@@ -10,7 +10,10 @@
   >
     <h1>{{ dialogTitle }}</h1>
   </div>
-  <div *ngIf="dialogSubtitle" class="ngx-large-format-dialog-header-title__text-wrapper">
-    <h4>{{ dialogSubtitle }}</h4>
+  <div class="ngx-large-format-dialog-header-title__text-wrapper">
+    <h4 *ngIf="dialogSubtitle">{{ dialogSubtitle }}</h4>
+    <ng-container *ngIf="!dialogSubtitle && dialogSubtitleTemplate">
+      <ng-container *ngTemplateOutlet="dialogSubtitleTemplate"></ng-container>
+    </ng-container>
   </div>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.spec.ts
@@ -47,6 +47,11 @@ describe(LargeFormatDialogHeaderTitleComponent.name, () => {
       expect(nativeElement.querySelector('h4')).not.toBeTruthy();
     });
 
+    it('should not have subtitle when dialogSubtitleTemplate is defined', () => {
+      component.dialogSubtitleTemplate = null;
+      expect(nativeElement.querySelector('h4')).not.toBeTruthy();
+    });
+
     it('should have subtitle when subtitle is passed in', () => {
       component.dialogSubtitle = 'subtitle';
       fixture.detectChanges();

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.ts
@@ -1,4 +1,4 @@
-import { ElementRef } from '@angular/core';
+import { ElementRef, TemplateRef } from '@angular/core';
 import { ChangeDetectionStrategy, Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
@@ -13,5 +13,6 @@ export class LargeFormatDialogHeaderTitleComponent {
   @Input() dialogTitle = '';
   @Input() dialogSubtitle?: string;
   @Input() imageTemplate: any;
+  @Input() dialogSubtitleTemplate: TemplateRef<any>;
   @HostBinding('class.ngx-large-format-dialog-header-title') hostClass = true;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.ts
@@ -13,6 +13,6 @@ export class LargeFormatDialogHeaderTitleComponent {
   @Input() dialogTitle = '';
   @Input() dialogSubtitle?: string;
   @Input() imageTemplate: any;
-  @Input() dialogSubtitleTemplate: TemplateRef<any>;
+  @Input() dialogSubtitleTemplate: TemplateRef<unknown>;
   @HostBinding('class.ngx-large-format-dialog-header-title') hostClass = true;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
@@ -45,6 +45,7 @@
     [dialogTitle]="dialogTitle"
     [dialogSubtitle]="dialogSubtitle"
     [imageTemplate]="imageTemplate"
+    [dialogSubtitleTemplate]="dialogSubtitleTemplate"
   ></ngx-large-format-dialog-header-title>
   <ngx-large-format-dialog-header-action
     [dirty]="dirty"

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
@@ -32,7 +32,7 @@ export class LargeFormatDialogContentComponent implements OnInit {
   @Input() dialogTitle = '';
   @Input() dialogSubtitle?: string;
   @Input() imgSrc?: string | SafeUrl;
-  @Input() dialogSubtitleTemplate?: TemplateRef<any>;
+  @Input() dialogSubtitleTemplate?: TemplateRef<unknown>;
 
   // header-action inputs
   @Input() dialogActionTitle = 'Close';

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
@@ -32,6 +32,7 @@ export class LargeFormatDialogContentComponent implements OnInit {
   @Input() dialogTitle = '';
   @Input() dialogSubtitle?: string;
   @Input() imgSrc?: string | SafeUrl;
+  @Input() dialogSubtitleTemplate?: TemplateRef<any>;
 
   // header-action inputs
   @Input() dialogActionTitle = 'Close';

--- a/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.html
+++ b/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.html
@@ -103,6 +103,42 @@
   </app-prism>
 </ngx-section>
 
+<ngx-section class="shadow" sectionTitle="With custom template for subtitle">
+  <ng-template #largeFormatCustomSubtitle let-context="context">
+    <ngx-large-format-dialog-content 
+      dialogTitle="Title"
+      [dialogSubtitleTemplate]="myCustomTemplateSubtitle" 
+      (closeOrCancel)="onCloseOrCancel()">
+      <p>Content</p>
+    </ngx-large-format-dialog-content>
+  </ng-template>
+  <ng-template #myCustomTemplateSubtitle>
+    <span>Hi <i class="ngx-icon ngx-trend-level"></i> <i class="ngx-icon ngx-hand"></i></span>
+  </ng-template>
+
+  <button type="button" class="btn" (click)="openDialog({ template: largeFormatCustomSubtitle, format: 'large', closeOnEscape: true })">
+    Open Dialog with Custom Template for SubTitle
+  </button>
+
+  <app-prism>
+      <![CDATA[<ng-template #largeFormatCustomSubtitle let-context="context">
+        <ngx-large-format-dialog-content 
+          dialogTitle="Title"
+          [dialogSubtitleTemplate]="myCustomTemplateSubtitle" 
+          (closeOrCancel)="onCloseOrCancel()">
+          <p>Content</p>
+        </ngx-large-format-dialog-content>
+      </ng-template>
+      <ng-template #myCustomTemplateSubtitle>
+        <span>Hi <i class="ngx-icon ngx-trend-level"></i> <i class="ngx-icon ngx-hand"></i></span>
+      </ng-template>
+    
+      <button type="button" class="btn" (click)="openDialog({ template: largeFormatCustomSubtitle, format: 'large', closeOnEscape: true })">
+        Open Dialog with Custom Template for SubTitle
+      </button>]]>
+    </app-prism>
+</ngx-section>
+
 <ngx-section class="shadow" sectionTitle="Basic w/ Footer">
   <p>Large Format Dialog can also have a <strong>Footer</strong> by rendering <code>ngx-large-format-dialog-footer</code> component as its content</p>
 


### PR DESCRIPTION
## Summary

Adding support for custom templates in the large dialog subtitle section

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
