### PR TITLE
Display subtitle container only when there is subtitle

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.html
@@ -10,7 +10,7 @@
   >
     <h1>{{ dialogTitle }}</h1>
   </div>
-  <div class="ngx-large-format-dialog-header-title__text-wrapper">
+  <div *ngIf="dialogSubtitle || dialogSubtitleTemplate" class="ngx-large-format-dialog-header-title__text-wrapper">
     <h4 *ngIf="dialogSubtitle">{{ dialogSubtitle }}</h4>
     <ng-container *ngIf="!dialogSubtitle && dialogSubtitleTemplate">
       <ng-container *ngTemplateOutlet="dialogSubtitleTemplate"></ng-container>


### PR DESCRIPTION
## Summary

- Only display subtitle container when there is a subtitle, either string or via template.

Before: LFD without subtitle passed
![image](https://user-images.githubusercontent.com/62297014/162998504-f6204b45-d73d-4de8-b666-5df8847c0662.png)



After: LFD without subtitle passed
![image](https://user-images.githubusercontent.com/62297014/162997758-88b8cdab-eb81-49f2-9047-f49898877f88.png)


## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
