### PR TITLE
Resolved Open Issue #653

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.spec.ts
@@ -121,4 +121,12 @@ describe('DropdownComponent', () => {
       expect(component.dropdown.open).toBe(false);
     }));
   });
+
+  describe('closeDropdownWhenCloseMethodIsCalled', () => {
+    it('should close the dropdown when the close method is called', () => {
+      component.dropdown.open = true;
+      component.dropdown.close();
+      expect(component.dropdown.open).toBe(false);
+    });
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
@@ -176,7 +176,14 @@ export class DropdownComponent implements AfterContentInit, OnDestroy {
     }
   }
 
-  private close() {
+  /**
+   * @function close
+   *
+   * Programmatically closes the dropdown menu. This method provides the same behavior as clicking off of the dropdown menu.
+   *
+   * @returns void
+   */
+  public close(): void {
     if (this.dropdownMenu) {
       this.renderer.removeClass(this.dropdownMenu.element, 'ngx-dropdown-menu--upwards');
     }

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.component.ts
@@ -183,7 +183,7 @@ export class DropdownComponent implements AfterContentInit, OnDestroy {
    *
    * @returns void
    */
-  public close(): void {
+  close(): void {
     if (this.dropdownMenu) {
       this.renderer.removeClass(this.dropdownMenu.element, 'ngx-dropdown-menu--upwards');
     }


### PR DESCRIPTION
## Summary

Added a public method to programmatically close the `NgxDropdown` component. This method can be accessed by creating a `ViewChild` in your Angular component, which references the `NgxDropdown` component.

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
