### PR TITLE
Json schema builder

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## HEAD (unreleased)
 
 - Fix (`ngx-select`): Tagging option width is not correct
+- Fix (`ngx-property-config`): Apply button no longer closes all dialogs
+- Feature (`ngx-property-config`): Property names and now generated from title and locked until changed
+- Feature (`ngx-input`): Now emits `lockChange` even when an input is unlocked
 
 ## 40.4.0 (2022-4-12)
 

--- a/projects/swimlane/ngx-ui/ng-package.json
+++ b/projects/swimlane/ngx-ui/ng-package.json
@@ -16,5 +16,5 @@
       "ng-in-viewport": "ngInViewport"
     }
   },
-  "allowedNonPeerDependencies": ["mousetrap", "ng2-file-upload", "normalize.css"]
+  "allowedNonPeerDependencies": ["mousetrap", "ng2-file-upload", "normalize.css", "camelcase"]
 }

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -46,6 +46,7 @@
     "ng-in-viewport": "^6.1.5"
   },
   "dependencies": {
+    "camelcase": "^5.0.0",
     "mousetrap": "^1.6.2",
     "@swimlane/ng2-file-upload": "1.1.0",
     "normalize.css": "^5.0.0",

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input.component.ts
@@ -197,6 +197,7 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
   @Output() keyup = new EventEmitter<KeyboardEvent>();
   @Output() click = new EventEmitter<Event>();
   @Output() select = new EventEmitter<FocusEvent>();
+  @Output() lockChange = new EventEmitter<boolean>();
 
   @ViewChild('inputControl') readonly inputControl: ElementRef<HTMLInputElement>;
   @ViewChild('inputModel') readonly inputModel: NgModel;
@@ -376,6 +377,7 @@ export class InputComponent implements AfterViewInit, OnDestroy, ControlValueAcc
       this.value = '';
     }
     this.disabled = false;
+    this.lockChange.emit(false);
     this.updateInputType();
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.html
@@ -29,7 +29,7 @@
     [schema]="context.schema"
     [formats]="context.formats"
     [rootItem]="true"
-    (updateSchema)="updateSchema($event)"
+    (updateProperty)="context.apply($event)"
   >
   </ngx-property-config>
 </ng-template>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
@@ -77,18 +77,22 @@ export class JsonEditorFlatComponent extends JsonEditor implements OnInit, OnCha
   }
 
   onPropertyConfig(): void {
-    this.dialogService.create({
+    const dialog = this.dialogService.create({
       template: this.propertyConfigTmpl,
       context: {
         property: this.schema,
         schema: this.schema,
-        formats: this.customFormats
+        formats: this.customFormats,
+        apply: (options: PropertyConfigOptions) => {
+          dialog.destroy();
+          this.updateSchemaProperty(options);
+        }
       },
       class: 'property-config-dialog'
     });
   }
 
-  updateSchema(options: PropertyConfigOptions): void {
+  updateSchemaProperty(options: PropertyConfigOptions): void {
     const editedSchema = options.newProperty;
 
     if (editedSchema.title) {

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
@@ -113,7 +113,7 @@
     [schema]="context.schema"
     [formats]="context.formats"
     [arrayItem]="true"
-    (updateSchema)="updateSchema($event)"
+    (updateProperty)="context.apply($event)"
   >
   </ngx-property-config>
 </ng-template>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.ts
@@ -62,19 +62,23 @@ export class ArrayNodeFlatComponent extends ArrayNode implements OnInit, OnChang
   }
 
   onPropertyConfig(item: JSONEditorSchema, index: number): void {
-    this.dialogService.create({
+    const dialog = this.dialogService.create({
       template: this.propertyConfigTmpl,
       context: {
         property: item,
         index,
         schema: this.schema,
-        formats: this.formats
+        formats: this.formats,
+        apply: (options: PropertyConfigOptions) => {
+          dialog.destroy();
+          this.updateSchemaProperty(options);
+        }
       },
       class: 'property-config-dialog'
     });
   }
 
-  updateSchema(options: PropertyConfigOptions): void {
+  updateSchemaProperty(options: PropertyConfigOptions): void {
     this.schema.items = options.newProperty;
     this.schemaRef.items = options.newProperty;
     this.schemaUpdate.emit();

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -178,7 +178,7 @@
     [index]="context.index"
     [schema]="context.schema"
     [formats]="context.formats"
-    (updateSchema)="updateSchema($event)"
+    (updateProperty)="context.apply($event)"
   >
   </ngx-property-config>
 </ng-template>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.ts
@@ -92,19 +92,23 @@ export class ObjectNodeFlatComponent extends ObjectNode implements OnInit, OnCha
   }
 
   onPropertyConfig(property: JSONEditorSchema, index: number): void {
-    this.dialogService.create({
+    const dialog = this.dialogService.create({
       template: this.propertyConfigTmpl,
       context: {
         property,
         index,
         schema: this.schema,
-        formats: this.formats
+        formats: this.formats,
+        apply: (options: PropertyConfigOptions) => {
+          dialog.destroy();
+          this.updateSchemaProperty(options);
+        }
       },
       class: 'property-config-dialog'
     });
   }
 
-  updateSchema(options: PropertyConfigOptions): void {
+  updateSchemaProperty(options: PropertyConfigOptions): void {
     const oldProperty = options.oldProperty;
     const newProperty = options.newProperty;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/property-config/property-config.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/property-config/property-config.component.html
@@ -7,6 +7,17 @@
   </div>
   <ngx-tabs *ngIf="property">
     <ngx-tab label="GENERAL">
+      <!-- TITLE -->
+      <ngx-input
+        *ngIf="!arrayItem"
+        type="text"
+        [(ngModel)]="editableProperty.title"
+        (change)="onTitleChange($event)"
+        [label]="'PROPERTY TITLE'"
+        [hint]="'A human-readable name for this property'"
+      >
+      </ngx-input>
+
       <!-- PROPERTY NAME -->
       <ngx-input
         *ngIf="!arrayItem && !rootItem"
@@ -15,17 +26,9 @@
         [(ngModel)]="editableProperty.propertyName"
         [label]="'PROPERTY NAME'"
         [required]="true"
+        [unlockable]="true"
+        (lockChanged)="isNameLocked = $event"
         [hint]="'Must only contain A-Z, a-z, 0-9 or _'"
-      >
-      </ngx-input>
-
-      <!-- TITLE -->
-      <ngx-input
-        *ngIf="!arrayItem"
-        type="text"
-        [(ngModel)]="editableProperty.title"
-        [label]="'PROPERTY TITLE'"
-        [hint]="'A human-readable name for this property'"
       >
       </ngx-input>
 
@@ -48,6 +51,7 @@
           (ngModelChange)="updateType($event[0])"
           [required]="true"
           [label]="'TYPE'"
+          [disabled]="!canChangeType"
         >
           <ngx-select-option *ngFor="let propType of propTypes" [name]="propType" [value]="propType">
           </ngx-select-option>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/property-config/property-config.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/property-config/property-config.component.ts
@@ -7,9 +7,9 @@ import {
   ViewEncapsulation,
   ChangeDetectionStrategy
 } from '@angular/core';
-import { DialogService } from '../../../../../dialog/dialog.service';
 import { JSONEditorSchema, propTypes, JsonSchemaDataType } from '../../../../json-editor.helper';
 import { JSONSchema7TypeName } from 'json-schema';
+import camelCase from 'camelcase';
 
 export interface PropertyConfigOptions {
   required: boolean;
@@ -38,7 +38,7 @@ export class PropertyConfigComponent implements OnInit {
 
   @Input() rootItem? = false;
 
-  @Output() updateSchema = new EventEmitter<PropertyConfigOptions>();
+  @Output() updateProperty = new EventEmitter<PropertyConfigOptions>();
 
   propTypes: string[] = propTypes;
 
@@ -46,12 +46,16 @@ export class PropertyConfigComponent implements OnInit {
 
   required = false;
 
-  newEnumValue = '';
+  isNameLocked = true;
 
-  constructor(private dialogService: DialogService) {}
+  canChangeType = false;
+
+  newEnumValue = '';
 
   ngOnInit() {
     this.editableProperty = JSON.parse(JSON.stringify(this.property));
+    this.isNameLocked = this.property.propertyName === camelCase(this.property.title);
+    this.canChangeType = !this.property.type;
 
     if (!this.arrayItem) {
       this.setRequired();
@@ -59,8 +63,7 @@ export class PropertyConfigComponent implements OnInit {
   }
 
   applyChanges(): void {
-    this.dialogService.destroyAll();
-    this.updateSchema.emit({
+    this.updateProperty.emit({
       required: this.required,
       index: this.index,
       newProperty: this.editableProperty,
@@ -122,6 +125,12 @@ export class PropertyConfigComponent implements OnInit {
     if (!enumValues.length) {
       // Remove enum property if empty
       delete this.editableProperty.enum;
+    }
+  }
+
+  onTitleChange(title: string): void {
+    if (this.isNameLocked) {
+      this.editableProperty.propertyName = camelCase(title);
     }
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/node-types/object-node.component.ts
@@ -22,6 +22,7 @@ import {
   PropertyIndex
 } from '../json-editor.helper';
 import { JSONSchema7TypeName } from 'json-schema';
+import camelCase from 'camelcase';
 
 @Directive()
 export class ObjectNode implements OnInit, OnChanges {
@@ -145,14 +146,26 @@ export class ObjectNode implements OnInit, OnChanges {
    * Adds a new property to the model
    */
   addProperty(dataType: JsonSchemaDataType): void {
-    const propName = `${dataType.name} ${this.propertyCounter}`;
-    this.propertyCounter++;
-    const schema = JSON.parse(JSON.stringify(dataType.schema));
+    let propertyCounter = 1;
+    let propTitle = `${dataType.name}`;
+    let propName = camelCase(propTitle);
 
-    this.model = { ...this.model };
-    this.model[propName] = createValueForSchema(dataType.schema as JSONEditorSchema);
+    // Find a unique name
+    while (propName in this.model) {
+      propTitle = `${dataType.name} ${propertyCounter}`;
+      propName = camelCase(propTitle);
+      propertyCounter++;
+    }
+
+    const schema = JSON.parse(JSON.stringify(dataType.schema)) as JSONEditorSchema;
+
+    this.model = {
+      ...this.model,
+      [propName]: createValueForSchema(schema)
+    };
     schema.nameEditable = !this.schemaBuilderMode;
     schema.propertyName = propName;
+    schema.title = propTitle;
 
     schema.id = this.propertyId++;
     this.propertyIndex[schema.id] = schema;


### PR DESCRIPTION
## Summary

- Fix (`ngx-property-config`): Apply button no longer closes all dialogs
- Feature (`ngx-property-config`): Property names and now generated from title and locked until changed
- Feature (`ngx-input`): Now emits `lockChange` even when an input is unlocked

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
