### PR TITLE
improvements to JSON editor text displays

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix (`ngx-select`): Tagging option width is not correct
 - Fix (`ngx-property-config`): Apply button no longer closes all dialogs
+- Fix (`ngx-json-editor-flat`): Long name and descriptions now display properly
 - Feature (`ngx-property-config`): Property names and now generated from title and locked until changed
 - Feature (`ngx-input`): Now emits `lockChange` even when an input is unlocked
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/node-info/node-info.component.scss
@@ -35,34 +35,47 @@ ngx-json-editor-node-info {
     overflow: hidden;
   }
 
-  .required,
   .info-type,
-  .property-name {
-    font-size: 12px;
-  }
-
-  .description {
-    font-size: 14px;
-  }
-
-  .required {
-    color: $color-red-400;
-  }
-
-  .property-name,
-  .dot-separator,
   .description {
     color: $color-blue-grey-250;
   }
 
-  .dot-separator {
-    font-size: 0.2em;
-    margin: 0 5px;
-    vertical-align: middle;
+  .info-type {
+    display: inline-flex;
+    font-size: 12px;
+    color: $color-blue-grey-250;
+    white-space: nowrap;
+
+    > * {
+      flex: 0 1 auto;
+      overflow: clip;
+      text-overflow: ellipsis;
+    }
+
+    .type {
+      flex: 0 0 auto;
+      color: #f0f1f6;
+    }
+
+    .dot-separator {
+      flex: 0 0 auto;
+      font-size: 0.2em;
+      margin: 0 5px;
+      vertical-align: middle;
+      line-height: 20px;
+    }
   }
 
-  .type {
-    color: #f0f1f6;
+  .description {
+    font-size: 14px;
+    color: $color-blue-grey-250;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: clip;
+  }
+
+  .required {
+    color: $color-red-400;
   }
 
   .editable-name {


### PR DESCRIPTION
## Summary

Long name and descriptions now display properly

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

Before:
<img width="520" alt="image" src="https://user-images.githubusercontent.com/509946/167675257-61cd52eb-fa61-4738-a420-140109b04fd6.png">


After:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/509946/167675277-e73ee005-dc9f-4c34-bee5-90e1c703e791.png">

