### PR TITLE
(release): 41.0.0

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 41.0.0 (2022-5-12)
+
 - Enhancement (`ngx-large-format-dialog-content`): Changing Active tab indicator (blue line) to the header bottom line level
 - Fix (`ngx-select`): Tagging option width is not correct
 - Fix (`ngx-property-config`): Apply button no longer closes all dialogs

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "40.5.0",
+  "version": "41.0.0",
   "engines": {
     "node": ">=12.0.0"
   },


### PR DESCRIPTION
## Summary

- Enhancement (`ngx-large-format-dialog-content`): Changing Active tab indicator (blue line) to the header bottom line level
- Fix (`ngx-select`): Tagging option width is not correct
- Fix (`ngx-property-config`): Apply button no longer closes all dialogs
- Fix (`ngx-json-editor-flat`): Long name and descriptions now display properly
- Feature (`ngx-property-config`): When a new property is added (in schema builder mode):
  - the property dialog is shown
  - the property name is generated from the title
  - the property type is editable
- Feature (`ngx-input`): Now emits `lockChange` even when an input is unlocked
- Enhancement: Added webhook icons
- BREAKING (`ngx-property-config`): Type is not editable once a property is added

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
