### PR TITLE
Fixing position and header, footer borders width

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Enhancement (`ngx-large-format-dialog-content`): Active tab indicator (blue line) position
+
 ## 42.0.3 (2022-5-17)
 
 - Enhancement (`ngx-property-config`): names generated from title are now Snake_Case

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.scss
@@ -25,7 +25,7 @@
     &__header {
       max-height: 90px;
       height: 90px;
-      border-bottom: 1px solid $color-blue-grey-700;
+      border-bottom: 2px solid $color-blue-grey-700;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -42,7 +42,7 @@
       max-height: 4rem;
       flex: 0 0 4rem;
       height: 4rem;
-      border-top: 1px solid $color-blue-grey-700;
+      border-top: 2px solid $color-blue-grey-700;
     }
 
     & .dialog-stepper,
@@ -82,6 +82,10 @@
 
       & .ngx-tabs.tabs-horizontal button.ngx-tab {
         height: 100%;
+      }
+
+      & .ngx-tabs.tabs-horizontal button.ngx-tab::after {
+        bottom: 1px;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixing position of the tab active line of large-format-dialog component
Changing width of header and footer lines of large-format-dialog component

![image](https://user-images.githubusercontent.com/14807967/170707669-b1e745df-cee1-4cbd-b58e-34d2f2ecca31.png)

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
