### PR TITLE
Adding support for binary format properties in json editor

### DIFF
--- a/cypress/e2e/components/json-editor.cy.ts
+++ b/cypress/e2e/components/json-editor.cy.ts
@@ -1,0 +1,53 @@
+describe('Json Editor', () => {
+  before(() => {
+    cy.visit('/json-editor');
+    cy.get('.page-loader').should('not.exist', { timeout: 20000 });
+  });
+
+  describe('JSON Editor', () => {
+    it('Should have data', () => {
+      cy.get('ngx-section').first().as('section1');
+      cy.get('@section1').within(() => {
+        cy.get('header h1').should('have.text', 'JSON Editor');
+        cy.get('ngx-json-editor-node').should('exist');
+      });
+    });
+
+    it('Should recognize binary format properties', () => {
+      cy.get('ngx-section').first().as('section1');
+      cy.get('@section1').within(() => {
+        cy.get('ngx-json-object-node > div > div').eq(10).as('divContainerBinary');
+        cy.get('@divContainerBinary').within(() => {
+          cy.get('.property-def .title').should('contain.text', 'File Binary');
+          cy.get('ngx-json-editor-node textarea').should('exist');
+        });
+      });
+    });
+  });
+
+  describe('JSON Editor Flat', () => {
+    it('Should have data', () => {
+      cy.get('ngx-section').eq(1).as('section2');
+      cy.get('@section2').within(() => {
+        cy.get('header h1').should('have.text', 'ngx-json-editor-flat');
+        cy.get('ngx-json-editor-flat').should('exist');
+      });
+    });
+
+    it('Should recognize binary format properties', () => {
+      cy.get('ngx-section').eq(1).as('section2');
+      cy.get('@section2').within(() => {
+        cy.get('ngx-json-editor-flat div.node').eq(11).as('divContainerBinary');
+        cy.get('@divContainerBinary').within(() => {
+          cy.get('ngx-json-editor-node-info').within(() => {
+            cy.get('.name').should('contain', 'File Binary');
+            cy.get('.type').should('contain', 'String');
+          });
+          cy.get('.node-input').within(() => {
+            cy.get('textarea').should('exist');
+          });
+        });
+      });
+    });
+  });
+});

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD (unreleased)
 
 - Enhancement (`ngx-select`): Add option values as `data-value` attribute.
+- Enhancement (`ngx-json-editor-flat`): Add support for binary format properties.
 
 ## 42.0.6 (2022-6-8)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -18,7 +18,7 @@
             [propertyName]="arrayName ? arrayName : schema?.propertyName"
             (propertyNameChange)="updatePropertyName(schema.id, $event)"
             [title]="schema?.title || label || (arrayItem ? 'Items' : schema?.propertyName)"
-            [type]="(schema?.format || schema?.type | titlecase) + (schema?.enum?.length ? ' + Enum' : '')"
+            [type]="(schema?.format && schema?.format !== 'binary' ? schema?.format : schema?.type | titlecase) + (schema?.enum?.length ? ' + Enum' : '')"
             [description]="schema?.description"
             [examples]="schema?.examples"
             [required]="required"
@@ -55,7 +55,7 @@
           <!-- String -->
           <ng-container *ngIf="schema?.type === 'string'">
             <!-- No format -->
-            <div *ngIf="!schema.format">
+            <div *ngIf="!schema.format || schema.format === 'binary'">
               <ngx-input
                 appearance="fill"
                 *ngIf="!schema?.enum"

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
@@ -89,7 +89,7 @@
     <!-- String -->
     <ng-container *ngIf="schema?.type === 'string'">
       <!-- No format -->
-      <div *ngIf="!schema.format">
+      <div *ngIf="!schema.format || schema.format === 'binary'">
         <textarea
           *ngIf="!schema?.enum"
           class="value-input"

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
@@ -13,6 +13,7 @@ export class SchemaValidatorService {
     });
     this.ajv.addFormat('password', '.*');
     this.ajv.addFormat('code', '.*');
+    this.ajv.addFormat('binary', '.*');
   }
 
   /**

--- a/src/app/components/json-editor-page/json-editor-page.component.ts
+++ b/src/app/components/json-editor-page/json-editor-page.component.ts
@@ -90,9 +90,14 @@ export class JsonEditorPageComponent {
         title: 'User API key',
         type: 'string',
         format: 'password'
+      },
+      file: {
+        title: 'File Binary',
+        type: 'string',
+        format: 'binary'
       }
     },
-    required: ['productId', 'productName', 'price', 'availability', 'onSale', 'dimensions', 'userApiKey']
+    required: ['productId', 'productName', 'price', 'availability', 'onSale', 'dimensions', 'userApiKey', 'file']
   };
 
   hideRoot = false;


### PR DESCRIPTION
## Summary

Adding support for binary format properties in json editor (including flat editor). Binary format should render a textbox

Schema
![image](https://user-images.githubusercontent.com/14807967/175333658-5ba26c7e-0341-4ab3-8912-79a10950b6a3.png)

Json editor
![image](https://user-images.githubusercontent.com/14807967/175334536-331cc04f-9453-4475-8312-cac9092e1de1.png)


Json editor flat
![image](https://user-images.githubusercontent.com/14807967/175334384-5ef2e24f-0ac1-40eb-afa2-711cc8caa11a.png)



## Checklist

- [X] \*Added unit tests
- [x] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [X] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
