### PR TITLE
Applying titlecase pipe correctly

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-json-editor-flat`): Applying titlecase pipe to type value in html.
+
 ## 42.0.7 (2022-6-24)
 
 - Enhancement (`ngx-select`): Add option values as `data-value` attribute.

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -18,7 +18,7 @@
             [propertyName]="arrayName ? arrayName : schema?.propertyName"
             (propertyNameChange)="updatePropertyName(schema.id, $event)"
             [title]="schema?.title || label || (arrayItem ? 'Items' : schema?.propertyName)"
-            [type]="(schema?.format && schema?.format !== 'binary' ? schema?.format : schema?.type | titlecase) + (schema?.enum?.length ? ' + Enum' : '')"
+            [type]="((schema?.format && schema?.format !== 'binary' ? schema?.format : schema?.type) | titlecase) + (schema?.enum?.length ? ' + Enum' : '')"
             [description]="schema?.description"
             [examples]="schema?.examples"
             [required]="required"


### PR DESCRIPTION
## Summary

Applying titlecase pipe correctly in json flat editor

Before
![image](https://user-images.githubusercontent.com/14807967/175645000-697b0aa8-74be-4052-8032-3c3aeeda5fdc.png)


After
![image](https://user-images.githubusercontent.com/14807967/175644925-9a28930b-2c70-4a5e-8f18-2afc05011b54.png)


## Checklist

- [ ] \*Added unit tests
- [X] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [X] Included screenshots of visual changes

_\*required_
