### PR TITLE
(release): 42.1.0

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD (unreleased)
 
+## 42.1.0 (2022-7-12)
+
+- Feature (`ngx-input`): Added `readonly` input
+
 ## 42.0.9 (2022-7-12)
 
 - Enhancement (`ngx-dialog`): Dialog close behavior can be controlled by `beforeClose` method when `closeOnEscape` or `closeOnBlur` are `true`

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "42.0.9",
+  "version": "42.1.0",
   "engines": {
     "node": ">=12.0.0"
   },


### PR DESCRIPTION
## Summary

Release `42.1.0`, which adds `readonly` support to the `ngx-input` component.

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
