### PR TITLE
Resolved issue with select filter not auto-focusing on open

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.spec.ts
@@ -80,7 +80,7 @@ describe('SelectDropdownComponent', () => {
       setTimeout(() => {
         expect(spy).toHaveBeenCalled();
         done();
-      }, 5);
+      }, 50);
     });
   });
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -128,7 +128,7 @@ export class SelectDropdownComponent implements AfterViewInit {
     if (this.filterable && !this.tagging) {
       setTimeout(() => {
         this.filterInput.nativeElement.focus();
-      }, 5);
+      }, 50);
     }
   }
 


### PR DESCRIPTION
## Summary

Resolved issue with `ngx-select` not consistently auto-focusing on the filter input when opened and when filtering is enabled.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
