### PR TITLE
Update changelog to match released features

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## HEAD (unreleased)
 
-- Enhancement (`ngx-dropdown`): Improve styles and behavior of dividers
-
 ## 42.1.1 (2022-7-18)
 
 - Fix (`ngx-select`): Filter input doesn't consistently autofocus on open
+- Fix (`ngx-json-editor-flat`): Fix bugs on json editor flat to allow to create array of objects
+- Enhancement (`ngx-dropdown`): Improve styles and behavior of dividers
 
 ## 42.1.0 (2022-7-12)
 
@@ -15,7 +15,6 @@
 ## 42.0.9 (2022-7-12)
 
 - Enhancement (`ngx-dialog`): Dialog close behavior can be controlled by `beforeClose` method when `closeOnEscape` or `closeOnBlur` are `true`
-- Fix (`ngx-json-editor-flat`): Fix bugs on json editor flat to allow to create array of objects
 
 ## 42.0.8 (2022-6-24)
 


### PR DESCRIPTION
## Summary

When I merged this PR https://github.com/swimlane/ngx-ui/pull/899, I failed to pull latest from master and messed up the changelog a bit. Moving this two features under today's 42.1.1 release since on that one is where they were shipped.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
