### PR TITLE
SPT-10204: ngx-select Caret and Clear Fix

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -67,7 +67,6 @@
       title="Clear Selections"
       aria-label="Clear Selections"
       class="ngx-select-clear"
-      [class]="{ 'ngx-select-clear--auto': autoTextSize }"
       (click)="onClear($event)"
     >
       <i class="ngx-icon ngx-x-small"></i>
@@ -77,7 +76,6 @@
       *ngIf="caretVisible"
       aria-label="Toggle Dropdown"
       class="ngx-select-caret"
-      [class]="{ 'ngx-select-caret--auto': autoTextSize }"
       (click)="onToggle($event)"
     >
       <i *ngIf="!selectCaret" class="ngx-icon ngx-chevron-bold-down"></i>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -1,88 +1,92 @@
-<div
-  [tabindex]="disabled ? -1 : tabindex"
-  (keydown)="onKeyDown($event)"
-  (keyup)="onGlobalKeyUp($event)"
-  class="ngx-select-input-box"
-  (click)="onClick()"
-  (focus)="onFocus()"
-  #inputContainer
->
-  <label *ngIf="label" class="ngx-select-label" [attr.for]="selectId">
-    <span>{{ label }}</span>
-    <span [innerHTML]="requiredIndicator"></span>
-  </label>
-  <span *ngIf="!selected?.length && placeholder" class="ngx-select-placeholder" [innerHTML]="placeholder"> </span>
-  <ul
-    *ngIf="tagging || selectedOptions?.length"
-    class="horizontal-list ngx-select-input-list"
-    [class.no-selections]="!selected?.length"
+<div class="ngx-select-input-box-outer-wrap">
+  <div
+    [tabindex]="disabled ? -1 : tabindex"
+    (keydown)="onKeyDown($event)"
+    (keyup)="onGlobalKeyUp($event)"
+    class="ngx-select-input-box"
+    (click)="onClick()"
+    (focus)="onFocus()"
+    #inputContainer
   >
-    <li
-      *ngFor="let option of selectedOptions"
-      class="ngx-select-input-option"
-      [class.disabled]="multiple && selectedOptions.length > 1 && option.disabled"
+    <label *ngIf="label" class="ngx-select-label" [attr.for]="selectId">
+      <span>{{ label }}</span>
+      <span [innerHTML]="requiredIndicator"></span>
+    </label>
+    <span *ngIf="!selected?.length && placeholder" class="ngx-select-placeholder" [innerHTML]="placeholder"> </span>
+    <ul
+      *ngIf="tagging || selectedOptions?.length"
+      class="horizontal-list ngx-select-input-list"
+      [class.no-selections]="!selected?.length"
     >
-      <ng-template
-        *ngIf="option.inputTemplate"
-        [ngTemplateOutlet]="option.inputTemplate"
-        [ngTemplateOutletContext]="{ option: option }"
+      <li
+        *ngFor="let option of selectedOptions"
+        class="ngx-select-input-option"
+        [class.disabled]="multiple && selectedOptions.length > 1 && option.disabled"
       >
+        <ng-template
+          *ngIf="option.inputTemplate"
+          [ngTemplateOutlet]="option.inputTemplate"
+          [ngTemplateOutletContext]="{ option: option }"
+        >
+        </ng-template>
+        <span *ngIf="!option.inputTemplate" class="ngx-select-input-name" [innerHTML]="option.name || option.value">
+        </span>
+        <button
+          type="button"
+          *ngIf="allowClear && (multiple || tagging) && !option.disabled"
+          title="Remove Selection"
+          class="ngx-select-clear"
+          (click)="onOptionRemove($event, option)"
+        >
+          <i class="ngx-icon ngx-x-small"></i>
+        </button>
+      </li>
+      <li *ngIf="tagging" class="ngx-select-input-box-wrapper">
+        <input
+          #tagInput
+          type="search"
+          class="ngx-select-text-box"
+          autocomplete="off"
+          autocorrect="off"
+          spellcheck="off"
+          (keydown)="onInputKeyDown($event)"
+          (keyup)="onInputKeyUp($event)"
+          (change)="$event.stopPropagation()"
+          (blur)="clearInput()"
+        />
+        <button type="button" aria-label="Clear" *ngIf="tagInput.value" class="ngx-select-clear-tagging-input" (click)="onClearTaggingInput($event)">
+          <i class="ngx-icon ngx-x-small"></i>
+        </button>
+      </li>
+    </ul>
+  </div>
+  <div class="ngx-select-input-box__controls" *ngIf="hasControls">
+    <button
+      type="button"
+      *ngIf="clearVisible"
+      title="Clear Selections"
+      aria-label="Clear Selections"
+      class="ngx-select-clear"
+      [class]="{ 'ngx-select-clear--auto': autoTextSize }"
+      (click)="onClear($event)"
+    >
+      <i class="ngx-icon ngx-x-small"></i>
+    </button>
+    <button
+      type="button"
+      *ngIf="caretVisible"
+      aria-label="Toggle Dropdown"
+      class="ngx-select-caret"
+      [class]="{ 'ngx-select-caret--auto': autoTextSize }"
+      (click)="onToggle($event)"
+    >
+      <i *ngIf="!selectCaret" class="ngx-icon ngx-chevron-bold-down"></i>
+      <span *ngIf="isNotTemplate; else tpl" [innerHTML]="selectCaret"> </span>
+      <ng-template #tpl>
+        <ng-container *ngTemplateOutlet="selectCaret"></ng-container>
       </ng-template>
-      <span *ngIf="!option.inputTemplate" class="ngx-select-input-name" [innerHTML]="option.name || option.value">
-      </span>
-      <button
-        type="button"
-        *ngIf="allowClear && (multiple || tagging) && !option.disabled"
-        title="Remove Selection"
-        class="ngx-select-clear"
-        (click)="onOptionRemove($event, option)"
-      >
-        <i class="ngx-icon ngx-x-small"></i>
-      </button>
-    </li>
-    <li *ngIf="tagging" class="ngx-select-input-box-wrapper">
-      <input
-        #tagInput
-        type="search"
-        class="ngx-select-text-box"
-        autocomplete="off"
-        autocorrect="off"
-        spellcheck="off"
-        (keydown)="onInputKeyDown($event)"
-        (keyup)="onInputKeyUp($event)"
-        (change)="$event.stopPropagation()"
-        (blur)="clearInput()"
-      />
-      <button type="button" aria-label="Clear" *ngIf="tagInput.value" class="ngx-select-clear-tagging-input" (click)="onClearTaggingInput($event)">
-        <i class="ngx-icon ngx-x-small"></i>
-      </button>
-    </li>
-  </ul>
-</div>
-<div class="ngx-select-input-box__controls" *ngIf="hasControls">
-  <button
-    type="button"
-    *ngIf="clearVisible"
-    title="Clear Selections"
-    aria-label="Clear Selections"
-    class="ngx-select-clear"
-    (click)="onClear($event)"
-  >
-    <i class="ngx-icon ngx-x-small"></i>
-  </button>
-  <button
-    type="button"
-    *ngIf="caretVisible"
-    aria-label="Toggle Dropdown"
-    class="ngx-select-caret"
-    (click)="onToggle($event)"
-  >
-    <i *ngIf="!selectCaret" class="ngx-icon ngx-chevron-bold-down"></i>
-    <span *ngIf="isNotTemplate; else tpl" [innerHTML]="selectCaret"> </span>
-    <ng-template #tpl>
-      <ng-container *ngTemplateOutlet="selectCaret"></ng-container>
-    </ng-template>
-  </button>
+    </button>
+  </div>
 </div>
 <div class="ngx-select-input-underline">
   <div class="underline-fill"></div>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -51,7 +51,15 @@ $color-chip-text: #fff;
     margin-bottom: 0;
     width: 100%;
 
+    .ngx-select-input-box-outer-wrap {
+      align-items: center;
+      display: flex;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+    }
+
     .ngx-select-input-box {
+      align-items: center;
       position: relative;
       background: transparent;
       outline: none;
@@ -61,7 +69,7 @@ $color-chip-text: #fff;
       min-height: 1.75em;
       min-width: 60px;
       cursor: pointer;
-      display: inline-block;
+      display: flex;
       vertical-align: bottom;
     }
 
@@ -84,7 +92,7 @@ $color-chip-text: #fff;
     }
 
     &--has-controls .ngx-select-input-list {
-      padding: 0 40px 0 0;
+      padding: 0 10px 0 0;
     }
 
     .ngx-select-label {
@@ -104,12 +112,10 @@ $color-chip-text: #fff;
     }
 
     .ngx-select-input-box__controls {
-      position: absolute;
-      top: 0.4em;
-      right: 5px;
-      z-index: 500;
-      font-size: 0.6em;
       color: $color-caret-bg;
+      display: flex;
+      flex-wrap: nowrap;
+      margin-right: 5px;
 
       button {
         padding: 0 2px;
@@ -120,8 +126,13 @@ $color-chip-text: #fff;
         }
       }
 
+      .ngx-select-clear,
+      .ngx-select-caret {
+        font-size: 0.6em;
+      }
+
       .ngx-select-clear {
-        font-size: 0.8em;
+        margin-right: 5px;
       }
 
       .ngx-select-caret {
@@ -208,6 +219,7 @@ $color-chip-text: #fff;
     .ngx-select-input {
       .ngx-select-input-box {
         cursor: text;
+        flex: 1;
       }
 
       .ngx-select-input-box-wrapper {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -115,11 +115,13 @@ $color-chip-text: #fff;
       color: $color-caret-bg;
       display: flex;
       flex-wrap: nowrap;
-      margin-right: 5px;
+      min-height: 1.75em;
+      padding-right: 5px;
 
       button {
         padding: 0 2px;
         cursor: pointer;
+        min-height: 1em;
 
         &:hover {
           color: $color-blue-400;
@@ -128,6 +130,8 @@ $color-chip-text: #fff;
 
       .ngx-select-clear,
       .ngx-select-caret {
+        align-items: center;
+        display: flex;
         font-size: 0.6em;
       }
 
@@ -530,11 +534,15 @@ $color-chip-text: #fff;
       padding-left: 10px;
     }
 
-    .ngx-select-flex-wrap .ngx-select-input-box {
-      @include input-fill-background;
+    .ngx-select-flex-wrap {
+      .ngx-select-input-box-outer-wrap {
+        @include input-fill-background;
+      }
 
-      min-height: 1.75em;
-      color: $color-blue-grey-050;
+      .ngx-select-input-box {
+        min-height: 1.75em;
+        color: $color-blue-grey-050;
+      }
     }
 
     .ngx-select-placeholder {


### PR DESCRIPTION
## Draft

Still doing some manual tests in places other than the demo application.

## Summary

Fixed the issue of inconsistent sizing and vertical alignment of the clear (x) and caret (v) by wrapping both the input and the input controls in a flex box and using flex properties instead of absolute alignment.

Fixes ngx-select caret scales inconsistently #583

<img width="816" alt="Screen Shot 2022-08-11 at 11 31 57 AM" src="https://user-images.githubusercontent.com/12173936/184196810-4782b0f2-2fa2-4410-9937-a00b69e35d2f.png">

<img width="810" alt="Screen Shot 2022-08-11 at 11 32 08 AM" src="https://user-images.githubusercontent.com/12173936/184196828-cb2020e3-d67a-431a-863d-869e1e07de10.png">

<img width="815" alt="Screen Shot 2022-08-11 at 11 32 25 AM" src="https://user-images.githubusercontent.com/12173936/184196845-56734563-3b02-41d1-a7b4-932ddda47b3f.png">

<img width="812" alt="Screen Shot 2022-08-11 at 11 32 34 AM" src="https://user-images.githubusercontent.com/12173936/184196851-9a54a898-ef7e-4005-8bd5-0ee40ff562ae.png">

<img width="1438" alt="Screen Shot 2022-08-11 at 11 57 32 AM" src="https://user-images.githubusercontent.com/12173936/184205791-1e9c9db3-268a-4bf4-9c71-935092f1101f.png">

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
