### PR TITLE
schema-validator.service.ts: use constructor in declare class

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/schema-validator.service.ts
@@ -5,12 +5,11 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class SchemaValidatorService {
-  ajv: Ajv.Ajv;
+  ajv = new Ajv({
+    allErrors: true
+  });
 
   constructor() {
-    this.ajv = new Ajv({
-      allErrors: true
-    });
     this.ajv.addFormat('password', '.*');
     this.ajv.addFormat('code', '.*');
     this.ajv.addFormat('binary', '.*');


### PR DESCRIPTION
schema-validator.service.ts: use constructor in declare class to be comptabible for all typescript versions.
fix #931 

## Summary

Replace me with a description of changes. Include screenshots where appropriate.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
