### PR TITLE
Fix: JSON editor flat array nodes not responding to nested schemaUpdate events

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: Add `cursor: pointer` to `ngx-button` class
 - Feature: `ngx-button` now accepts a `type` input
 - Breaking: `ngx-button` now defaults to `type="button"`
+- Fix: (`ngx-json-editor-flat`) nodes inside array nodes will emit `schemaUpdate` events
 
 ## 42.5.0 (2022-10-17)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix: Add `cursor: pointer` to `ngx-button` class
 - Feature: `ngx-button` now accepts a `type` input
 - Breaking: `ngx-button` now defaults to `type="button"`
-- Fix: (`ngx-json-editor-flat`) nodes inside array nodes will emit `schemaUpdate` events
+- Fix: `ngx-json-editor-flat` array nodes will forward `schemaUpdate` events from nested nodes
 
 ## 42.5.0 (2022-10-17)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
@@ -28,6 +28,7 @@
       [isDuplicated]="isDuplicated"
       [passwordToggleEnabled]="passwordToggleEnabled"
       [inputControlTemplate]="inputControlTemplate"
+      (schemaUpdate)="schemaUpdate.emit(schemaRef)"
     >
       <div class="node-options" node-options>
         <button


### PR DESCRIPTION
## Summary

Ensures json editor flat array nodes will forward `schemaUpdate` events from nested nodes

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
