### PR TITLE
JSON Editor: node redraws at bottom of list when value is cleared

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -78,7 +78,7 @@
                   [filterable]="false"
                   *ngIf="schema?.enum"
                   [ngModel]="[model]"
-                  (ngModelChange)="updateModel($event[0])"
+                  (ngModelChange)="updateModel($event[0] || [''])"
                   [required]="required"
                   [disabled]="isDuplicated"
                 >


### PR DESCRIPTION
## Summary
Resolved issue with JSON Editor component where a node would redraw at the bottom of the list when an existing value was cleared from the `ngx-select`. This was occurring on `Enum` types on the JSON Editor component.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
