### PR TITLE
fix(ngx-input): textarea autosize directive is not considering initial value

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## HEAD (unreleased)
 
-## 44.2.1 (2022-12-27)
+## 44.2.3 (2022-12-27)
 
-- Fix(`ngx-input`): textarea autosize directive respects the value and adjusts the height accordingly
+- Fix(`ngx-input`): textarea autosize directive respects the initial value and adjusts the height accordingly
 
 ## 44.2.0 (2022-12-27)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD (unreleased)
 
+## 44.2.1 (2022-12-27)
+
+- Fix(`ngx-input`): textarea autosize directive respects the value and adjusts the height accordingly
+
 ## 44.2.0 (2022-12-27)
 
 - Feature: `ngx-tree` now support virtual scrolling

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "44.2.0",
+  "version": "44.2.1",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "44.2.1",
+  "version": "44.2.3",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
@@ -1,5 +1,7 @@
-import { ElementRef, Directive, Input } from '@angular/core';
+import { ElementRef, Directive, Input, AfterContentInit } from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { NgModel } from '@angular/forms';
+import { delay, filter, take } from 'rxjs';
 
 @Directive({
   exportAs: 'ngxAutosize',
@@ -9,7 +11,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
     '(input)': 'onInput()'
   }
 })
-export class AutosizeDirective {
+export class AutosizeDirective implements AfterContentInit {
   @Input('autosize')
   get enabled() {
     return this._enabled;
@@ -23,7 +25,22 @@ export class AutosizeDirective {
     return this.element.nativeElement.nodeName as 'TEXTAREA' | 'INPUT';
   }
 
-  constructor(readonly element: ElementRef<HTMLInputElement | HTMLTextAreaElement>) {}
+  constructor(
+    readonly element: ElementRef<HTMLInputElement | HTMLTextAreaElement>,
+    private readonly ngModel: NgModel
+  ) {}
+
+  ngAfterContentInit(): void {
+    this.ngModel.valueChanges
+      .pipe(
+        filter(value => !!value && value?.length > 0),
+        take(1),
+        delay(0) // delay is added as the scrollHeight of textarea is 0 even though there is value
+      )
+      .subscribe(() => {
+        this.onInput();
+      });
+  }
 
   onInput() {
     if (this._enabled) {

--- a/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/input/input-autosize.directive.ts
@@ -1,7 +1,7 @@
 import { ElementRef, Directive, Input, AfterContentInit } from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { NgModel } from '@angular/forms';
-import { delay, filter, take } from 'rxjs';
+import { delay, filter, take } from 'rxjs/operators';
 
 @Directive({
   exportAs: 'ngxAutosize',
@@ -31,15 +31,17 @@ export class AutosizeDirective implements AfterContentInit {
   ) {}
 
   ngAfterContentInit(): void {
-    this.ngModel.valueChanges
-      .pipe(
-        filter(value => !!value && value?.length > 0),
-        take(1),
-        delay(0) // delay is added as the scrollHeight of textarea is 0 even though there is value
-      )
-      .subscribe(() => {
-        this.onInput();
-      });
+    if (this.ngModel) {
+      this.ngModel.valueChanges
+        .pipe(
+          filter(value => !!value && value?.length > 0),
+          take(1),
+          delay(0) // delay is added as the scrollHeight of textarea is 0 even though there is value
+        )
+        .subscribe(() => {
+          this.onInput();
+        });
+    }
   }
 
   onInput() {

--- a/projects/swimlane/ngx-ui/src/lib/directives/resize-observer/resize-observer.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/directives/resize-observer/resize-observer.directive.spec.ts
@@ -32,6 +32,6 @@ describe('ResizeObserverDirective', () => {
     setTimeout(() => {
       expect(spy).toHaveBeenCalledTimes(1);
       done();
-    }, 100);
+    }, 150);
   });
 });

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -422,6 +422,12 @@
       <app-prism>
     <![CDATA[<ngx-input autosize appearance="fill" type="number" label="Fill Resize Input"></ngx-input>]]>
       </app-prism>
+
+      <br />
+
+      <ngx-input type="textarea" [(ngModel)]="longInputValueTextarea" autosize label="Textarea Autosize"></ngx-input>
+
+      <br />
     </ngx-section>
 
     <ngx-section class="shadow" sectionTitle="Appearances">

--- a/src/app/forms/inputs-page/inputs-page.component.ts
+++ b/src/app/forms/inputs-page/inputs-page.component.ts
@@ -22,6 +22,7 @@ export class InputsPageComponent {
   output: any;
   patternValue = 'Has space';
   readonlyTextareaValue = lorem.words(100);
+  longInputValueTextarea = lorem.paragraphs(2);
 
   onClick(event: any) {
     console.log({ event });


### PR DESCRIPTION
## Summary

fix textarea autosize directive to work with initial value 

Also, fixed a failing test case (failing in `master` - this test case is not related to textarea autosize)

![textarea-autosize](https://user-images.githubusercontent.com/98421392/226269276-7394b177-d845-4f05-838f-c3a3fb16884e.gif)


## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
