### PR TITLE
Update Card Avatar and Large Format Dialog Content Components to Enable Removal of White Background from Images

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.html
@@ -1,7 +1,13 @@
 <div class="ngx-card-avatar--avatar" [ngClass]="{'has-status': status}">
   <div class="inner-logo">
     <div *ngIf="status" class="status" [ngClass]="status"></div>
-    <img *ngIf="src" class="ngx-card-avatar--img" [src]="src" draggable="false" />
+    <img 
+      *ngIf="src" 
+      class="ngx-card-avatar--img"
+      [class.ngx-card-avatar--img__remove-background]="removeImageBackground" 
+      [src]="src" 
+      draggable="false" 
+    />
     <div class="ngx-card-avatar--content">
       <ng-content></ng-content>
     </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.html
@@ -4,7 +4,7 @@
     <img 
       *ngIf="src" 
       class="ngx-card-avatar--img"
-      [class.ngx-card-avatar--img__remove-background]="removeImageBackground" 
+      [class.ngx-card-avatar--img__default-background]="removeImageBackground" 
       [src]="src" 
       draggable="false" 
     />

--- a/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.scss
@@ -50,7 +50,7 @@ $color-background-grey: $color-blue-grey-750;
         height: 100%;
         border-radius: 100%;
 
-        &__remove-background {
+        &__default-background {
           background-color: transparent;
         }
       }

--- a/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.scss
@@ -49,6 +49,10 @@ $color-background-grey: $color-blue-grey-750;
         width: 100%;
         height: 100%;
         border-radius: 100%;
+
+        &__remove-background {
+          background-color: transparent;
+        }
       }
 
       .ngx-card-avatar--content {

--- a/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/card/card-avatar/card-avatar.component.ts
@@ -17,4 +17,5 @@ import { CardStatus } from '../card-status.enum';
 export class CardAvatarComponent {
   @Input() src: string | SafeUrl;
   @Input() status: CardStatus;
+  @Input() removeImageBackground?: boolean;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.scss
@@ -29,6 +29,10 @@
 
   &__img {
     background-color: white;
+
+    &__remove-background {
+      background-color: transparent;
+    }
   }
 
   &__clear {

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-title/large-format-dialog-header-title.component.scss
@@ -30,7 +30,7 @@
   &__img {
     background-color: white;
 
-    &__remove-background {
+    &__default-background {
       background-color: transparent;
     }
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
@@ -41,7 +41,7 @@
   <img 
     *ngIf="imgSrc && !logoTemplate" 
     class="ngx-large-format-dialog-header-title__img" 
-    [class.ngx-large-format-dialog-header-title__img__remove-background]="removeImageBackground"
+    [class.ngx-large-format-dialog-header-title__img__default-background]="removeImageBackground"
     [src]="imgSrc" 
     draggable="false" 
   />

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
@@ -38,7 +38,13 @@
 </main>
 
 <ng-template #myTemplate>
-  <img *ngIf="imgSrc && !logoTemplate" class="ngx-large-format-dialog-header-title__img" [src]="imgSrc" draggable="false" />
+  <img 
+    *ngIf="imgSrc && !logoTemplate" 
+    class="ngx-large-format-dialog-header-title__img" 
+    [class.ngx-large-format-dialog-header-title__img__remove-background]="removeImageBackground"
+    [src]="imgSrc" 
+    draggable="false" 
+  />
   <div *ngIf="!imgSrc && logoTemplate" class="ngx-large-format-dialog-header-title__clear">
     <ng-container *ngTemplateOutlet="logoTemplate"></ng-container>
   </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
@@ -31,6 +31,7 @@ export class LargeFormatDialogContentComponent implements OnInit {
   @Input() dialogTitle = '';
   @Input() dialogSubtitle?: string;
   @Input() imgSrc?: string | SafeUrl;
+  @Input() removeImageBackground?: boolean;
   @Input() logoTemplate?: TemplateRef<unknown>;
   @Input() dialogSubtitleTemplate?: TemplateRef<unknown>;
   @Input() format: 'large' | 'medium' = 'large';

--- a/projects/swimlane/ngx-ui/src/lib/directives/resize-observer/resize-observer.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/directives/resize-observer/resize-observer.directive.spec.ts
@@ -32,6 +32,6 @@ describe('ResizeObserverDirective', () => {
     setTimeout(() => {
       expect(spy).toHaveBeenCalledTimes(1);
       done();
-    }, 100);
+    }, 1000);
   });
 });

--- a/src/app/components/card-page/card-page.component.html
+++ b/src/app/components/card-page/card-page.component.html
@@ -829,6 +829,8 @@
       <a class="documentation-content" (click)="scrollTo('ngx-card-footer-outputs')">ngx-card-footer Outputs</a>
       <a class="documentation-content" (click)="scrollTo('ngx-card-placeholder-inputs')">ngx-card-placeholder Inputs</a>
       <a class="documentation-content" (click)="scrollTo('ngx-card-placeholder-outputs')">ngx-card-placeholder Outputs</a>
+      <a class="documentation-content" (click)="scrollTo('ngx-card-avatar-inputs')">ngx-card-avatar Inputs</a>
+      <a class="documentation-content" (click)="scrollTo('ngx-card-avatar-outputs')">ngx-card-avatar Outputs</a>
       <hr>
 
       <h3 class="style-header" id="ngx-card-inputs">ngx-card Inputs</h3>
@@ -1006,6 +1008,42 @@
       </table>
       <hr>
       <h3 class="style-header" id="ngx-card-placeholder-outputs">ngx-card-placeholder Outputs</h3>
+      <h4>No component outputs to display.</h4>
+
+      <h3 class="style-header" id="ngx-card-avatar-inputs">ngx-card-avatar Inputs</h3>
+      <table class="table documentation-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>
+              <code class="component-type">@Input()</code>
+              <code>src: string | SafeUrl</code>
+            </th>
+            <td>The source for the image.</td>
+          </tr>
+          <tr>
+            <th>
+              <code class="component-type">@Input()</code>
+              <code>status: CardStatus</code>
+            </th>
+            <td>The status to display the card in, either <code>Success</code>, <code>Error</code> or <code>Disabled</code>.</td>
+          </tr>
+          <tr>
+            <th>
+              <code class="component-type">@Input()</code>
+              <code>removeImageBackground: boolean</code>
+            </th>
+            <td>Whether the default white background for the image is removed.</td>
+          </tr>
+        </tbody>
+      </table>
+      <hr>
+      <h3 class="style-header" id="ngx-card-avatar-outputs">ngx-card-avatar Outputs</h3>
       <h4>No component outputs to display.</h4>
     </ngx-tab>
   </ngx-tabs>

--- a/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.html
+++ b/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.html
@@ -1207,6 +1207,13 @@
         <tr>
           <th>
             <code class="component-type">@Input()</code>
+            <code class="input-name">removeImageBackground: boolean</code>
+          </th>
+          <td>Whether the default white background for the image is removed.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">@Input()</code>
             <code class="input-name">skipDirtyAlert: boolean</code>
           </th>
           <td>Whether the component should skip alerting the user when the component is closed in a dirty state.</td>


### PR DESCRIPTION
## Summary

- Updated `ngx-card-avatar` and `ngx-large-format-dialog-content` components with new `@Input()` for enabling the removal of the default white background on images. 
- Updated API documentation `ngx-large-format-dialog-content` component to include new `Input()` and added missing documentation for `ngx-card-avatar` component.

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
