### PR TITLE
fix(ngx-input): textarea autosize directive is not considering initial value

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-input`): textarea autosize directive respects the initial value and adjusts the height accordingly
+
 ## 44.3.0 (2023-3-21)
 
 - Feature (`ngx-large-format-dialog-content`): now accepts a `removeImageBackground` input to allow the removal of the default, white background

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -422,6 +422,15 @@
       <app-prism>
     <![CDATA[<ngx-input autosize appearance="fill" type="number" label="Fill Resize Input"></ngx-input>]]>
       </app-prism>
+
+      <br />
+
+      <ngx-input type="textarea" [(ngModel)]="longInputValueTextarea" autosize label="Textarea Autosize"></ngx-input>
+
+      <br />
+      <app-prism>
+    <![CDATA[<ngx-input type="textarea" [(ngModel)]="longInputValueTextarea" autosize label="Textarea Autosize"></ngx-input>]]>
+      </app-prism>
     </ngx-section>
 
     <ngx-section class="shadow" sectionTitle="Appearances">

--- a/src/app/forms/inputs-page/inputs-page.component.html
+++ b/src/app/forms/inputs-page/inputs-page.component.html
@@ -422,15 +422,6 @@
       <app-prism>
     <![CDATA[<ngx-input autosize appearance="fill" type="number" label="Fill Resize Input"></ngx-input>]]>
       </app-prism>
-
-      <br />
-
-      <ngx-input type="textarea" [(ngModel)]="longInputValueTextarea" autosize label="Textarea Autosize"></ngx-input>
-
-      <br />
-      <app-prism>
-    <![CDATA[<ngx-input type="textarea" [(ngModel)]="longInputValueTextarea" autosize label="Textarea Autosize"></ngx-input>]]>
-      </app-prism>
     </ngx-section>
 
     <ngx-section class="shadow" sectionTitle="Appearances">

--- a/src/app/forms/inputs-page/inputs-page.component.ts
+++ b/src/app/forms/inputs-page/inputs-page.component.ts
@@ -22,6 +22,7 @@ export class InputsPageComponent {
   output: any;
   patternValue = 'Has space';
   readonlyTextareaValue = lorem.words(100);
+  longInputValueTextarea = lorem.paragraphs(2);
 
   onClick(event: any) {
     console.log({ event });


### PR DESCRIPTION
## Summary

fix textarea autosize directive to work with initial value 

![textarea-autosize](https://user-images.githubusercontent.com/98421392/226269276-7394b177-d845-4f05-838f-c3a3fb16884e.gif)


## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
