### PR TITLE
Section header and button toggle bug fix

### DIFF
--- a/cypress/e2e/components/sections.cy.ts
+++ b/cypress/e2e/components/sections.cy.ts
@@ -28,6 +28,7 @@ describe('Sections', () => {
           .should('have.attr', 'aria-expanded', 'true');
         cy.root().ngxClose();
         cy.get('.ngx-section-toggle').should('have.attr', 'aria-expanded', 'false');
+        cy.wait(100);
         cy.root().ngxOpen();
         cy.get('.ngx-section-toggle').should('have.attr', 'aria-expanded', 'true');
       });
@@ -66,6 +67,7 @@ describe('Sections', () => {
 
         cy.realPress('Space'); // Presses the button
         cy.get('@CUT').find('.ngx-section-header').should('have.class', 'section-collapsed');
+        cy.wait(100);
 
         cy.realPress('Space'); // Presses the button
         cy.get('@CUT').find('.ngx-section-header').should('not.have.class', 'section-collapsed');

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD (unreleased)
 
 - Fix (`ngx-button-toggle-group`): reset/correct animation dimensions
+- Fix (`ngx-section`): toggle with both header and button now works correctly
 
 ## 44.4.0 (2023-3-25)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.html
@@ -7,9 +7,9 @@
     [class.header-toggle]="headerToggle"
     class="ngx-section-header"
     [attr.tabindex]="headerToggle && 0"
-    (keyup.space)="headerToggle && sectionCollapsible && onSectionClicked()"
-    (keyup.enter)="headerToggle && sectionCollapsible && onSectionClicked()"
-    (click)="headerToggle && sectionCollapsible && onSectionClicked()"
+    (keyup.space)="headerToggle && sectionCollapsible && onSectionClicked($event)"
+    (keyup.enter)="headerToggle && sectionCollapsible && onSectionClicked($event)"
+    (click)="headerToggle && sectionCollapsible && onSectionClicked($event)"
   >
     <button
       *ngIf="sectionCollapsible && togglePosition !== TogglePosition.None"
@@ -18,10 +18,10 @@
       title="Toggle Content Visibility"
       [attr.aria-controls]="id"
       [attr.aria-expanded]="!sectionCollapsed"
-      (keyup.space)="sectionCollapsible && onSectionClicked()"
-      (click)="sectionCollapsible && onSectionClicked()"
+      (keyup.space)="sectionCollapsible && onSectionClicked($event)"
+      (click)="sectionCollapsible && onSectionClicked($event)"
     >
-      <ngx-icon 
+      <ngx-icon
         [fontIcon]="sectionCollapsed ? 'chevron-bold-right' : 'chevron-bold-down'">
       </ngx-icon>
     </button>

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.html
@@ -7,9 +7,9 @@
     [class.header-toggle]="headerToggle"
     class="ngx-section-header"
     [attr.tabindex]="headerToggle && 0"
-    (keyup.space)="headerToggle && sectionCollapsible && onSectionClicked($event)"
-    (keyup.enter)="headerToggle && sectionCollapsible && onSectionClicked($event)"
-    (click)="headerToggle && sectionCollapsible && onSectionClicked($event)"
+    (keyup.space)="headerToggle && sectionCollapsible && onSectionClicked()"
+    (keyup.enter)="headerToggle && sectionCollapsible && onSectionClicked()"
+    (click)="headerToggle && sectionCollapsible && onSectionClicked()"
   >
     <button
       *ngIf="sectionCollapsible && togglePosition !== TogglePosition.None"
@@ -18,8 +18,8 @@
       title="Toggle Content Visibility"
       [attr.aria-controls]="id"
       [attr.aria-expanded]="!sectionCollapsed"
-      (keyup.space)="sectionCollapsible && onSectionClicked($event)"
-      (click)="sectionCollapsible && onSectionClicked($event)"
+      (keyup.space)="sectionCollapsible && onSectionClicked()"
+      (click)="sectionCollapsible && onSectionClicked()"
     >
       <ngx-icon
         [fontIcon]="sectionCollapsed ? 'chevron-bold-right' : 'chevron-bold-down'">

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.spec.ts
@@ -51,7 +51,8 @@ describe('SectionComponent', () => {
 
   it('onSectionClicked collapses section and triggers toggle emit', () => {
     spyOn(component.toggle, 'emit');
-    component.onSectionClicked();
+    const event = new PointerEvent('pointerdown');
+    component.onSectionClicked(event);
 
     expect(component.sectionCollapsed).toEqual(true);
     expect(component.toggle.emit).toHaveBeenCalled();

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.spec.ts
@@ -51,8 +51,7 @@ describe('SectionComponent', () => {
 
   it('onSectionClicked collapses section and triggers toggle emit', () => {
     spyOn(component.toggle, 'emit');
-    const event = new PointerEvent('pointerdown');
-    component.onSectionClicked(event);
+    component.onSectionClicked();
 
     expect(component.sectionCollapsed).toEqual(true);
     expect(component.toggle.emit).toHaveBeenCalled();

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
@@ -53,7 +53,8 @@ export class SectionComponent {
 
   readonly TogglePosition = TogglePosition;
 
-  onSectionClicked(): void {
+  onSectionClicked(event: PointerEvent): void {
+    event.stopPropagation();
     this.sectionCollapsed = !this.sectionCollapsed;
     this.toggle.emit(this.sectionCollapsed);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
@@ -1,17 +1,18 @@
 import {
-  Component,
-  Input,
-  ContentChild,
-  Output,
-  EventEmitter,
-  ViewEncapsulation,
   ChangeDetectionStrategy,
-  HostBinding
+  Component,
+  ContentChild,
+  EventEmitter,
+  HostBinding,
+  Input,
+  Output,
+  ViewEncapsulation
 } from '@angular/core';
 
 import { SectionHeaderComponent } from './section-header.component';
 import { SectionAppearance } from './section-appearance.enum';
 import { TogglePosition } from './section-toggle-position.enum';
+import { debounceable } from '@swimlane/ngx-ui/decorators/debounceable/debounceable.decorator';
 
 let nextId = 0;
 
@@ -53,8 +54,8 @@ export class SectionComponent {
 
   readonly TogglePosition = TogglePosition;
 
-  onSectionClicked(event: PointerEvent): void {
-    event.stopPropagation();
+  @debounceable(100, true)
+  onSectionClicked(): void {
     this.sectionCollapsed = !this.sectionCollapsed;
     this.toggle.emit(this.sectionCollapsed);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
@@ -12,7 +12,7 @@ import {
 import { SectionHeaderComponent } from './section-header.component';
 import { SectionAppearance } from './section-appearance.enum';
 import { TogglePosition } from './section-toggle-position.enum';
-import { debounceable } from '@swimlane/ngx-ui/decorators/debounceable/debounceable.decorator';
+import { debounceable } from '../../decorators/debounceable/debounceable.decorator';
 
 let nextId = 0;
 

--- a/src/app/components/sections-page/sections-page.component.html
+++ b/src/app/components/sections-page/sections-page.component.html
@@ -12,7 +12,7 @@
       </ngx-section>
       <app-prism>
     <![CDATA[<ngx-section
-      id="attack-details" 
+      id="attack-details"
       class="shadow"
       sectionTitle="Attack Details"
     >
@@ -20,7 +20,7 @@
     </ngx-section>]]>
       </app-prism>
     </ngx-section>
-    
+
     <ngx-section class="shadow" [sectionTitle]="'Custom Template and Shadow'">
       <ngx-section class="shadow">
         <ngx-section-header>
@@ -43,7 +43,7 @@
     </ngx-section>]]>
         </app-prism>
     </ngx-section>
-    
+
     <ngx-section class="shadow" [sectionTitle]="'Custom Template and Shadow'">
       <ngx-section class="shadow" [sectionTitle]="'Attack Details'" [sectionCollapsible]="false">
         Hash rm -rf gc Starcraft continue *.* d00dz deadlock snarf endif wannabee tera perl less bar strlen tarball
@@ -62,7 +62,7 @@
     </ngx-section>]]>
         </app-prism>
     </ngx-section>
-    
+
     <ngx-section class="shadow" [sectionTitle]="'No Title and Shadow'">
       <ngx-section class="shadow">
         Hash rm -rf gc Starcraft continue *.* d00dz deadlock snarf endif wannabee tera perl less bar strlen tarball
@@ -77,7 +77,7 @@
     </ngx-section>]]>
         </app-prism>
     </ngx-section>
-    
+
     <ngx-section [sectionTitle]="'Outline'">
       <ngx-section [sectionTitle]="'Attack Details'" appearance="outline">
         Hash rm -rf gc Starcraft continue *.* d00dz deadlock snarf endif wannabee tera perl less bar strlen tarball
@@ -95,7 +95,7 @@
     </ngx-section>]]>
         </app-prism>
     </ngx-section>
-    
+
     <ngx-section [sectionTitle]="'Outline and Toggle Right'">
       <ngx-section [sectionTitle]="'Attack Details'" appearance="outline" togglePosition="right">
         Hash rm -rf gc Starcraft continue *.* d00dz deadlock snarf endif wannabee tera perl less bar strlen tarball
@@ -114,7 +114,7 @@
     </ngx-section>]]>
         </app-prism>
     </ngx-section>
-    
+
     <ngx-section [sectionTitle]="'Light'">
       <ngx-section [sectionTitle]="'Light'" appearance="light">
         Hash rm -rf gc Starcraft continue *.* d00dz deadlock snarf endif wannabee tera perl less bar strlen tarball
@@ -132,7 +132,7 @@
     </ngx-section>]]>
         </app-prism>
     </ngx-section>
-    
+
     <ngx-section [sectionTitle]="'Hide toggle use Header'">
       <ngx-section sectionTitle="Attack Details" togglePosition="none" [headerToggle]="true">
         Hash rm -rf gc Starcraft continue *.* d00dz deadlock snarf endif wannabee tera perl less bar strlen tarball
@@ -149,6 +149,24 @@
       Some Content
     </ngx-section>]]>
         </app-prism>
+    </ngx-section>
+
+    <ngx-section [sectionTitle]="'Hide toggle use Header'">
+      <ngx-section sectionTitle="Multiple toggle triggers" togglePosition="right" [headerToggle]="true">
+        Hash rm -rf gc Starcraft continue *.* d00dz deadlock snarf endif wannabee tera perl less bar strlen tarball
+        bytes ban headers
+        gnu brute force. All your base are belong to us semaphore exception giga highjack system mailbomb eaten by a
+        grue
+        error fopen null. James T. Kirk firewall recursively hello world man pages protected. uwu
+      </ngx-section>
+      <app-prism>
+        <![CDATA[<ngx-section
+        sectionTitle="Attack Details"
+        togglePosition="none"
+        [headerToggle]="true">
+        Some Content
+      </ngx-section>]]>
+      </app-prism>
     </ngx-section>
   </ngx-tab>
   <ngx-tab label="API">


### PR DESCRIPTION
## Summary
This fixes a bug that prevented sections from being toggled when clicking the toggle button if both the header toggle and button toggle were enabled

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
