### PR TITLE
Fix ngx-section test race condition

### DIFF
--- a/cypress/e2e/components/sections.cy.ts
+++ b/cypress/e2e/components/sections.cy.ts
@@ -13,6 +13,7 @@ describe('Sections', () => {
 
     afterEach(() => {
       cy.get('@CUT').ngxOpen();
+      cy.wait(100);
     });
 
     it('has no detectable a11y violations on load', () => {
@@ -39,6 +40,7 @@ describe('Sections', () => {
         cy.get('.ngx-section-header').first().should('not.have.class', 'section-collapsed');
         cy.get('.ngx-section-content').first().should('exist');
         cy.get('.ngx-section-toggle').first().click();
+        cy.wait(100);
         cy.get('.ngx-section-header').first().should('have.class', 'section-collapsed');
         cy.get('.ngx-section-content').should('not.exist');
       });

--- a/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/section/section.component.ts
@@ -54,7 +54,7 @@ export class SectionComponent {
 
   readonly TogglePosition = TogglePosition;
 
-  @debounceable(100, true)
+  @debounceable(75, true)
   onSectionClicked(): void {
     this.sectionCollapsed = !this.sectionCollapsed;
     this.toggle.emit(this.sectionCollapsed);


### PR DESCRIPTION
## Summary

This fixes a race condition introduced to the ngx-section tests.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
