### PR TITLE
ngx-select-dropdown - clearQueryFilter event

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Feature (`ngx-select-dropdown`): A new event is triggered when the X button is pressed to clear the filter query.
+
 ## 44.5.4 (2023-5-2)
 
 - Fix (`ngx-select-dropdown`): When the filterable select input has focus, tab event should not open the next popover if the next control is ngx-select.

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-dropdown.component.ts
@@ -99,6 +99,7 @@ export class SelectDropdownComponent implements AfterViewInit {
   @Output() keyboardSelection = new EventEmitter<SelectDropdownOption>();
   @Output() keyboardDeselection = new EventEmitter<SelectDropdownOption>();
   @Output() close = new EventEmitter<boolean | undefined>();
+  @Output() clearQueryFilter = new EventEmitter<void>();
 
   @ViewChild('filterInput')
   readonly filterInput?: ElementRef<HTMLInputElement>;
@@ -158,6 +159,7 @@ export class SelectDropdownComponent implements AfterViewInit {
     this.filterQuery = '';
     this.updateFilterQueryIsInOptions();
     this.cdr.markForCheck();
+    this.clearQueryFilter.emit();
   }
 
   onInputKeyUp(event: KeyboardEvent): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
@@ -47,6 +47,7 @@
     [options]="options"
     (keyup)="keyup.emit($event)"
     (close)="onClose(true)"
+    (clearQueryFilter)="clearQueryFilter.emit()"
     (selection)="onDropdownSelection($event)"
     (deselection)="onDropdownDeselection($event)"
     (keyboardSelection)="onDropdownSelection($event, false)"

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -168,6 +168,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   @Output() change = new EventEmitter<any[]>();
   @Output() keyup = new EventEmitter<{ event: KeyboardEvent; value?: string }>();
   @Output() toggle = new EventEmitter<boolean>();
+  @Output() clearQueryFilter = new EventEmitter<void>();
 
   @ViewChild(SelectInputComponent, { static: true })
   readonly inputComponent: SelectInputComponent;

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -1258,6 +1258,13 @@
           </th>
           <td>Event emitted when the dropdown is toggled open or closed.</td>
         </tr>
+        <tr>
+          <th>
+            <code class="component-type">@Output()</code>
+            <code>clearQueryFilter: EventEmitter&lt;void&gt;</code>
+          </th>
+          <td>Event emitted when the query filter is cleared.</td>
+        </tr>
       </tbody>
     </table>
     <hr>


### PR DESCRIPTION
## Summary
A new event is triggered when the X button is pressed to clear the filter query.

Prettier and Lint changes:
Fixes were applied only to the affected files.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
