### PR TITLE
SPT-18941: repair datetime input bug

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -18,7 +18,10 @@
             [propertyName]="arrayName ? arrayName : schema?.propertyName"
             (propertyNameChange)="updatePropertyName(schema.id, $event)"
             [title]="schema?.title || label || (arrayItem ? 'Items' : schema?.propertyName)"
-            [type]="((schema?.format && schema?.format !== 'binary' ? schema?.format : schema?.type) | titlecase) + (schema?.enum?.length ? ' + Enum' : '')"
+            [type]="
+              ((schema?.format && schema?.format !== 'binary' ? schema?.format : schema?.type) | titlecase) +
+              (schema?.enum?.length ? ' + Enum' : '')
+            "
             [description]="schema?.description"
             [examples]="schema?.examples"
             [required]="required"
@@ -28,7 +31,19 @@
 
         <div *ngIf="!schemaBuilderMode" class="node-input">
           <ng-container *ngIf="inputControlTemplate">
-            <ng-container *ngTemplateOutlet="inputControlTemplate; context: { nodeModel: model, nodeSchema: schema, nodePath: path, nodeChangeValue$: nodeChangeValue$, nodeContext: contextItem, nodeExpandTrigger$: nodeExpandTrigger$}"></ng-container>
+            <ng-container
+              *ngTemplateOutlet="
+                inputControlTemplate;
+                context: {
+                  nodeModel: model,
+                  nodeSchema: schema,
+                  nodePath: path,
+                  nodeChangeValue$: nodeChangeValue$,
+                  nodeContext: contextItem,
+                  nodeExpandTrigger$: nodeExpandTrigger$
+                }
+              "
+            ></ng-container>
           </ng-container>
           <ng-container *ngIf="!inputControlTemplate">
             <!-- Number | Integer -->
@@ -118,7 +133,7 @@
                 <ngx-input
                   type="datetime-local"
                   [ngModel]="model"
-                  (ngModelChange)="updateModel($event)"
+                  (ngModelChange)="updateDateTime($event)"
                   [requiredIndicator]="false"
                   [required]="required"
                   [disabled]="isDuplicated"
@@ -176,7 +191,6 @@
               <span *ngFor="let error of ownErrors">{{ error.message }}</span>
             </div>
           </ng-container>
-          
         </div>
 
         <div *ngIf="schemaBuilderMode" class="node-constrains">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.html
@@ -18,10 +18,7 @@
             [propertyName]="arrayName ? arrayName : schema?.propertyName"
             (propertyNameChange)="updatePropertyName(schema.id, $event)"
             [title]="schema?.title || label || (arrayItem ? 'Items' : schema?.propertyName)"
-            [type]="
-              ((schema?.format && schema?.format !== 'binary' ? schema?.format : schema?.type) | titlecase) +
-              (schema?.enum?.length ? ' + Enum' : '')
-            "
+            [type]="((schema?.format && schema?.format !== 'binary' ? schema?.format : schema?.type) | titlecase) + (schema?.enum?.length ? ' + Enum' : '')"
             [description]="schema?.description"
             [examples]="schema?.examples"
             [required]="required"
@@ -31,19 +28,7 @@
 
         <div *ngIf="!schemaBuilderMode" class="node-input">
           <ng-container *ngIf="inputControlTemplate">
-            <ng-container
-              *ngTemplateOutlet="
-                inputControlTemplate;
-                context: {
-                  nodeModel: model,
-                  nodeSchema: schema,
-                  nodePath: path,
-                  nodeChangeValue$: nodeChangeValue$,
-                  nodeContext: contextItem,
-                  nodeExpandTrigger$: nodeExpandTrigger$
-                }
-              "
-            ></ng-container>
+            <ng-container *ngTemplateOutlet="inputControlTemplate; context: { nodeModel: model, nodeSchema: schema, nodePath: path, nodeChangeValue$: nodeChangeValue$, nodeContext: contextItem, nodeExpandTrigger$: nodeExpandTrigger$}"></ng-container>
           </ng-container>
           <ng-container *ngIf="!inputControlTemplate">
             <!-- Number | Integer -->
@@ -191,6 +176,7 @@
               <span *ngFor="let error of ownErrors">{{ error.message }}</span>
             </div>
           </ng-container>
+          
         </div>
 
         <div *ngIf="schemaBuilderMode" class="node-constrains">

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/json-editor-node-flat.component.ts
@@ -12,6 +12,7 @@ import {
   OnDestroy
 } from '@angular/core';
 import { JsonEditorNode } from '../../json-editor-node';
+import { DateFormatPipe } from 'ngx-moment';
 
 import { DialogService } from '../../../dialog/dialog.service';
 import { JSONEditorSchema, JSONEditorTemplateProperty, JsonSchemaDataType } from '../../json-editor.helper';
@@ -23,6 +24,7 @@ import { JSONSchema7TypeName } from 'json-schema';
   selector: 'ngx-json-editor-node-flat',
   templateUrl: './json-editor-node-flat.component.html',
   styleUrls: ['./json-editor-node-flat.component.scss'],
+  providers: [DateFormatPipe],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -71,7 +73,7 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
   nodeExpandTrigger$ = new Subject<boolean>();
   private readonly unsub$: Subject<void> = new Subject();
 
-  constructor(public dialogMngr: DialogService) {
+  constructor(public dialogMngr: DialogService, private dateFormat: DateFormatPipe) {
     super(dialogMngr);
   }
 
@@ -111,5 +113,9 @@ export class JsonEditorNodeFlatComponent extends JsonEditorNode implements OnIni
     if (this.expanded !== value) {
       this.expanded = value;
     }
+  }
+
+  updateDateTime(value: any): void {
+    this.updateDateTimeModel(value, this.dateFormat);
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-node.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-node.ts
@@ -14,6 +14,9 @@ import {
 import { createValueForSchema, inferType, JSONEditorSchema } from './json-editor.helper';
 import { DialogComponent } from '../dialog/dialog.component';
 import { DialogService } from '../dialog/dialog.service';
+import { DateFormatPipe } from 'ngx-moment';
+
+const DATETIME_FORMAT = 'YYYY-MM-DD[T]HH:mm:ss';
 
 @Directive()
 export class JsonEditorNode implements OnInit, OnChanges {
@@ -175,6 +178,10 @@ export class JsonEditorNode implements OnInit, OnChanges {
   updateModel(value: any): void {
     this.model = value;
     this.modelChange.emit(this.model);
+  }
+
+  updateDateTimeModel(value: any, format: DateFormatPipe): void {
+    this.updateModel(format.transform(value, DATETIME_FORMAT));
   }
 
   /**

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.html
@@ -140,7 +140,7 @@
           [placeholder]="placeholder"
           [ngModel]="model"
           [disabled]="isDuplicated"
-          (ngModelChange)="updateModel($event)"
+          (ngModelChange)="updateDateTime($event)"
           [required]="required"
         />
       </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/json-editor-node.component.ts
@@ -3,11 +3,13 @@ import { JsonEditorNode } from '../../json-editor-node';
 
 import { DialogService } from '../../../dialog/dialog.service';
 import { JSONEditorSchema } from '../../json-editor.helper';
+import { DateFormatPipe } from 'ngx-moment';
 
 @Component({
   selector: 'ngx-json-editor-node',
   templateUrl: 'json-editor-node.component.html',
   styleUrls: ['./json-editor-node.component.scss'],
+  providers: [DateFormatPipe],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -28,7 +30,7 @@ export class JsonEditorNodeComponent extends JsonEditorNode implements OnInit {
 
   placeholder = '';
 
-  constructor(public dialogMngr: DialogService) {
+  constructor(public dialogMngr: DialogService, private dateFormat: DateFormatPipe) {
     super(dialogMngr);
   }
 
@@ -38,5 +40,9 @@ export class JsonEditorNodeComponent extends JsonEditorNode implements OnInit {
     if (this.schema.examples && Array.isArray(this.schema.examples)) {
       this.placeholder = this.schema.examples.join(', ');
     }
+  }
+
+  updateDateTime(value: any): void {
+    this.updateDateTimeModel(value, this.dateFormat);
   }
 }


### PR DESCRIPTION
## Summary

Datetime input is failing because the datetime input is omitting the seconds, so I use a pipe to resolve this issue.

Before:

https://github.com/swimlane/ngx-ui/assets/100230626/08d49a38-8ae6-4176-8137-22bb04b48004

Now:

https://github.com/swimlane/ngx-ui/assets/100230626/24653c58-7a12-44d9-9886-238645abfaa8


## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
