### PR TITLE
fix: repair html input type overwritten

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.helper.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor.helper.ts
@@ -234,7 +234,7 @@ export function inferType(value: any, overrides?: any, allowedTypes?: string[]):
   if (!type) {
     type = dataTypeMap.object.schema;
   }
-  return type;
+  return { ...type };
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fix a bug caused by the dataTypeMap overwrite, so I create a copy to avoid make changes directly in this variable.

## Checklist

- [x] \*Added a code reviewer

_\*required_
