### PR TITLE
Add the support to display one item in PlusMenu

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.html
@@ -22,7 +22,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-
     <g class="right two" transform="translate(0, 0)">
       <defs>
         <linearGradient [id]="'right-two-grad--' + uid">

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.scss
@@ -142,6 +142,30 @@
       border-radius: var(--button-radius) var(--button-radius) var(--button-radius) var(--radial-size);
     }
 
+    .ngx-plus-menu--items-container {
+      position: absolute;
+      top: var(--button-size);
+      right: var(--button-size);
+    }
+  }
+
+  &.position-right.has-one {
+    .ngx-plus-menu--item {
+      &-0 {
+        top: 150px;
+        right: 166px;
+      }
+    }
+
+    .ngx-plus-menu--icon {
+      &-0 {
+        top: 97px;
+        right: 97px;
+      }
+    }
+  }
+
+  &.position-right.has-two {
     .ngx-plus-menu--content-container > svg {
       position: absolute;
       top: -21px;
@@ -248,22 +272,6 @@
       height: 200px;
       text-align: center;
       bottom: 40px;
-
-      > svg {
-        left: auto;
-        right: auto;
-        bottom: 0;
-
-        .bottom {
-          &.two {
-            display: unset;
-          }
-
-          &.three {
-            display: none;
-          }
-        }
-      }
     }
 
     .ngx-plus-menu--circle-container {
@@ -300,6 +308,42 @@
       background: rgba(var(--background-color), var(--background-opacity));
       box-shadow: 0 0 var(--shadow-blur) var(--shadow-blur) rgba(var(--background-color), var(--background-opacity));
       border-radius: var(--radial-radius) var(--radial-radius) var(--button-radius) var(--button-radius);
+    }
+  }
+
+  &.position-bottom.has-one {
+    .ngx-plus-menu--item {
+      &-0 {
+        top: unset;
+        bottom: 8px;
+        right: 206px;
+      }
+    }
+
+    .ngx-plus-menu--icon {
+      &-0 {
+        top: unset;
+        bottom: 124px;
+        right: 218px;
+      }
+    }
+  }
+
+  &.position-bottom.has-two {
+    .ngx-plus-menu--content-container > svg {
+      left: auto;
+      right: auto;
+      bottom: 0;
+
+      .bottom {
+        &.two {
+          display: unset;
+        }
+
+        &.three {
+          display: none;
+        }
+      }
     }
 
     .ngx-plus-menu--item {
@@ -399,18 +443,6 @@
       height: var(--size);
       text-align: center;
       top: 40px;
-
-      > svg {
-        .top {
-          &.two {
-            display: unset;
-          }
-
-          &.three {
-            display: none;
-          }
-        }
-      }
     }
 
     .ngx-plus-menu--circle-container {
@@ -447,6 +479,36 @@
       background: rgba(var(--background-color), var(--background-opacity));
       box-shadow: 0 0 var(--shadow-blur) var(--shadow-blur) rgba(var(--background-color), var(--background-opacity));
       border-radius: var(--button-radius) var(--button-radius) var(--radial-radius) var(--radial-radius);
+    }
+  }
+
+  &.position-top.has-one {
+    .ngx-plus-menu--item {
+      &-0 {
+        top: 133px;
+        right: 206px;
+      }
+    }
+
+    .ngx-plus-menu--icon {
+      &-0 {
+        top: 50px;
+        right: 220px;
+      }
+    }
+  }
+
+  &.position-top.has-two {
+    .ngx-plus-menu--content-container > svg {
+      .top {
+        &.two {
+          display: unset;
+        }
+
+        &.three {
+          display: none;
+        }
+      }
     }
 
     .ngx-plus-menu--item {

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.spec.ts
@@ -19,7 +19,7 @@ const expectHtmlEquals = (actual: string, expected: string, options?: any) => {
   expect(actual).toEqual(expected, 'Expected HTML to match');
 };
 
-describe('PlusMenuComponent', () => {
+fdescribe('PlusMenuComponent', () => {
   let shallow: Shallow<PlusMenuComponent>;
 
   const upload = {
@@ -44,6 +44,68 @@ describe('PlusMenuComponent', () => {
   });
 
   describe('right', () => {
+    describe('one item, default colors', () => {
+      let rendering: Rendering<PlusMenuComponent, unknown>;
+
+      beforeEach(async () => {
+        rendering = await shallow.render({
+          bind: {
+            items: [create]
+          }
+        });
+      });
+
+      it('has correct items', () => {
+        expect(rendering.find('.ngx-plus-menu--item')).toHaveFound(1);
+        expect(rendering.find('.ngx-plus-menu--icon')).toHaveFound(1);
+      });
+
+      it('has correct (default) color', () => {
+        const icon0 = rendering.find('.ngx-plus-menu--icon-0').nativeElement;
+        const style = window.getComputedStyle(icon0);
+
+        expect(style.borderColor).toBe('rgb(159, 206, 54)');
+      });
+
+      it('starts closed', () => {
+        expect(rendering.instance.open).toBe(false);
+        expect(rendering.element.nativeElement).not.toHaveClass('open');
+      });
+
+      it('opens', fakeAsync(() => {
+        rendering.find('.ngx-plus-menu--circle-container').triggerEventHandler('click', null);
+        tick();
+        rendering.fixture.detectChanges();
+
+        expect(rendering.instance.open).toBe(true);
+        expect(rendering.element.nativeElement).toHaveClass('open');
+      }));
+
+      it('renders correct item content', () => {
+        expectHtmlEquals(
+          rendering.find('.ngx-plus-menu--item-0').nativeElement,
+          `
+          <div class="ngx-plus-menu--item ngx-plus-menu--item-0">
+            Create
+            <div class="subtitle">
+              ctrl + alt + n
+            </div>
+          </div>`
+        );
+      });
+
+      it('renders correct icons', () => {
+        expectHtmlEquals(
+          rendering.find('.ngx-plus-menu--icon-0').nativeElement,
+          `
+          <div class="ngx-plus-menu--icon ngx-plus-menu--icon-0">
+            <ngx-icon ng-reflect-font-icon="add-circle-thin">
+            </ngx-icon>
+          </div>`
+        );
+      });
+    });
+
     describe('two items, default colors', () => {
       let rendering: Rendering<PlusMenuComponent, unknown>;
 
@@ -185,6 +247,31 @@ describe('PlusMenuComponent', () => {
   });
 
   describe('bottom', () => {
+    describe('one item, defaults', () => {
+      let rendering: Rendering<PlusMenuComponent, unknown>;
+
+      beforeEach(async () => {
+        rendering = await shallow.render({
+          bind: {
+            items: [upload],
+            position: PlusMenuPosition.Bottom
+          }
+        });
+      });
+
+      it('shows menu title', () => {
+        expectHtmlEquals(
+          rendering.find('.ngx-plus-menu--menu-title').nativeElement,
+          '<span class="ngx-plus-menu--menu-title"></span>'
+        );
+      });
+
+      it('has correct items', () => {
+        expect(rendering.find('.ngx-plus-menu--item')).toHaveFound(1);
+        expect(rendering.find('.ngx-plus-menu--icon')).toHaveFound(1);
+      });
+    });
+
     describe('two items, defaults', () => {
       let rendering: Rendering<PlusMenuComponent, unknown>;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
@@ -44,7 +44,7 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
   }
 
   get itemColor1() {
-    return this.items[1].color || this.menuColor;
+    return this.items[1]?.color || this.menuColor;
   }
 
   get itemColor2() {
@@ -59,10 +59,22 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
   @HostBinding('class.open')
   open = false;
 
+  @HostBinding('class.has-one')
+  @Input()
+  get hasOne(): boolean {
+    return this.items.length == 1;
+  }
+
+  @HostBinding('class.has-two')
+  @Input()
+  get hasTwo(): boolean {
+    return this.items.length == 2;
+  }
+
   @HostBinding('class.has-three')
   @Input()
   get hasThree(): boolean {
-    return this.items.length > 2;
+    return this.items.length == 3;
   }
 
   uid = '';

--- a/src/app/components/plus-menu-page/plus-menu-page.component.html
+++ b/src/app/components/plus-menu-page/plus-menu-page.component.html
@@ -2,6 +2,20 @@
 
 <ngx-tabs>
   <ngx-tab label="Examples">
+    <ngx-section class="shadow" sectionTitle="Plus Menu - Right - One Item">
+      <div class="container-right">
+        <ngx-plus-menu [items]="[create]" (clickItem)="onClick($event)"></ngx-plus-menu>
+      </div>
+      <app-prism>
+        <![CDATA[
+        <ngx-plus-menu
+          [items]="[create]"
+          menuTitle="Install a Plugin"
+          (clickItem)="onClick($event)">
+        </ngx-plus-menu> ]]>
+      </app-prism>
+    </ngx-section>
+
     <ngx-section class="shadow" sectionTitle="Plus Menu - Right - Two Items">
       <div class="container-right">
         <ngx-plus-menu class="my-class" [items]="[upload, create]" (clickItem)="onClick($event)"></ngx-plus-menu>
@@ -25,6 +39,21 @@
         <ngx-plus-menu
           [items]="[upload, create, search]"
           menuColor="#CDD2DD"
+          menuTitle="Install a Plugin"
+          (clickItem)="onClick($event)">
+        </ngx-plus-menu> ]]>
+      </app-prism>
+    </ngx-section>
+
+    <ngx-section class="shadow" sectionTitle="Plus Menu - Bottom - One Item">
+      <div class="container-bottom">
+        <ngx-plus-menu [items]="[create]" position="bottom" menuColor="#01E1B9" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+      </div>
+      <app-prism>
+        <![CDATA[
+        <ngx-plus-menu
+          [items]="[create]"
+          position="bottom"
           menuTitle="Install a Plugin"
           (clickItem)="onClick($event)">
         </ngx-plus-menu> ]]>
@@ -55,6 +84,21 @@
         <ngx-plus-menu
           [items]="[upload, create, search]"
           position="bottom"
+          menuTitle="Install a Plugin"
+          (clickItem)="onClick($event)">
+        </ngx-plus-menu> ]]>
+      </app-prism>
+    </ngx-section>
+
+    <ngx-section class="shadow" sectionTitle="Plus Menu - Top - One Item">
+      <div class="container-top">
+        <ngx-plus-menu [items]="[create]" position="top" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+      </div>
+      <app-prism>
+        <![CDATA[
+        <ngx-plus-menu
+          [items]="[create]"
+          position="top"
           menuTitle="Install a Plugin"
           (clickItem)="onClick($event)">
         </ngx-plus-menu> ]]>
@@ -93,6 +137,20 @@
     
     <h3> Menu Items with Custom Colors </h3>
     
+    <ngx-section class="shadow" sectionTitle="Plus Menu - Right - One Item Custom Color">
+      <div class="container-right">
+        <ngx-plus-menu class="my-class" [items]="[createCustomColor]" (clickItem)="onClick($event)"></ngx-plus-menu>
+      </div>
+      <app-prism>
+        <![CDATA[
+        <ngx-plus-menu
+          [items]="[createCustomColor]"
+          menuTitle="Install a Plugin"
+          (clickItem)="onClick($event)">
+        </ngx-plus-menu> ]]>
+      </app-prism>
+    </ngx-section>
+
     <ngx-section class="shadow" sectionTitle="Plus Menu - Right - Two Items Custom Color">
       <div class="container-right">
         <ngx-plus-menu class="my-class" [items]="[upload, createCustomColor]" (clickItem)="onClick($event)"></ngx-plus-menu>
@@ -116,6 +174,21 @@
         <ngx-plus-menu
           [items]="[upload, create, searchCustomColor]"
           menuColor="#01E1B9"
+          menuTitle="Install a Plugin"
+          (clickItem)="onClick($event)">
+        </ngx-plus-menu> ]]>
+      </app-prism>
+    </ngx-section>
+
+    <ngx-section class="shadow" sectionTitle="Plus Menu - Bottom - One Item Custom Color">
+      <div class="container-bottom">
+        <ngx-plus-menu [items]="[uploadCustomColor]" position="bottom" menuColor="#01E1B9" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+      </div>
+      <app-prism>
+        <![CDATA[
+        <ngx-plus-menu
+          [items]="[uploadCustomColor]"
+          position="bottom"
           menuTitle="Install a Plugin"
           (clickItem)="onClick($event)">
         </ngx-plus-menu> ]]>
@@ -146,6 +219,21 @@
         <ngx-plus-menu
           [items]="[uploadCustomColor, create, searchCustomColor]"
           position="bottom"
+          menuTitle="Install a Plugin"
+          (clickItem)="onClick($event)">
+        </ngx-plus-menu> ]]>
+      </app-prism>
+    </ngx-section>
+
+    <ngx-section class="shadow" sectionTitle="Plus Menu - Top - One Item Custom Color">
+      <div class="container-top">
+        <ngx-plus-menu [items]="[createCustomColor]" position="top" menuTitle="Install a Plugin" (clickItem)="onClick($event)"></ngx-plus-menu>
+      </div>
+      <app-prism>
+        <![CDATA[
+        <ngx-plus-menu
+          [items]="[createCustomColor]"
+          position="top"
           menuTitle="Install a Plugin"
           (clickItem)="onClick($event)">
         </ngx-plus-menu> ]]>


### PR DESCRIPTION
## Summary

Add the support to display one item in PlusMenu.

<img width="1728" alt="image" src="https://github.com/swimlane/ngx-ui/assets/129995474/14c0366b-7d65-42b3-ba34-d1a3807c4216">

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
