### PR TITLE
feat(datetime): support for seconds & milliseconds

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Enhancement (`ngx-datetime`): Supports seconds and milliseconds in the time picker.
+
 ## 45.0.4 (2023-8-9)
 
 - Enhancement (`fonts`): New set of fonts added.

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.html
@@ -40,7 +40,7 @@
       'icon-clock': inputType === 'time'
     }"
     class="calendar-dialog-btn"
-  ></button>  
+  ></button>
 </div>
 
 <ng-template #dialogTpl>
@@ -95,6 +95,33 @@
         max="59"
         (change)="minuteChanged($event)"
         [disabled]="isTimeDisabled('minute')"
+      >
+      </ngx-input>
+    </div>
+    <div>
+      <ngx-input
+        type="number"
+        hint="Second"
+        [id]="id + '-second'"
+        [ngModel]="second"
+        min="0"
+        max="59"
+        (change)="secondChanged($event)"
+        [disabled]="isTimeDisabled('second')"
+      >
+      </ngx-input>
+    </div>
+    <div>
+      <ngx-input
+        type="number"
+        hint="Millisecond"
+        [id]="id + '-millisecond'"
+        [ngModel]="millisecond"
+        min="0"
+        max="999"
+        (change)="millisecondChanged($event)"
+        [disabled]="isTimeDisabled('millisecond')"
+        class="milliseconds"
       >
       </ngx-input>
     </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.scss
@@ -168,12 +168,17 @@ $input-invalid-color: $color-red;
     justify-content: space-between;
 
     > * {
-      flex: 0 0 calc(33% - 6px);
+      flex: 0 0 calc(15% - 6px);
     }
 
     .ngx-input {
       margin-top: 0;
       padding-top: 0;
+      width: 35px;
+
+      &.milliseconds {
+        width: 55px;
+      }
 
       .ngx-input-underline {
         background-color: $color-input-text;

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -27,6 +27,7 @@ const LOCAL_YEAR = '' + MOON_LANDING_DATE.toLocaleDateString('en-US', { year: 'n
 
 const LOCAL_HOUR = LOCAL_TIME.split(':')[0];
 const LOCAL_MIN = MOON_LANDING_DATE.toLocaleTimeString('en-US', { minute: 'numeric' });
+const LOCAL_SEC = MOON_LANDING_DATE.toLocaleTimeString('en-US', { second: 'numeric' });
 const LOCAL_AM_PM = LOCAL_TIME.slice(-2);
 
 describe('DateTimeComponent', () => {
@@ -337,6 +338,20 @@ describe('DateTimeComponent', () => {
         expect(typeof component.displayValue === 'string').toBeTruthy();
         expect(component.displayValue).toEqual('Jul 21, 1969 05:17:43 +09:00 (JST)');
       });
+
+      it('should support seconds & milliseconds', () => {
+        component.format = 'MMM DD, YYYY HH:mm:ss:SSS';
+        component.timezone = 'Asia/Tokyo';
+
+        const isoDateString = '2023-10-27T05:57:12.890Z';
+        component.writeValue(new Date(isoDateString));
+        fixture.detectChanges();
+
+        expect(component.value).toBeTruthy();
+        expect(component.value instanceof Date).toBeTruthy();
+        expect(typeof component.displayValue === 'string').toBeTruthy();
+        expect(component.displayValue).toEqual('Oct 27, 2023 14:57:12:890');
+      });
     });
   });
 
@@ -415,6 +430,8 @@ describe('DateTimeComponent', () => {
       expect(component.dialogModel.isSame(MOON_LANDING_DATE)).toBeTruthy();
       expect(component.hour).toBe(+LOCAL_HOUR);
       expect(component.minute).toBe(LOCAL_MIN);
+      expect(component.second).toBe(LOCAL_SEC);
+      // expect(component.millisecond).toBe(LOCAL_MIN);
       expect(component.amPmVal).toBe(LOCAL_AM_PM);
       expect(component.isCurrent()).toBe(false);
 
@@ -456,6 +473,59 @@ describe('DateTimeComponent', () => {
 
       component.apply();
       expect(component.displayValue).toEqual(`${LOCAL_DATE} 11:${LOCAL_MIN} ${LOCAL_AM_PM}`);
+    });
+
+    it('should update seconds', () => {
+      component.format = 'MM/DD/YYYY hh:mm:ss:SSS';
+      expect(component.dialogModel).toBeTruthy();
+      expect(moment.isMoment(component.dialogModel)).toBeTruthy();
+
+      expect(component.hour).toBe(+LOCAL_HOUR);
+      expect(component.minute).toBe(LOCAL_MIN);
+      expect(component.amPmVal).toBe(LOCAL_AM_PM);
+      expect(component.isCurrent()).toBe(false);
+      component.apply();
+
+      expect(component.displayValue).toEqual(`${LOCAL_DATE} 0${LOCAL_HOUR}:${LOCAL_MIN}:${LOCAL_SEC}:000`);
+
+      const SECONDS_VALUE = 55;
+      component.secondChanged(SECONDS_VALUE);
+
+      expect(component.isCurrent()).toBe(false);
+      expect(component.second).toBe(SECONDS_VALUE + '');
+
+      component.apply();
+      expect(component.displayValue).toEqual(`${LOCAL_DATE} 0${LOCAL_HOUR}:${LOCAL_MIN}:${SECONDS_VALUE}:000`);
+    });
+
+    it('should update milliseconds', () => {
+      component.format = 'MM/DD/YYYY hh:mm:ss:SSS';
+      expect(component.dialogModel).toBeTruthy();
+      expect(moment.isMoment(component.dialogModel)).toBeTruthy();
+
+      expect(component.hour).toBe(+LOCAL_HOUR);
+      expect(component.minute).toBe(LOCAL_MIN);
+      expect(component.second).toBe(LOCAL_SEC);
+      expect(component.amPmVal).toBe(LOCAL_AM_PM);
+      expect(component.isCurrent()).toBe(false);
+      component.apply();
+
+      expect(component.displayValue).toEqual(`${LOCAL_DATE} 0${LOCAL_HOUR}:${LOCAL_MIN}:${LOCAL_SEC}:000`);
+
+      const MILLISECONDS_VALUE = 786;
+      component.millisecondChanged(MILLISECONDS_VALUE);
+
+      expect(component.hour).toBe(+LOCAL_HOUR);
+      expect(component.minute).toBe(LOCAL_MIN);
+      expect(component.second).toBe(LOCAL_SEC);
+      expect(component.millisecond).toBe(MILLISECONDS_VALUE + '');
+      expect(component.amPmVal).toBe(LOCAL_AM_PM);
+      expect(component.isCurrent()).toBe(false);
+
+      component.apply();
+      expect(component.displayValue).toEqual(
+        `${LOCAL_DATE} 0${LOCAL_HOUR}:${LOCAL_MIN}:${LOCAL_SEC}:${MILLISECONDS_VALUE}`
+      );
     });
 
     it('should update am/pm', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.spec.ts
@@ -431,7 +431,6 @@ describe('DateTimeComponent', () => {
       expect(component.hour).toBe(+LOCAL_HOUR);
       expect(component.minute).toBe(LOCAL_MIN);
       expect(component.second).toBe(LOCAL_SEC);
-      // expect(component.millisecond).toBe(LOCAL_MIN);
       expect(component.amPmVal).toBe(LOCAL_AM_PM);
       expect(component.isCurrent()).toBe(false);
 

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -440,7 +440,7 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
         now.millisecond() === this.dialogModel.millisecond()
       );
     }
-    return now.isSame(this.dialogModel, 'millisecond');
+    return now.isSame(this.dialogModel, this.inputType === 'datetime' ? 'millisecond' : 'minute');
   }
 
   clear(): void {

--- a/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-time/date-time.component.ts
@@ -320,6 +320,8 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
   dialogModel: moment.Moment;
   hour: number;
   minute: string;
+  second: string;
+  millisecond: string;
   amPmVal: string;
   modes = ['millisecond', 'second', 'minute', 'hour', 'date', 'month', 'year'];
   timeValues = {};
@@ -395,12 +397,24 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
     this.dialogModel = this.createMoment(date);
     this.hour = +this.dialogModel.format('hh');
     this.minute = this.dialogModel.format('mm');
+    this.second = this.dialogModel.format('ss');
+    this.millisecond = this.dialogModel.format('SSS');
     this.amPmVal = this.dialogModel.format('A');
   }
 
   minuteChanged(newVal: number): void {
     this.dialogModel = this.dialogModel.clone().minute(newVal);
     this.minute = this.dialogModel.format('mm');
+  }
+
+  secondChanged(newVal: number): void {
+    this.dialogModel = this.dialogModel.clone().second(newVal);
+    this.second = this.dialogModel.format('ss');
+  }
+
+  millisecondChanged(newVal: number): void {
+    this.dialogModel = this.dialogModel.clone().millisecond(newVal);
+    this.millisecond = this.dialogModel.format('SSS');
   }
 
   hourChanged(newVal: number): void {
@@ -419,9 +433,14 @@ export class DateTimeComponent implements OnDestroy, OnChanges, ControlValueAcce
   isCurrent() {
     const now = this.createMoment(new Date());
     if (this.inputType === 'time') {
-      return now.hour() === this.dialogModel.hour() && now.minute() === this.dialogModel.minute();
+      return (
+        now.hour() === this.dialogModel.hour() &&
+        now.minute() === this.dialogModel.minute() &&
+        now.second() === this.dialogModel.second() &&
+        now.millisecond() === this.dialogModel.millisecond()
+      );
     }
-    return now.isSame(this.dialogModel, 'minute');
+    return now.isSame(this.dialogModel, 'millisecond');
   }
 
   clear(): void {

--- a/src/app/forms/datetime-page/datetime-page.component.html
+++ b/src/app/forms/datetime-page/datetime-page.component.html
@@ -4,7 +4,7 @@
     <ngx-section class="shadow" sectionTitle="Date Input">
       <label>Current Value:</label>
       <output>{{ date | json }}</output>
-    
+
       <ngx-date-time
         name="date-input1"
         label="Date of attack"
@@ -14,9 +14,9 @@
         (dateTimeSelected)="dateTimeSelected($event)"
       >
       </ngx-date-time>
-    
+
       <br />
-    
+
       <app-prism>
     <![CDATA[<ngx-date-time
       name="date-input1"
@@ -29,10 +29,10 @@
     >
     </ngx-date-time>]]>
       </app-prism>
-    
+
       <br />
       <br />
-    
+
       <ngx-date-time name="date-input2" label="Disabled" [disabled]="true" [(value)]="date2">
       </ngx-date-time>
       <br />
@@ -45,13 +45,13 @@
     >
     </ngx-date-time>]]>
       </app-prism>
-    
+
       <br />
       <br />
-    
+
       <label>Current Value:</label>
       <output>{{ date3 | json }}</output>
-    
+
       <ngx-date-time name="date-input3" label="Custom Format" [(value)]="date3" [format]="'M/Y'">
       </ngx-date-time>
       <br />
@@ -63,10 +63,10 @@
     >
     </ngx-date-time>]]>
       </app-prism>
-    
+
       <br />
       <br />
-    
+
       <ngx-date-time
         name="date-input4"
         label="Min/Max Dates"
@@ -88,22 +88,22 @@
     </ngx-date-time>]]>
       </app-prism>
     </ngx-section>
-    
+
     <ngx-section class="shadow" sectionTitle="Form Control">
       Form Control Value: {{ dateControl.value | json }}
-    
+
       <ngx-date-time label="Form Control" [formControl]="dateControl"></ngx-date-time>
-    
+
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
         <ngx-date-time label="Form Control Name" formControlName="date"></ngx-date-time>
         <ngx-date-time label="Disabled" formControlName="disabledDate"></ngx-date-time>
       </form>
     </ngx-section>
-    
+
     <ngx-section class="shadow" sectionTitle="Date/Time Input">
       <label>Value: </label>
       <output>{{ dateTime | json }}</output>
-    
+
       <ngx-date-time
         name="datetime-input"
         inputType="datetime"
@@ -122,11 +122,11 @@
     </ngx-date-time>]]>
       </app-prism>
     </ngx-section>
-    
+
     <ngx-section class="shadow" sectionTitle="TimeZones">
       <label>Current Value:</label>
       <output>{{ eventDate | json }}</output>
-    
+
       <ngx-date-time
         name="timezone-local"
         inputType="datetime"
@@ -135,7 +135,7 @@
         [(value)]="eventDate"
       >
       </ngx-date-time>
-    
+
       <ngx-date-time
         name="timezone-utc"
         inputType="datetime"
@@ -144,7 +144,7 @@
         [(value)]="eventDate"
       >
       </ngx-date-time>
-    
+
       <ngx-date-time
         name="timezone-jst"
         inputType="datetime"
@@ -153,7 +153,7 @@
         [(value)]="eventDate"
       >
       </ngx-date-time>
-    
+
       <app-prism>
     <![CDATA[ <ngx-date-time
       name="timezone-local"
@@ -163,7 +163,7 @@
       [(value)]="eventDate"
     >
     </ngx-date-time>
-    
+
       <ngx-date-time
       name="timezone-utc"
       inputType="datetime"
@@ -172,7 +172,7 @@
       [(value)]="eventDate"
     >
     </ngx-date-time>
-    
+
     <ngx-date-time
       name="timezone-jst"
       inputType="datetime"
@@ -183,11 +183,11 @@
     </ngx-date-time>]]>
       </app-prism>
     </ngx-section>
-    
+
     <ngx-section class="shadow" sectionTitle="Time Input">
       <label>Current Value:</label>
       <output>{{ time | json }}</output>
-    
+
       <ngx-date-time
         name="time-input1"
         inputType="time"
@@ -205,7 +205,7 @@
     >
     </ngx-date-time>]]>
       </app-prism>
-    
+
       <ngx-date-time
       name="time-input2"
       inputType="time"
@@ -214,7 +214,7 @@
       [(value)]="time"
       >
       </ngx-date-time>
-    
+
       <ngx-date-time
       name="time-input2"
       inputType="time"
@@ -223,7 +223,7 @@
       [(value)]="time"
       >
       </ngx-date-time>
-    
+
       <ngx-date-time
       name="time-input2"
       inputType="time"
@@ -233,39 +233,39 @@
       >
       </ngx-date-time>
     </ngx-section>
-    
+
     <ngx-section class="shadow" sectionTitle="Precision">
       <label>Current Value:</label>
       <output>{{ precisionDate | json }}</output>
-    
+
       <ngx-date-time
         label="Year"
         precision="year"
         [(value)]="precisionDate"
       >
       </ngx-date-time>
-    
+
       <ngx-date-time
         label="Month"
         precision="month"
         [(value)]="precisionDate"
       >
       </ngx-date-time>
-    
+
       <ngx-date-time
         label="Hour"
         precision="hour"
         [(value)]="precisionDate"
       >
       </ngx-date-time>
-    
+
       <ngx-date-time
         label="Minutes"
         precision="minute"
         [(value)]="precisionDate"
       >
       </ngx-date-time>
-    
+
       <app-prism>
     <![CDATA[<ngx-date-time
       label="Year"
@@ -273,21 +273,21 @@
       [(value)]="precisionDate"
     >
     </ngx-date-time>
-    
+
       <ngx-date-time
       label="Month"
       precision="month"
       [(value)]="precisionDate"
     >
     </ngx-date-time>
-    
+
       <ngx-date-time
       label="Hour"
       precision="hour"
       [(value)]="precisionDate"
     >
     </ngx-date-time>
-    
+
       <ngx-date-time
       label="Minutes"
       precision="minute"
@@ -296,13 +296,13 @@
     </ngx-date-time>]]>
       </app-prism>
     </ngx-section>
-    
+
     <ngx-section class="shadow" sectionTitle="Autosize">
       <label>Current Value:</label>
       <output>{{ curDate2 | json }}</output>
-    
+
       <br />
-    
+
       <ngx-date-time
         autosize="true"
         inputType="date"
@@ -312,9 +312,9 @@
         format="YYYY"
       >
       </ngx-date-time>
-    
+
       <br />
-    
+
       <ngx-date-time
         autosize="true"
         inputType="date"
@@ -324,9 +324,9 @@
         format="MMM YYYY"
       >
       </ngx-date-time>
-    
+
       <br />
-    
+
       <ngx-date-time
         autosize="true"
         appearance="fill"
@@ -337,9 +337,9 @@
         format="MMM DD, YYYY, hh:mm"
       >
       </ngx-date-time>
-    
+
       <br />
-    
+
       <ngx-date-time
         autosize="true"
         appearance="fill"
@@ -350,9 +350,9 @@
         format="MMM DD, YYYY, hh:mm:ss"
       >
       </ngx-date-time>
-    
+
       <br />
-    
+
       <ngx-date-time
         autosize="true"
         appearance="fill"
@@ -365,18 +365,18 @@
       >
       </ngx-date-time>
     </ngx-section>
-    
+
     <ngx-section sectionTitle="Native">
       <label>Date</label>
       <input type="date" value="2018-07-22" min="2018-01-01">
-    
+
       <br />
       <br />
-    
+
       <label>Date/Time Local</label>
       <input type="datetime-local" value="2018-07-22" min="2018-01-01">
     </ngx-section>
-    
+
     <ngx-section class="shadow" sectionTitle="Appearances">
       <table class="appearance-table">
         <tr>
@@ -417,6 +417,11 @@
           <td>Date/Time</td>
           <td><ngx-date-time [ngModel]="curDate2" inputType="datetime" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text"></ngx-date-time></td>
           <td><ngx-date-time [ngModel]="curDate2" inputType="datetime" appearance="fill" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text"></ngx-date-time></td>
+        </tr>
+        <tr class="full-datetime">
+          <td>Date/Time with seconds & milliseconds</td>
+          <td><ngx-date-time [ngModel]="fullDate" format="DD/MM/YYYY hh:mm:ss:SSS Z" displayMode="custom" inputType="datetime" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text"></ngx-date-time></td>
+          <td><ngx-date-time [ngModel]="fullDate" format="DD/MM/YYYY hh:mm:ss:SSS Z" displayMode="custom" inputType="datetime" appearance="fill" label="Label" hint="A brief bit of help text" placeholder="Placeholder Text" ></ngx-date-time></td>
         </tr>
         <tr>
           <td>Invalid</td>

--- a/src/app/forms/datetime-page/datetime-page.component.scss
+++ b/src/app/forms/datetime-page/datetime-page.component.scss
@@ -1,0 +1,9 @@
+table.appearance-table {
+  max-width: 850px;
+
+  tr.full-datetime {
+    td {
+      width: 320px;
+    }
+  }
+}

--- a/src/app/forms/datetime-page/datetime-page.component.ts
+++ b/src/app/forms/datetime-page/datetime-page.component.ts
@@ -8,6 +8,7 @@ const MOON_LANDING = '1969-07-20T20:17:43Z';
 @Component({
   selector: 'app-datetime-page',
   templateUrl: './datetime-page.component.html',
+  styleUrls: ['./datetime-page.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DatetimePageComponent {
@@ -27,6 +28,7 @@ export class DatetimePageComponent {
 
   curDate: any = new Date(TOHOKU_EARTHQUAKE);
   curDate2: any = new Date('10/10/2016 2:35 PM');
+  fullDate = new Date();
 
   dateControl: FormControl;
   disabledDateControl: FormControl;


### PR DESCRIPTION
## Summary

This PR introduces the ability for users to input, view, and persist time with precision up to milliseconds in the DateTime control. This enhancement is crucial for scenarios where precise time tracking is necessary.

![Recording 2023-10-27 at 14 38 57](https://github.com/swimlane/ngx-ui/assets/98421392/0da6af27-ea13-414b-851e-dca50af5bda4)

## Checklist

- [x] \*Added unit tests
- [ ] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
