### PR TITLE
Bug fix: dropdown options not cleared for ngx-select component when iterable is set to an empty array

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -199,6 +199,8 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
 
       if (arr.length) {
         this.options = arr;
+      } else {
+        this.options = [];
       }
     }
 


### PR DESCRIPTION
## Summary

Fixed bug with `ngx-select` component where the dropdown options rendered as `ngx-select-option` components were not being removed from the DOM when the iterable was set to an empty array.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
