### PR TITLE
Adding timeStamp when emitting change

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Enhancement (`ngx-toggle`): Added `timeStamp` when emiting `change`
+- Enhancement (`ngx-checkbox`): Added `timeStamp` when emiting `change`
+
 ## 48.0.3 (2024-09-17)
 
 - Enhancement (`ngx-toggle`): Added `change` output to align with `ngx-checkbox`

--- a/projects/swimlane/ngx-ui/src/lib/components/checkbox/checkbox.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/checkbox/checkbox.component.ts
@@ -129,6 +129,10 @@ export class CheckboxComponent implements ControlValueAccessor {
   };
 
   private emitChange() {
-    this.change.emit({ stopPropagation: () => {}, target: { checked: this._value } } as any);
+    this.change.emit({
+      stopPropagation: () => {},
+      timeStamp: new CustomEvent('change').timeStamp,
+      target: { checked: this._value }
+    } as any);
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/toggle/toggle.component.ts
@@ -145,6 +145,10 @@ export class ToggleComponent implements ControlValueAccessor {
   };
 
   private emitChange() {
-    this.change.emit({ stopPropagation: () => {}, target: { checked: this._value } } as any);
+    this.change.emit({
+      stopPropagation: () => {},
+      timeStamp: new CustomEvent('change').timeStamp,
+      target: { checked: this._value }
+    } as any);
   }
 }


### PR DESCRIPTION
## Summary

Adding timeStamp value when emitting change event for ngx-checkbox and ngx-toggle

## Checklist

- [ ] \*Added unit tests
- [X] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
