### PR TITLE
Removing validation of indeterminate state from checkbox 'checked' prop

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix: Removing the `indeterminate state value validation` in the 'checked' input of the checkbox component
+
 ## 49.0.0 (2025-02-11)
 
 - Enhancement (`ngx-checkbox`): a new look is available that displays `indeterminate` state.

--- a/projects/swimlane/ngx-ui/src/lib/components/checkbox/checkbox.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/checkbox/checkbox.component.ts
@@ -57,7 +57,7 @@ export class CheckboxComponent implements ControlValueAccessor {
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('checked')
   set value(value: boolean) {
-    if (this._value !== value && !this.indeterminate) {
+    if (this._value !== value) {
       this._value = value;
       this.cdr.markForCheck();
       this.onChangeCallback(this._value);


### PR DESCRIPTION
## Summary

Removing the `indeterminate state value validation` in the 'checked' input of the checkbox component

## Checklist

- [ ] \*Added unit tests
- [X] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
