### PR TITLE
Firefox calendar fixed

### DIFF
--- a/cypress/e2e/components/calendar.cy.ts
+++ b/cypress/e2e/components/calendar.cy.ts
@@ -5,7 +5,7 @@ describe('Calendar', () => {
   // TODO: replace date with static date instead of today.
   const today = moment();
 
-  const NOT_FOCUSED = 'rgb(148, 198, 255) auto 0px';
+  const NOT_FOCUSED = 'rgb(148, 198, 255) none 0px';
   const FOCUSED = 'rgb(148, 198, 255) solid 2px';
 
   before(() => {

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
@@ -33,7 +33,7 @@ $calendar-month-current: colors.$color-blue-grey-750;
   }
 
   button {
-    outline: 0px auto colors.$color-blue-200;
+    outline: none;
 
     &:focus-within {
       outline: 2px solid colors.$color-blue-200;

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
@@ -33,7 +33,7 @@ $calendar-month-current: colors.$color-blue-grey-750;
   }
 
   button {
-    outline: none;
+    outline: 0px none colors.$color-blue-200;
 
     &:focus-within {
       outline: 2px solid colors.$color-blue-200;


### PR DESCRIPTION
## Summary

Fixes display issue with the Calendars on Firefox by setting the outline property to none instead of auto, ensuring consistent rendering across browsers.

<img width="1728" alt="Screenshot 2025-05-08 at 11 23 34 AM" src="https://github.com/user-attachments/assets/0c9e1d26-531c-4008-bdec-8f22ce62b7d1" />


## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
