### PR TITLE
calendar fixed on firefox

### DIFF
--- a/cypress/e2e/components/calendar.cy.ts
+++ b/cypress/e2e/components/calendar.cy.ts
@@ -5,7 +5,7 @@ describe('Calendar', () => {
   // TODO: replace date with static date instead of today.
   const today = moment();
 
-  const NOT_FOCUSED = 'rgb(148, 198, 255) none 0px';
+  const NOT_FOCUSED = 'rgb(148, 198, 255) 0px';
   const FOCUSED = 'rgb(148, 198, 255) solid 2px';
 
   before(() => {

--- a/cypress/e2e/components/calendar.cy.ts
+++ b/cypress/e2e/components/calendar.cy.ts
@@ -5,7 +5,7 @@ describe('Calendar', () => {
   // TODO: replace date with static date instead of today.
   const today = moment();
 
-  const NOT_FOCUSED = 'rgb(148, 198, 255) 0px';
+  const NOT_FOCUSED = 'rgb(148, 198, 255) none 0px';
   const FOCUSED = 'rgb(148, 198, 255) solid 2px';
 
   before(() => {

--- a/cypress/e2e/components/calendar.cy.ts
+++ b/cypress/e2e/components/calendar.cy.ts
@@ -5,7 +5,7 @@ describe('Calendar', () => {
   // TODO: replace date with static date instead of today.
   const today = moment();
 
-  const NOT_FOCUSED = 'rgb(148, 198, 255) auto 0px';
+  const NOT_FOCUSED = 'rgb(148, 198, 255) none 0px';
   const FOCUSED = 'rgb(148, 198, 255) solid 2px';
 
   before(() => {

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-calendar`): Improved Firefox compatibility by replacing outline: auto with outline: none
+
 ## 49.2.0 (2025-03-20)
 
 - Enhancement (`icons`): Added `field-dynamic` icon

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
@@ -33,7 +33,7 @@ $calendar-month-current: colors.$color-blue-grey-750;
   }
 
   button {
-    outline: 0px auto colors.$color-blue-200;
+    outline: 0px none colors.$color-blue-200;
 
     &:focus-within {
       outline: 2px solid colors.$color-blue-200;

--- a/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/calendar/calendar.component.scss
@@ -33,7 +33,7 @@ $calendar-month-current: colors.$color-blue-grey-750;
   }
 
   button {
-    outline: 0px none colors.$color-blue-200;
+    outline: 0px colors.$color-blue-200;
 
     &:focus-within {
       outline: 2px solid colors.$color-blue-200;


### PR DESCRIPTION
## Summary

Fixes display issue with the Calendar on Firefox by setting the outline property to none instead of auto, ensuring consistent rendering across browsers.
<img width="1728" alt="Screenshot 2025-05-12 at 10 58 13 PM" src="https://github.com/user-attachments/assets/3ab077a9-a07c-433b-a22b-6c3ea14aae92" />

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
