### PR TITLE
Breaking: ColumnComponent supports new declarative syntax for dynamic components

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD (unreleased)
 
+- Breaking (`ngx-column`): Dynamic Components now follow declarative syntax to support outputs, two-way data binding
 - Fix (`ngx-date-range-picker`): Error handling for invalid custom input and updated preset list.
 
 ## 50.0.0-alpha.3 (2025-07-14)

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.html
@@ -1,10 +1,10 @@
-@if (!column?.content) {
+@if (!column()?.content) {
 <header>
   <h4>{{ column?.title }}</h4>
 </header>
 }
 <div class="column">
-  @if (column?.children) {
+  @if (column()?.children) {
   <section class="column-list">
     <div class="search">
       <ngx-icon fontIcon="search" class="search-icon pull-left"></ngx-icon>
@@ -16,7 +16,7 @@
         name="searchInputValue"
         placeholder="Search"
         (keyup)="onInputChange($event)"
-        [disabled]="!column.children.length"
+        [disabled]="!column().children.length"
       ></ngx-input>
     </div>
     @if (list) {
@@ -43,15 +43,12 @@
     </cdk-virtual-scroll-viewport>
     }
   </section>
-  } @if (activeChild?.content) {
-  <section class="column-expanded" #expandedSection [ngStyle]="{ width: activeChild.content.width }">
-    <ng-container
-      *ngComponentOutlet="
-        activeChild.content.component;
-        inputs: activeChild.content.inputs ? activeChild.content.inputs : {};
-        module: activeChild.content.module ? activeChild.content.module : {}
-      "
-    ></ng-container>
-  </section>
   }
+  <section
+    class="column-expanded"
+    [ngStyle]="{ width: activeChild?.content?.width }"
+    [ngClass]="{ hidden: !activeChild?.content }"
+  >
+    <ng-container #expandedSection></ng-container>
+  </section>
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.html
@@ -1,6 +1,6 @@
 @if (!column()?.content) {
 <header>
-  <h4>{{ column?.title }}</h4>
+  <h4>{{ column()?.title }}</h4>
 </header>
 }
 <div class="column">

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.scss
@@ -112,6 +112,9 @@
 
   section.column-expanded {
     overflow: auto;
+    &.hidden {
+      display: none;
+    }
   }
 
   &:not(.expanded) {

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.spec.ts
@@ -122,13 +122,20 @@ describe('ColumnComponent', () => {
   describe('column events', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(ColumnComponent);
-      component = fixture.componentInstance;
-      component.column = column;
+      fixture.componentRef?.setInput('column', column);
       fixture.detectChanges();
+      component = fixture.componentInstance;
     });
 
     it('should emit column id on click', () => {
-      const activeColumn = column.children[0].children[0];
+      const activeColumn = {
+        id: '3o',
+        active: false,
+        title: 'Column 3o',
+        content: {
+          component: ColumnTestContentComponent
+        }
+      };
       spyOn(component.tabClick, 'emit');
       component.ngOnChanges({
         column: {
@@ -151,7 +158,14 @@ describe('ColumnComponent', () => {
     });
 
     it('should emit column id on keyup', () => {
-      const activeColumn = column.children[0].children[0];
+      const activeColumn = {
+        id: '3o',
+        active: false,
+        title: 'Column 3o',
+        content: {
+          component: ColumnTestContentComponent
+        }
+      };
       spyOn(component.tabClick, 'emit');
       component.ngOnChanges({
         column: {
@@ -174,7 +188,14 @@ describe('ColumnComponent', () => {
     });
 
     it('should emit column id on keyup with space bar', () => {
-      const activeColumn = column.children[0].children[0];
+      const activeColumn = {
+        id: '3o',
+        active: false,
+        title: 'Column 3o',
+        content: {
+          component: ColumnTestContentComponent
+        }
+      };
       spyOn(component.tabClick, 'emit');
       component.ngOnChanges({
         column: {

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.ts
@@ -1,11 +1,13 @@
 import {
   Component,
-  EventEmitter,
-  Input,
+  ComponentRef,
+  input,
   OnChanges,
-  Output,
+  output,
   signal,
   SimpleChanges,
+  viewChild,
+  ViewContainerRef,
   ViewEncapsulation
 } from '@angular/core';
 import { Column } from './column.types';
@@ -22,14 +24,15 @@ import { Column } from './column.types';
   }
 })
 export class ColumnComponent implements OnChanges {
-  @Input() column: Column = null;
-  @Input() height: string;
-  @Output() tabClick = new EventEmitter<{ columnId: string }>();
+  column = input<Column | null>(null);
+  height = input<string>('');
+  tabClick = output<{ columnId: string }>();
+  vcr = viewChild('expandedSection', { read: ViewContainerRef });
   scrollerHeight = signal('300');
-
   activeChild: Column = null;
   list: Column[] = [];
   searchInputValue = '';
+  componentRef: ComponentRef<any> | null = null;
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.column?.currentValue) {
@@ -48,28 +51,42 @@ export class ColumnComponent implements OnChanges {
   }
 
   onChildClick(columnId: string) {
-    this.activeChild = this.column.children.find(child => child.id === columnId);
+    this.activeChild = this.column().children.find(child => child.id === columnId);
     this.tabClick.emit({ columnId });
+    if (this.activeChild?.content && this.activeChild?.content.component) {
+      this.vcr()?.clear();
+      this.componentRef = this.vcr()?.createComponent(
+        this.activeChild.content.component,
+        this.activeChild.content.options || {}
+      );
+    }
   }
 
   onChildKeyup(event: KeyboardEvent, columnId: string) {
     if (event.key === 'Enter' || event.key === ' ') {
-      this.activeChild = this.column.children.find(child => child.id === columnId);
+      this.activeChild = this.column().children.find(child => child.id === columnId);
       this.tabClick.emit({ columnId });
+      if (this.activeChild?.content && this.activeChild?.content.component) {
+        this.vcr()?.clear();
+        this.componentRef = this.vcr()?.createComponent(
+          this.activeChild.content.component,
+          this.activeChild.content.options || {}
+        );
+      }
     }
   }
 
   onInputChange(event: KeyboardEvent) {
     const change = (event.target as HTMLInputElement).value;
     if (!change.length) {
-      this.list = this.column.children ? this.column.children : [];
+      this.list = this.column().children ? this.column().children : [];
     } else {
       const query = change.toLowerCase();
-      const results = this.column.children.filter((child: Column) => {
+      const results = this.column().children.filter((child: Column) => {
         return child.title.toLowerCase().includes(query);
       });
       if (!results.length) {
-        this.list = this.column.children ? this.column.children : [];
+        this.list = this.column().children ? this.column().children : [];
         this.activeChild = this.list.find(child => child.active);
       } else {
         this.list = results;

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.types.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.types.ts
@@ -1,3 +1,15 @@
+import { Binding, EnvironmentInjector, Injector } from '@angular/core';
+
+export interface ColumnCustomComponentOptions {
+  index?: number;
+  injector?: Injector;
+  ngModuleRef?: any;
+  environmentInjector?: EnvironmentInjector | any;
+  projectableNodes?: Node[][];
+  directives?: any[];
+  bindings?: Binding[];
+}
+
 export interface Column {
   id: string;
   active: boolean;
@@ -7,8 +19,6 @@ export interface Column {
   content?: {
     width?: string;
     component: any;
-    inputs?: any;
-    outputs?: any;
-    module?: any;
+    options?: ColumnCustomComponentOptions;
   };
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.spec.ts
@@ -53,10 +53,10 @@ describe('ColumnsComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ColumnsComponent);
-    component = fixture.componentInstance;
-    component.column = column;
-    component.columns = [];
+    fixture.componentRef?.setInput('column', column);
     fixture.detectChanges();
+    component = fixture.componentInstance;
+    component.columns = [];
   });
 
   it('should be defined', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, signal, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import { Component, input, OnChanges, signal, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { ColumnComponent } from './column/column.component';
 import { Column } from './column/column.types';
 
@@ -15,8 +15,8 @@ import { Column } from './column/column.types';
   }
 })
 export class ColumnsComponent implements OnChanges {
-  @Input() column: Column;
-  @Input() height: string;
+  column = input<Column | null>(null);
+  height = input<string>('');
   columns: Array<Column>;
   columnComponent = ColumnComponent;
   columnHeight = signal('');
@@ -66,7 +66,7 @@ export class ColumnsComponent implements OnChanges {
 
   getCurrentColumns(): Array<Column> {
     const columns = [];
-    return this.traverseActivePath(this.column, columns);
+    return this.traverseActivePath(this.column(), columns);
   }
 
   onColumnNavigation(col: { columnId: string }): void {

--- a/src/app/components/column-page/column-page.component.ts
+++ b/src/app/components/column-page/column-page.component.ts
@@ -29,7 +29,7 @@ export class ColumnPageComponent {
                 title: 'Column 1d',
                 content: {
                   component: ColumnTestContentComponent,
-                  inputs: {}
+                  options: {}
                 }
               },
               {
@@ -48,7 +48,7 @@ export class ColumnPageComponent {
                         title: 'Column 1g',
                         content: {
                           component: ColumnTestContentComponent,
-                          inputs: {}
+                          options: {}
                         }
                       },
                       {
@@ -57,7 +57,7 @@ export class ColumnPageComponent {
                         title: 'Column 1h',
                         content: {
                           component: ColumnTestContentComponent,
-                          inputs: {}
+                          options: {}
                         }
                       }
                     ]
@@ -116,7 +116,7 @@ export class ColumnPageComponent {
                         title: 'Column 3f',
                         content: {
                           component: ColumnTestContentComponent,
-                          inputs: {}
+                          options: {}
                         }
                       },
                       {
@@ -135,7 +135,7 @@ export class ColumnPageComponent {
                                 title: 'Column 3i',
                                 content: {
                                   component: ColumnTestContentComponent,
-                                  inputs: {}
+                                  options: {}
                                 }
                               },
                               {
@@ -144,7 +144,7 @@ export class ColumnPageComponent {
                                 title: 'Column 3j',
                                 content: {
                                   component: ColumnTestContentComponent,
-                                  inputs: {}
+                                  options: {}
                                 }
                               }
                             ]
@@ -517,9 +517,7 @@ export class ColumnPageComponent {
             title: 'Column 1c',
             content: {
               component: 'ColumnTestContentComponent',
-              inputs: {},
-              outputs: {},
-              module: {}
+              options: {}
             }
           }
         ]
@@ -540,9 +538,7 @@ export class ColumnPageComponent {
                 title: 'Column 2c',
                 content: {
                   component: 'ColumnTestContentComponent',
-                  inputs: {},
-                  outputs: {},
-                  module: {}
+                  options: {}
                 }
               }
             ]


### PR DESCRIPTION
## Summary

* Breaking: dynamic components use declarative syntax in columns

## Checklist

- [X] \*Added unit tests
- [X] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [X] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
