### PR TITLE
(release): 50.0.0-alpha.4

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## HEAD (unreleased)
 
-- Breaking (`ngx-column`): Dynamic Components now follow declarative syntax to support outputs, two-way data binding
+## 50.0.0-alpha.4 (2025-07-23)
+
+- Breaking (`ngx-column`): Setting Dynamic Components in `content` now follow declarative syntax to support outputs, two-way data binding
 - Fix (`ngx-date-range-picker`): Error handling for invalid custom input and updated preset list.
 
 ## 50.0.0-alpha.3 (2025-07-14)

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "50.0.0-alpha.3",
+  "version": "50.0.0-alpha.4",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/src/app/components/column-page/column-page.component.html
+++ b/src/app/components/column-page/column-page.component.html
@@ -94,8 +94,10 @@
             <p>
               Column can either accept a list of Columns set on the children property or a custom template set on the
               content property. Internally ngx-columns will display either a list of options or the custom content
-              specified. The content property model maps to the same interface used by *ngComponentOutlet. When content
-              is specified, use component, inputs, and outputs to pass models to the internal view.
+              specified. The content property model maps to the same interface used by vcr().createComponent(). When
+              content is specified, set a component property to the Component reference you wish to dynamically
+              generate. The component property is passed in the first argument of createComponent internally. Pass any
+              option to the second argument of createComponent using the options property.
             </p>
 
             <p>


### PR DESCRIPTION
## Summary

- Breaking (`ngx-column`): Setting Dynamic Components in `content` now follow declarative syntax to support outputs, two-way data binding
- Fix (`ngx-date-range-picker`): Error handling for invalid custom input and updated preset list.

## Checklist

- [X] \*Added unit tests
- [X] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [X] Updated the demo page
- [] Included screenshots of visual changes

_\*required_
