### PR TITLE
feat: Column Events

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enhancement (`ngx-date-range-picker`): Added tooltip
 - Enhancement (`ngx-date-range-picker`): Added future preset values
 - Enhancement (`ngx-date-range-picker`): Input Fields for preset values display relative expressions (e.g., now-2d to now) instead of converted date values for better clarity and editing.
+- Enhancement (`ngx-column`): Added output `onColumnChange` that emits an event whenever the user changes the active column.
 
 ## 50.0.0-alpha.5 (2025-07-24)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.html
@@ -23,7 +23,7 @@
 
     <cdk-virtual-scroll-viewport #virtualScrollViewport [style.height.px]="scrollerHeight()" itemSize="40">
       <div
-        *cdkVirtualFor="let child of list; index as i"
+        *cdkVirtualFor="let child of list"
         class="ngx-list__virtual-scroll__item"
         (click)="onChildClick(child.id)"
         (keyup)="onChildKeyup($event, child.id)"

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.spec.ts
@@ -167,11 +167,26 @@ describe('ColumnComponent', () => {
     it('should emit column id on click', () => {
       const activeColumn = {
         id: '3o',
-        active: false,
+        active: true,
         title: 'Column 3o',
-        content: {
-          component: ColumnTestContentComponent
-        }
+        children: [
+          {
+            id: '3p',
+            active: false,
+            title: 'Column 3p',
+            content: {
+              component: ColumnTestContentComponent
+            }
+          },
+          {
+            id: '3q',
+            active: false,
+            title: 'Column 3q',
+            content: {
+              component: ColumnTestContentComponent
+            }
+          }
+        ]
       };
       spyOn(component.tabClick, 'emit');
       component.ngOnChanges({
@@ -182,26 +197,38 @@ describe('ColumnComponent', () => {
           isFirstChange: () => true
         }
       });
-      component.onChildClick(activeColumn.id);
-      expect(activeColumn).toEqual({
-        id: '3o',
-        active: false,
-        title: 'Column 3o',
-        content: {
-          component: ColumnTestContentComponent
-        }
+      component.onChildClick('3p');
+      expect(component.tabClick.emit).toHaveBeenCalledWith({
+        columnId: '3p',
+        active: true,
+        title: 'Column 3p',
+        content: true
       });
-      expect(component.tabClick.emit).toHaveBeenCalledWith({ columnId: activeColumn.id });
     });
 
     it('should emit column id on keyup', () => {
       const activeColumn = {
         id: '3o',
-        active: false,
+        active: true,
         title: 'Column 3o',
-        content: {
-          component: ColumnTestContentComponent
-        }
+        children: [
+          {
+            id: '3p',
+            active: false,
+            title: 'Column 3p',
+            content: {
+              component: ColumnTestContentComponent
+            }
+          },
+          {
+            id: '3q',
+            active: false,
+            title: 'Column 3q',
+            content: {
+              component: ColumnTestContentComponent
+            }
+          }
+        ]
       };
       spyOn(component.tabClick, 'emit');
       component.ngOnChanges({
@@ -212,26 +239,38 @@ describe('ColumnComponent', () => {
           isFirstChange: () => true
         }
       });
-      component.onChildKeyup({ key: 'Enter' } as any, activeColumn.id);
-      expect(activeColumn).toEqual({
-        id: '3o',
-        active: false,
-        title: 'Column 3o',
-        content: {
-          component: ColumnTestContentComponent
-        }
+      component.onChildKeyup({ key: 'Enter' } as any, '3p');
+      expect(component.tabClick.emit).toHaveBeenCalledWith({
+        columnId: '3p',
+        active: true,
+        title: 'Column 3p',
+        content: true
       });
-      expect(component.tabClick.emit).toHaveBeenCalledWith({ columnId: activeColumn.id });
     });
 
     it('should emit column id on keyup with space bar', () => {
       const activeColumn = {
         id: '3o',
-        active: false,
+        active: true,
         title: 'Column 3o',
-        content: {
-          component: ColumnTestContentComponent
-        }
+        children: [
+          {
+            id: '3p',
+            active: false,
+            title: 'Column 3p',
+            content: {
+              component: ColumnTestContentComponent
+            }
+          },
+          {
+            id: '3q',
+            active: false,
+            title: 'Column 3q',
+            content: {
+              component: ColumnTestContentComponent
+            }
+          }
+        ]
       };
       spyOn(component.tabClick, 'emit');
       component.ngOnChanges({
@@ -242,16 +281,13 @@ describe('ColumnComponent', () => {
           isFirstChange: () => true
         }
       });
-      component.onChildKeyup({ key: ' ' } as any, activeColumn.id);
-      expect(activeColumn).toEqual({
-        id: '3o',
-        active: false,
-        title: 'Column 3o',
-        content: {
-          component: ColumnTestContentComponent
-        }
+      component.onChildKeyup({ key: ' ' } as any, '3p');
+      expect(component.tabClick.emit).toHaveBeenCalledWith({
+        columnId: '3p',
+        active: true,
+        title: 'Column 3p',
+        content: true
       });
-      expect(component.tabClick.emit).toHaveBeenCalledWith({ columnId: activeColumn.id });
     });
 
     it('should display content on click', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.spec.ts
@@ -193,7 +193,19 @@ describe('ColumnsComponent', () => {
       }
     ];
     spyOn(component, 'deactivatePath').and.callThrough();
-    component.onColumnNavigation({ columnId });
+    component.onColumnNavigation({
+      columnId,
+      active: false,
+      title: 'Child Column 1-1-1',
+      children: [
+        {
+          columnId: '1-1-1-1',
+          active: false,
+          title: 'Child Column 1-1-1',
+          content: true
+        }
+      ]
+    });
 
     expect(component.columns.length).toBe(3);
     expect(component.columns[0].id).toBe('1');

--- a/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.ts
@@ -1,5 +1,5 @@
-import { Component, input, OnChanges, signal, SimpleChanges, ViewEncapsulation } from '@angular/core';
-import { ColumnComponent } from './column/column.component';
+import { Component, input, OnChanges, output, signal, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import { ColumnComponent, ColumnTabClickEvent } from './column/column.component';
 import { Column } from './column/column.types';
 
 @Component({
@@ -17,9 +17,10 @@ import { Column } from './column/column.types';
 export class ColumnsComponent implements OnChanges {
   column = input<Column | null>(null);
   height = input<string>('');
+  onColumnChange = output<ColumnTabClickEvent>();
+  columnHeight = signal('');
   columns: Array<Column>;
   columnComponent = ColumnComponent;
-  columnHeight = signal('');
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.column?.currentValue) {
@@ -69,15 +70,16 @@ export class ColumnsComponent implements OnChanges {
     return this.traverseActivePath(this.column(), columns);
   }
 
-  onColumnNavigation(col: { columnId: string }): void {
-    const parentColumn = this.columns.find(parent => parent.children?.find(column => column.id === col.columnId));
-    const selectedColumn = parentColumn?.children?.find(column => column.id === col.columnId);
+  onColumnNavigation(event: ColumnTabClickEvent): void {
+    const parentColumn = this.columns.find(parent => parent.children?.find(column => column.id === event.columnId));
+    const selectedColumn = parentColumn?.children?.find(column => column.id === event.columnId);
 
     if (parentColumn && parentColumn.children) {
       parentColumn.children.forEach(child => this.deactivatePath(child));
       selectedColumn.active = true;
     }
 
+    this.onColumnChange.emit(event);
     this.columns = this.getCurrentColumns();
   }
 }

--- a/src/app/components/column-page/column-page.component.html
+++ b/src/app/components/column-page/column-page.component.html
@@ -26,9 +26,9 @@
   </ngx-tab>
   <ngx-tab label="API">
     <h3>Table of Contents</h3>
-    <a class="documentation-content" (click)="scrollTo('ngx-columns-inputs')">ngx-columns Inputs</a>
-    <a class="documentation-content" (click)="scrollTo('ngx-columns-column')">ngx-columns Column</a>
-    <a class="documentation-content" (click)="scrollTo('ngx-columns-column-spec')">ngx-columns Column</a>
+    <a class="documentation-content" (click)="scrollTo('ngx-columns-inputs')">Inputs</a>
+    <a class="documentation-content" (click)="scrollTo('ngx-columns-column')">Column</a>
+    <a class="documentation-content" (click)="scrollTo('ngx-columns-column-spec')">Spec</a>
     <h3 class="style-header" id="ngx-columns-inputs">ngx-columns Inputs</h3>
     <table class="table documentation-table">
       <thead>
@@ -55,6 +55,13 @@
             <code>height: string</code>
           </th>
           <td>Change the overall height of the columns by providing a <code>string</code> value in pixels.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>onColumnChange: ColumnTabClickEvent</code>
+          </th>
+          <td>Emits whenever there is user interaction that changes the active column.</td>
         </tr>
       </tbody>
     </table>
@@ -109,8 +116,6 @@
               In the above example, the component is referenced as a string for visibility. In practice, pass the
               reference to the Component you want to display in the custom content area.
             </p>
-
-            <p></p>
           </td>
         </tr>
       </tbody>

--- a/src/app/components/column-page/column-page.component.html
+++ b/src/app/components/column-page/column-page.component.html
@@ -27,7 +27,6 @@
   <ngx-tab label="API">
     <h3>Table of Contents</h3>
     <a class="documentation-content" (click)="scrollTo('ngx-columns-inputs')">Inputs</a>
-    <a class="documentation-content" (click)="scrollTo('ngx-columns-column')">Column</a>
     <a class="documentation-content" (click)="scrollTo('ngx-columns-column-spec')">Spec</a>
     <h3 class="style-header" id="ngx-columns-inputs">ngx-columns Inputs</h3>
     <table class="table documentation-table">


### PR DESCRIPTION
feat: column should emit event when user interacts
fix: remove unused template variable
fix: type definition flaw
fix: issues on demo page

## Summary

ColumnsComponent now exposes an output named `onColumnChange` that emits an event whenever the user interacts with a tab.

## Checklist

- [X] \*Added unit tests
- [X] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
