### PR TITLE
date-range selected range cancel fix

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-date-range-picker`): Support string or Date input for `selectedRange`.
+
 ## 50.0.3 (2025-08-20)
 
 - Fix: Moved date-fns to project dependencies

--- a/projects/swimlane/ngx-ui/src/lib/components/date-range-calendar/date-range-picker.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-range-calendar/date-range-picker.component.ts
@@ -144,15 +144,23 @@ export class DateRangePickerComponent implements OnInit, OnChanges {
 
   private initializeFromSelectedRange() {
     if (this.selectedRange) {
+      const startDate =
+        typeof this.selectedRange.start === 'string'
+          ? DateUtils.parseExpression(this.selectedRange.start)
+          : this.selectedRange.start;
+      const endDate =
+        typeof this.selectedRange.end === 'string'
+          ? DateUtils.parseExpression(this.selectedRange.end)
+          : this.selectedRange.end;
       this.lastConfirmedRange = {
-        startDate: new Date(this.selectedRange.start),
-        endDate: new Date(this.selectedRange.end)
+        startDate,
+        endDate
       };
       this.form.startRaw = this.selectedRange.start;
       this.form.endRaw = this.selectedRange.end;
-      this.form.startDate = this.parseFn(this.selectedRange.start);
-      this.form.endDate = this.parseFn(this.selectedRange.end);
-      this.setTooltipDate(this.form.startDate, this.form.endDate);
+      this.form.startDate = startDate;
+      this.form.endDate = endDate;
+      this.setTooltipDate(startDate, endDate);
     }
   }
 


### PR DESCRIPTION
## Summary

Support string or Date input for selectedRange.

https://github.com/user-attachments/assets/7a4c58cc-c2a8-4b34-b7bc-cbe8a6302b8d


## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
