### PR TITLE
Fix select options replaced when they were bound using the input options

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Fix (`ngx-select`): Allow overwriting the value of the `options` input only if the select has its options defined by the template.
+- Fix (`ngx-select`): Only overwrite the `options` input if a value is provided in the template.
 - Fix (`ngx-date-range-picker`): Fix end expression for presets values.
 - Fix (`ngx-date-range-picker`): Support string or Date input for `selectedRange`.
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HEAD (unreleased)
 
 - Fix (`ngx-select`): Only overwrite the `options` input if a value is provided in the template.
-- Fix (`ngx-date-range-picker`): Fix end expression for presets values.
+- Fix (`ngx-date-range-picker`): Fix end expression for preset values.
 - Fix (`ngx-date-range-picker`): Support string or Date input for `selectedRange`.
 
 ## 50.0.3 (2025-08-20)

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-select`): Allow overwriting the value of the `options` input only if the select has its options defined by the template.
 - Fix (`ngx-date-range-picker`): Support string or Date input for `selectedRange`.
 
 ## 50.0.3 (2025-08-20)

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
@@ -388,8 +388,8 @@ describe('SelectComponent', () => {
   });
 
   describe('optionsTemplate', () => {
-    it('do not override items when they were bound by the "options" input', () => {
-      component.select.items = [
+    it('do not overwrite items when they were bound by the "options" input', () => {
+      component.select.options = [
         selectDropdownOptionMock({ value: { value: 'test' } }),
         selectDropdownOptionMock({ value: { value: 'test1' } }),
         selectDropdownOptionMock({ value: { value: 'test2' } })
@@ -399,8 +399,8 @@ describe('SelectComponent', () => {
       expect(component.select.options.length).toBe(3);
     });
 
-    it('override items when they were not bound by the "options" input', () => {
-      component.select.items = [selectDropdownOptionMock({ value: { value: 'test' } })];
+    it('overwrite items when they were not bound by the "options" input', () => {
+      component.select.options = [selectDropdownOptionMock({ value: { value: 'test' } })];
       component.select['_boundByOptionsInput'] = false;
       component.select.optionTemplates = { toArray: () => [] } as any;
       fixture.detectChanges();

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
@@ -386,4 +386,25 @@ describe('SelectComponent', () => {
       expect(component.select.disabled).toBeFalse();
     });
   });
+
+  describe('optionsTemplate', () => {
+    it('do not override items when they were bound by the "options" input', () => {
+      component.select.items = [
+        selectDropdownOptionMock({ value: { value: 'test' } }),
+        selectDropdownOptionMock({ value: { value: 'test1' } }),
+        selectDropdownOptionMock({ value: { value: 'test2' } })
+      ];
+      component.select.optionTemplates = { toArray: () => [] } as any;
+      fixture.detectChanges();
+      expect(component.select.options.length).toBe(3);
+    });
+
+    it('override items when they were not bound by the "options" input', () => {
+      component.select.items = [selectDropdownOptionMock({ value: { value: 'test' } })];
+      component.select['_boundByOptionsInput'] = false;
+      component.select.optionTemplates = { toArray: () => [] } as any;
+      fixture.detectChanges();
+      expect(component.select.options.length).toBe(0);
+    });
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -94,7 +94,13 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   @Input() selectCaret: string;
   @Input() requiredIndicator: string | boolean = '*';
 
-  @Input() options: SelectDropdownOption[] = [];
+  @Input() set options(options: SelectDropdownOption[]) {
+    this._boundByOptionsInput = true;
+    this._options = options;
+  }
+  get options(): SelectDropdownOption[] {
+    return this._options;
+  }
   @Input() identifier: string;
   @Input() appearance = Appearance.Legacy;
 
@@ -208,9 +214,9 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
       }
 
       if (arr.length) {
-        this.options = arr;
-      } else {
-        this.options = [];
+        this._options = arr;
+      } else if (!this._boundByOptionsInput) {
+        this._options = [];
       }
     }
 
@@ -273,6 +279,8 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   private _optionTemplates: QueryList<SelectOptionDirective>;
   private _value: any[] = [];
   private _autosizeMinWidth = '60px';
+  private _options: SelectDropdownOption[] = [];
+  private _boundByOptionsInput = false;
 
   constructor(
     private readonly _element: ElementRef,


### PR DESCRIPTION
## Summary

This is a fix to do not replace the value of the `options` input with the options added in the template. The issue was introduced in the following PR https://github.com/swimlane/ngx-ui/pull/1019

The new behavior will allow to overwrite the value of the `options` input only if the select has options defined in the template.

## Checklist

- [X] \*Added unit tests
- [X] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
