### PR TITLE
select dropdown numeric values filter fix

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-select`): Fix filtering of numeric option values.
+
 ## 50.0.4 (2025-09-02)
 
 - Fix (`ngx-select`): Only overwrite the `options` input if a value is provided in the template.

--- a/projects/swimlane/ngx-ui/src/lib/components/select/contains-filter.util.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/contains-filter.util.ts
@@ -11,10 +11,6 @@ export function containsFilter(
   }
 
   if (typeof value === 'string') {
-    if (!isNaN(+value)) {
-      return value === keyword;
-    }
-
     const escapedKeyword = escapeRegExp(keyword);
     // eslint-disable-next-line
     const idx = options.filterCaseSensitive ? value.indexOf(keyword) : value.search(new RegExp(escapedKeyword, 'i'));


### PR DESCRIPTION
## Summary

Changed filtering logic to allow numeric options by removing the isNaN check.

https://github.com/user-attachments/assets/989d3390-385f-4881-a306-dd49b2ba955b



## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
