### PR TITLE
Ngx-filter: Show caret when multi dimension is enabled and no values are selected

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-filter`): Show caret when `multiDimension` is enabled and no values are selected
+
 ## 50.1.0 (2025-09-17)
 
 - Feature (`ngx-multi-dimension-selection`): Added a new multi-dimension selection component

--- a/projects/swimlane/ngx-ui/src/lib/components/filter/filter.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/filter/filter.component.ts
@@ -475,7 +475,7 @@ export class FilterComponent implements ControlValueAccessor, AfterViewInit, OnD
   get caretVisible(): boolean {
     if (this.hasSelections) return false;
     if (this.disableDropdown) return false;
-    return !(!this.options || !this.options.length);
+    return !(!this.options || !this.options.length) || !!this.selectionList;
   }
 
   get clearVisible() {


### PR DESCRIPTION
## Summary

- Fix: `ngx-filter` now displays the caret when the `multiDimension` input is set to `true` and no values are selected.

<img width="2556" height="1289" alt="Screenshot 2025-09-18 at 7 00 38 PM" src="https://github.com/user-attachments/assets/c4be1152-e6ac-4216-a2bb-503ed7895413" />

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
