### PR TITLE
(release): 51.3.2

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Enhancement (`ngx-card`): Added a new input attribute in ngx-card to display content when we hover over the card.
 
+## 51.3.2 (2026-04-08)
+- Enhancement (`ngx-column`): Fix scroll position when changing columns after filtering.
+
 ## 51.3.1 (2026-03-12)
 
 - Enhancement (`ngx-column`): Added custom header template for each column

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "51.3.1",
+  "version": "51.3.2",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.html
@@ -11,7 +11,7 @@
   <section class="column-list">
     <div class="search">
       <ngx-icon fontIcon="search" class="search-icon pull-left"></ngx-icon>
-      <button class="btn btn-link pull-right" *ngIf="searchInputValue?.length > 0" (click)="searchInputValue = ''">
+      <button class="btn btn-link pull-right" *ngIf="searchInputValue?.length > 0" (click)="clearFilter()">
         <ngx-icon fontIcon="x"></ngx-icon>
       </button>
       <ngx-input

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.spec.ts
@@ -14,6 +14,7 @@ export class ColumnTestContentComponent {}
 describe('ColumnComponent', () => {
   let component: ColumnComponent;
   let fixture: ComponentFixture<ColumnComponent>;
+  let searchInputWriteValueSpy: jasmine.Spy;
 
   const column = {
     id: '3m',
@@ -162,6 +163,8 @@ describe('ColumnComponent', () => {
       fixture.componentRef?.setInput('column', column);
       fixture.detectChanges();
       component = fixture.componentInstance;
+      searchInputWriteValueSpy = jasmine.createSpy('writeValue');
+      (component as any).searchInput = () => ({ writeValue: searchInputWriteValueSpy });
     });
 
     it('should emit column id on click', () => {
@@ -357,6 +360,7 @@ describe('ColumnComponent', () => {
         }
       } as unknown as KeyboardEvent;
       component.onInputChange(inputEvent);
+      expect(component.searchInputValue).toBe('Column 3n');
       expect(component.list).toEqual([
         {
           id: '3n',
@@ -383,6 +387,7 @@ describe('ColumnComponent', () => {
         }
       } as unknown as KeyboardEvent;
       component.onInputChange(inputEvent);
+      expect(component.searchInputValue).toBe('');
       expect(component.list).toEqual([
         {
           id: '3n',
@@ -506,6 +511,47 @@ describe('ColumnComponent', () => {
           }
         }
       ]);
+    });
+
+    it('should clear filter after child click selection', () => {
+      component.onInputChange({
+        target: { value: 'Column 3n' }
+      } as unknown as KeyboardEvent);
+      expect(component.searchInputValue).toBe('Column 3n');
+
+      component.onChildClick('3p');
+      expect(component.searchInputValue).toBe('');
+      expect(component.list).toEqual(column.children);
+      expect(searchInputWriteValueSpy).toHaveBeenCalledWith('');
+    });
+
+    it('should clear filter after child key selection', () => {
+      component.onInputChange({
+        target: { value: 'Column 3n' }
+      } as unknown as KeyboardEvent);
+      expect(component.searchInputValue).toBe('Column 3n');
+
+      component.onChildKeyup({ key: 'Enter' } as any, '3p');
+      expect(component.searchInputValue).toBe('');
+      expect(component.list).toEqual(column.children);
+      expect(searchInputWriteValueSpy).toHaveBeenCalledWith('');
+    });
+
+    it('should scroll to child by id first then title', () => {
+      const scrollToIndex = jasmine.createSpy('scrollToIndex');
+      (component as any).virtualScrollViewport = () => ({
+        elementRef: { nativeElement: { scrollHeight: 100 } },
+        scrollToIndex
+      });
+
+      const byId = component.scrollToChild('3p', 'does-not-matter');
+      expect(byId).toBeTrue();
+      expect(scrollToIndex).toHaveBeenCalledWith(1);
+
+      scrollToIndex.calls.reset();
+      const byTitle = component.scrollToChild(undefined, 'Column 3n');
+      expect(byTitle).toBeTrue();
+      expect(scrollToIndex).toHaveBeenCalledWith(0);
     });
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/column/column.component.ts
@@ -13,6 +13,7 @@ import {
   AfterViewInit
 } from '@angular/core';
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { InputComponent } from '../../input/input.component';
 import { Column } from './column.types';
 
 export interface ColumnTabClickEvent {
@@ -41,6 +42,7 @@ export class ColumnComponent implements OnChanges, AfterViewInit {
   tabClick = output<ColumnTabClickEvent>();
   scrollerHeight = signal('300');
   vcr = viewChild('expandedSection', { read: ViewContainerRef });
+  searchInput = viewChild<InputComponent>('searchInput');
   virtualScrollViewport = viewChild<CdkVirtualScrollViewport>('virtualScrollViewport');
   activeChild: Column | null = null;
   list: Column[] = [];
@@ -102,6 +104,7 @@ export class ColumnComponent implements OnChanges, AfterViewInit {
     if (this.activeChild?.content && this.activeChild?.content.component) {
       this.displayContent();
     }
+    this.clearFilter();
   }
 
   onChildKeyup(event: KeyboardEvent, columnId: string) {
@@ -112,6 +115,7 @@ export class ColumnComponent implements OnChanges, AfterViewInit {
       if (this.activeChild?.content && this.activeChild?.content.component) {
         this.displayContent();
       }
+      this.clearFilter();
     }
   }
 
@@ -127,7 +131,8 @@ export class ColumnComponent implements OnChanges, AfterViewInit {
   }
 
   onInputChange(event: KeyboardEvent) {
-    const change = (event.target as HTMLInputElement).value;
+    this.searchInputValue = (event.target as HTMLInputElement).value;
+    const change = this.searchInputValue;
     if (!change.length) {
       this.list = this.column().children ? this.column().children : [];
     } else {
@@ -147,6 +152,17 @@ export class ColumnComponent implements OnChanges, AfterViewInit {
     }
   }
 
+  clearFilter(): void {
+    this.searchInputValue = '';
+    this.list = this.column().children ? this.column().children : [];
+    this.activeChild = this.list.find(child => child.active);
+
+    const searchInputCmp = this.searchInput();
+    if (searchInputCmp) {
+      searchInputCmp.writeValue('');
+    }
+  }
+
   getScrollTop(): number {
     const viewport = this.virtualScrollViewport();
     if (viewport) {
@@ -161,5 +177,38 @@ export class ColumnComponent implements OnChanges, AfterViewInit {
     if (viewport) {
       viewport.scrollToOffset(scrollTop);
     }
+  }
+
+  scrollToChild(targetChildId: string | undefined, targetChildTitle: string | undefined): boolean {
+    if (!targetChildId && !targetChildTitle) {
+      return false;
+    }
+
+    const children = this.column()?.children;
+    const viewport = this.virtualScrollViewport();
+    if (!children?.length || !viewport) {
+      return false;
+    }
+
+    const viewportElement = viewport.elementRef.nativeElement as HTMLElement;
+    if (!viewportElement || viewportElement.scrollHeight <= 0) {
+      return false;
+    }
+
+    let childIndex = -1;
+    if (targetChildId) {
+      childIndex = children.findIndex(child => child.id === targetChildId);
+    }
+
+    if (childIndex === -1 && targetChildTitle) {
+      childIndex = children.findIndex(child => child.title === targetChildTitle);
+    }
+
+    if (childIndex === -1) {
+      return false;
+    }
+
+    viewport.scrollToIndex(childIndex);
+    return true;
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.html
@@ -1,3 +1,3 @@
-@if (columns) { @for (column of columns; track column) {
+@if (columns) { @for (column of columns; track column.id) {
 <ngx-column [column]="column" [height]="columnHeight()" [headerTemplate]="headerTemplate()" (tabClick)="onColumnNavigation($event)"></ngx-column>
 } }

--- a/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.spec.ts
@@ -254,4 +254,55 @@ describe('ColumnsComponent', () => {
     expect(activeColumn.active).toBeFalsy();
     expect(activeColumn.children[0].active).toBeFalsy();
   });
+
+  it('should save selected child id/title when filter is active', () => {
+    const columnCompMock = {
+      column: () => ({
+        id: 'c1',
+        children: [
+          { id: 'c1-1', title: 'Child 1', active: true },
+          { id: 'c1-2', title: 'Child 2', active: false }
+        ]
+      }),
+      searchInputValue: 'abc',
+      virtualScrollViewport: () => null
+    };
+
+    component.columnComponents = {
+      length: 1,
+      forEach: cb => [columnCompMock].forEach(cb),
+      toArray: () => [columnCompMock]
+    } as any;
+
+    component.saveScrollState();
+
+    expect((component as any).selectedChildIds.get('c1')).toBe('c1-1');
+    expect((component as any).selectedChildTitles.get('c1')).toBe('Child 1');
+    expect((component as any).scrollPositions.has('c1')).toBeFalse();
+  });
+
+  it('should restore scroll using selected child id/title', () => {
+    const scrollToChild = jasmine.createSpy('scrollToChild').and.returnValue(true);
+    const columnCompMock = {
+      column: () => ({ id: 'c1' }),
+      scrollToChild,
+      virtualScrollViewport: () => null
+    };
+
+    component.columns = [{ id: 'c1', active: true, title: 'C1' } as any];
+    component.columnComponents = {
+      length: 1,
+      forEach: cb => [columnCompMock].forEach(cb),
+      toArray: () => [columnCompMock]
+    } as any;
+
+    (component as any).selectedChildIds.set('c1', 'c1-2');
+    (component as any).selectedChildTitles.set('c1', 'Child 2');
+
+    const restored = component.restoreScrollPositions();
+    expect(restored).toBeTrue();
+    expect(scrollToChild).toHaveBeenCalledWith('c1-2', 'Child 2');
+    expect((component as any).selectedChildIds.has('c1')).toBeFalse();
+    expect((component as any).selectedChildTitles.has('c1')).toBeFalse();
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/column/columns.component.ts
@@ -11,7 +11,6 @@ import {
   QueryList,
   AfterViewChecked,
   OnDestroy,
-  ElementRef,
   inject,
   NgZone,
   ChangeDetectorRef
@@ -41,23 +40,23 @@ export class ColumnsComponent implements OnChanges, AfterViewChecked, OnDestroy 
   columnComponent = ColumnComponent;
 
   @ViewChildren(ColumnComponent) columnComponents!: QueryList<ColumnComponent>;
-  private elementRef = inject(ElementRef);
   private ngZone = inject(NgZone);
   private cdr = inject(ChangeDetectorRef);
 
   private scrollPositions: Map<string, number> = new Map();
+  private selectedChildIds: Map<string, string> = new Map();
+  private selectedChildTitles: Map<string, string> = new Map();
   private shouldRestoreScroll = false;
   private rafId1: number | null = null;
   private rafId2: number | null = null;
   private restoreAttempts = 0;
-  private readonly MAX_RESTORE_ATTEMPTS = 2;
+  private readonly MAX_RESTORE_ATTEMPTS = 6;
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.column?.currentValue) {
-      // Save scroll positions before columns change, in case parent updates column input directly
-      // Only save if we have existing columns not initial load
+      // Save scroll state before columns change.
       if (this.columns && this.columns.length > 0) {
-        this.saveScrollPositions();
+        this.saveScrollState();
       }
 
       this.columns = this.getCurrentColumns();
@@ -143,27 +142,48 @@ export class ColumnsComponent implements OnChanges, AfterViewChecked, OnDestroy 
     }
   }
 
-  saveScrollPositions(): void {
-    if (!this.elementRef?.nativeElement) return;
+  private hasActiveFilter(columnComp: ColumnComponent): boolean {
+    return !!columnComp.searchInputValue?.trim().length;
+  }
 
-    // Use component references to match by column ID (more reliable when components are recreated)
-    if (this.columnComponents && this.columns && this.columnComponents.length > 0) {
-      this.columnComponents.forEach(columnComp => {
-        const column = columnComp.column();
-        if (column) {
-          const viewportRef = columnComp.virtualScrollViewport();
-          if (viewportRef) {
-            const viewportElement = viewportRef.elementRef.nativeElement as HTMLElement;
-            const scrollTop = viewportElement.scrollTop ?? 0;
-            this.scrollPositions.set(column.id, scrollTop);
-          }
-        }
-      });
+  private getColumnComponentById(columnId: string): ColumnComponent | undefined {
+    return this.columnComponents?.toArray().find(columnComp => columnComp.column()?.id === columnId);
+  }
+
+  saveScrollState(): void {
+    if (!this.columnComponents || this.columnComponents.length === 0) {
+      return;
     }
+
+    this.columnComponents.forEach(columnComp => {
+      const column = columnComp.column();
+      if (!column) {
+        return;
+      }
+
+      if (this.hasActiveFilter(columnComp)) {
+        const selectedChild = column.children?.find(child => child.active);
+        if (selectedChild?.id) {
+          this.selectedChildIds.set(column.id, selectedChild.id);
+        }
+        if (selectedChild?.title) {
+          this.selectedChildTitles.set(column.id, selectedChild.title);
+        }
+        this.scrollPositions.delete(column.id);
+        return;
+      }
+
+      const viewport = columnComp.virtualScrollViewport();
+      if (viewport) {
+        this.scrollPositions.set(column.id, viewport.measureScrollOffset('top'));
+      }
+    });
   }
 
   restoreScrollPositions(): boolean {
-    if (!this.elementRef?.nativeElement || this.scrollPositions.size === 0) return false;
+    if (this.selectedChildTitles.size === 0 && this.scrollPositions.size === 0) {
+      return false;
+    }
 
     // Match columns with viewports by column ID, not index
     // This ensures we restore to the correct column even if the order changes or components are recreated
@@ -174,15 +194,26 @@ export class ColumnsComponent implements OnChanges, AfterViewChecked, OnDestroy 
       this.columnComponents.forEach(columnComp => {
         const column = columnComp.column();
         if (column) {
+          const selectedChildId = this.selectedChildIds.get(column.id);
+          const selectedChildTitle = this.selectedChildTitles.get(column.id);
+          if (selectedChildId || selectedChildTitle) {
+            expectedRestoreCount++;
+            if (columnComp.scrollToChild(selectedChildId, selectedChildTitle)) {
+              restoredCount++;
+              this.selectedChildIds.delete(column.id);
+              this.selectedChildTitles.delete(column.id);
+            }
+            return;
+          }
+
           const savedScrollTop = this.scrollPositions.get(column.id);
           if (savedScrollTop !== undefined) {
             expectedRestoreCount++;
             const viewport = columnComp.virtualScrollViewport();
             if (viewport) {
               const viewportElement = viewport.elementRef.nativeElement as HTMLElement;
-              // Check if viewport is ready (has content)
               if (viewportElement && viewportElement.scrollHeight > 0) {
-                viewportElement.scrollTop = savedScrollTop;
+                viewport.scrollToOffset(savedScrollTop);
                 restoredCount++;
               }
             }
@@ -237,15 +268,21 @@ export class ColumnsComponent implements OnChanges, AfterViewChecked, OnDestroy 
   }
 
   onColumnNavigation(event: ColumnTabClickEvent): void {
-    // Save scroll positions BEFORE making any changes
-    this.saveScrollPositions();
+    // Save scroll state BEFORE making any changes.
+    this.saveScrollState();
 
     const parentColumn = this.columns.find(parent => parent.children?.find(column => column.id === event.columnId));
     const selectedColumn = parentColumn?.children?.find(column => column.id === event.columnId);
 
-    if (parentColumn && parentColumn.children) {
+    if (parentColumn && parentColumn.children && selectedColumn) {
       parentColumn.children.forEach(child => this.deactivatePath(child));
       selectedColumn.active = true;
+      const parentColumnComponent = this.getColumnComponentById(parentColumn.id);
+      if (parentColumnComponent && this.hasActiveFilter(parentColumnComponent)) {
+        this.selectedChildIds.set(parentColumn.id, selectedColumn.id);
+        this.selectedChildTitles.set(parentColumn.id, selectedColumn.title);
+        this.scrollPositions.delete(parentColumn.id);
+      }
     }
 
     this.onColumnChange.emit(event);


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/508c9426-e68a-4164-bd15-58cc04ff99a5


## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes scroll/selection state handling and virtual scroll restoration logic, which can regress navigation behavior in edge cases (empty lists, delayed viewport render) but is covered by added unit tests.
> 
> **Overview**
> Fixes `ngx-columns` scroll restoration when a column filter is active by saving the *selected child* (id/title) instead of a raw scroll offset, then restoring by scrolling to that child via new `ColumnComponent.scrollToChild()`.
> 
> Also clears the search filter whenever a child is selected (click/keyboard) and ensures the `ngx-input` UI is reset via a new `clearFilter()` helper. Minor template update tracks columns by `column.id`, and the package/changelog are bumped for `51.3.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 213bfca4a44853694fd5c624df70c820f1b2eb8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->