### PR TITLE
feat: [SPT-55765] Adding undo redo buttons in the dialog header

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/dialog.module.ts
@@ -6,6 +6,7 @@ import { InjectionService } from '../../services/injection/injection.service';
 import { InputModule } from '../input/input.module';
 import { LongPressButtonModule } from '../long-press/long-press-button.module';
 import { OverlayModule } from '../overlay/overlay.module';
+import { TooltipModule } from '../tooltip/tooltip.module';
 
 import { AlertComponent } from './alert/alert.component';
 import { DialogComponent } from './dialog.component';
@@ -42,6 +43,6 @@ import { LargeFormatDialogContentComponent } from './large-format/large-format-d
     LargeFormatDialogSubTabsDirective
   ],
   providers: [InjectionService],
-  imports: [CommonModule, OverlayModule, InputModule, FormsModule, LongPressButtonModule]
+  imports: [CommonModule, OverlayModule, InputModule, FormsModule, LongPressButtonModule, TooltipModule]
 })
 export class DialogModule {}

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-action/large-format-dialog-header-action.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-action/large-format-dialog-header-action.component.html
@@ -1,0 +1,32 @@
+@if (showUndoRedo) {
+	<div class="ngx-large-format-dialog-header-action__undo-redo-container">
+		<button
+			type="button"
+			class="undo-button btn btn-link"
+			ngx-tooltip
+			tooltipTitle="Undo"
+			[disabled]="!undoRedoState.canUndo"
+			(click)="undo.emit()"
+		>
+			<i class="ngx-icon ngx-undo"></i>
+		</button>
+		<button
+			type="button"
+			class="redo-button btn btn-link"
+			ngx-tooltip
+			tooltipTitle="Redo"
+			[disabled]="!undoRedoState.canRedo"
+			(click)="redo.emit()"
+		>
+			<i class="ngx-icon ngx-redo"></i>
+		</button>
+	</div>
+}
+<button
+	type="button"
+	class="ngx-large-format-dialog-header-action__button btn btn-link"
+	(click)="closeOrCancel.emit(dirty)"
+>
+	<i class="ngx-icon ngx-x"></i>
+	{{ dirty ? dirtyActionTitle : actionTitle }}
+</button>

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-action/large-format-dialog-header-action.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-action/large-format-dialog-header-action.component.scss
@@ -7,11 +7,18 @@
   align-items: center;
   justify-content: flex-end;
 
+  &__undo-redo-container {
+    display: flex;
+    gap: var(--spacing-8);
+    align-items: center;
+  }
+
   &__button {
     color: colors.$color-blue-grey-400;
     font-size: 0.8125rem;
     line-height: 1rem;
     padding-right: 0;
+    margin-left: var(--spacing-24);
 
     & i.ngx-icon {
       font-size: 0.625rem;

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-action/large-format-dialog-header-action.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-header-action/large-format-dialog-header-action.component.ts
@@ -10,16 +10,7 @@ import {
 
 @Component({
   selector: 'ngx-large-format-dialog-header-action',
-  template: `
-    <button
-      type="button"
-      class="ngx-large-format-dialog-header-action__button btn btn-link"
-      (click)="closeOrCancel.emit(dirty)"
-    >
-      <i class="ngx-icon ngx-x"></i>
-      {{ dirty ? dirtyActionTitle : actionTitle }}
-    </button>
-  `,
+  templateUrl: './large-format-dialog-header-action.component.html',
   styleUrls: ['./large-format-dialog-header-action.component.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -29,6 +20,10 @@ export class LargeFormatDialogHeaderActionComponent {
   @Input() actionTitle = 'Close';
   @Input() dirty = false;
   @Input() dirtyActionTitle = 'Cancel';
+  @Input() showUndoRedo = false;
+  @Input() undoRedoState: { canUndo: boolean; canRedo: boolean } = { canUndo: false, canRedo: false };
+  @Output() undo = new EventEmitter<void>();
+  @Output() redo = new EventEmitter<void>();
 
   @Output() closeOrCancel = new EventEmitter<boolean>();
 

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
@@ -62,6 +62,10 @@
     [dirty]="dirty"
     [actionTitle]="dialogActionTitle"
     [dirtyActionTitle]="dialogDirtyActionTitle"
-    (closeOrCancel)="onCloseOrCancel($event)"
+    [showUndoRedo]="showUndoRedo"
+    [undoRedoState]="undoRedoState"
+    (undo)="undo.emit()"
+    (redo)="redo.emit()"
+    (closeOrCancel)="closeOrCancel.emit($event)"
   ></ngx-large-format-dialog-header-action>
 </ng-template>

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
@@ -41,6 +41,8 @@ export class LargeFormatDialogContentComponent implements OnInit {
   @Input() dialogActionTitle = 'Close';
   @Input() dirty = false;
   @Input() dialogDirtyActionTitle = 'Cancel';
+  @Input() showUndoRedo = false;
+  @Input() undoRedoState: { canUndo: boolean; canRedo: boolean } = { canUndo: false, canRedo: false };
 
   // dirty alert options
   @Input() dirtyAlertOptions?: DialogOptions;
@@ -48,6 +50,8 @@ export class LargeFormatDialogContentComponent implements OnInit {
 
   // header-action outputs
   @Output() closeOrCancel = new EventEmitter<boolean>();
+  @Output() undo = new EventEmitter<void>();
+  @Output() redo = new EventEmitter<void>();
 
   @HostBinding('class.ngx-large-format-dialog-content')
   get isLargeFormat() {

--- a/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.html
+++ b/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.html
@@ -1113,6 +1113,38 @@
         </ngx-tab>
       </ngx-tabs>
     </ngx-section>
+
+    <ngx-section class="shadow" sectionTitle="With Undo Redo Buttons">
+      <ng-template #largeFormatWithUndoRedo let-context="context">
+        <ngx-large-format-dialog-content 
+          dialogTitle="Title"
+          dialogSubtitle="Optional Subtitle" 
+          [showUndoRedo]="true"
+          [undoRedoState]="{canUndo: true, canRedo: true}"
+          (undo)="onUndo()"
+          (redo)="onRedo()"
+          (closeOrCancel)="onCloseOrCancel()"
+        >
+          <p>Content</p>
+        </ngx-large-format-dialog-content>
+      </ng-template>
+    
+      <button type="button" class="btn" (click)="openDialog({ template: largeFormatWithUndoRedo, format: 'large', closeOnEscape: true })">
+        Open Large Dialog with Undo Redo Buttons
+      </button>
+    
+      <app-prism>
+    <![CDATA[<ng-template #largeFormatWithUndoRedo>
+      <ngx-large-format-dialog-content dialogTitle="Dialog Title" dialogSubtitle="Optional Subtitle" [showUndoRedo]="true" [undoRedoState]="{canUndo: true, canRedo: true}" (undo)="onUndo()" (redo)="onRedo()" (closeOrCancel)="onCloseOrCancel()">
+        <p>Content</p>
+      </ngx-large-format-dialog-content>
+    </ng-template>
+    
+    <button type="button" class="btn" (click)="openDialog({ template: largeFormatWithUndoRedo, format: 'large' })">
+      Open Large Dialog
+    </button>]]>
+      </app-prism>
+    </ngx-section>
     
     <ng-template #dialogDrawerTemplate let-close="close" let-context="context">
       <app-parent-drawer (dismiss)="close.emit()"></app-parent-drawer>

--- a/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.ts
+++ b/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.ts
@@ -54,6 +54,14 @@ export class DialogLargeFormatDialogPageComponent {
     this.dialogRef?.destroy();
   }
 
+  onUndo() {
+    return;
+  }
+
+  onRedo() {
+    return;
+  }
+
   onCloseOrCancel2(isDirty: boolean) {
     alert('isDirty: ' + isDirty);
     this.dialogRef?.destroy();


### PR DESCRIPTION
## Summary

- Added Undo redo buttons beside the close button in the dialog which can be hidden/showed based on the flag. 
- The component takes in canUndo and canRedo to enable/disable the buttons
- Emits undo OR redo event when buttons are clicked.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
