### PR TITLE
(feat): Placeholder for additional actions

### DIFF
--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.html
@@ -58,6 +58,11 @@
     [imageTemplate]="imageTemplate"
     [dialogSubtitleTemplate]="dialogSubtitleTemplate"
   ></ngx-large-format-dialog-header-title>
+  <ng-container *ngIf="!stepperTemplate && !tabsTemplate">
+    <div *ngIf="largeFormatDialogHeaderContent" class="ngx-large-format-dialog-header-content">
+      <ng-container *ngTemplateOutlet="largeFormatDialogHeaderContent"></ng-container>
+    </div>
+  </ng-container>
   <ngx-large-format-dialog-header-action
     [dirty]="dirty"
     [actionTitle]="dialogActionTitle"

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.scss
@@ -63,6 +63,16 @@
       align-items: center;
       justify-content: space-between;
       padding: 0 2rem;
+
+      .ngx-large-format-dialog-header-content {
+        flex: 1;
+        margin: 0 var(--spacing-12);
+      }
+
+      ngx-large-format-dialog-header-title:has(+ .ngx-large-format-dialog-header-content),
+      .ngx-large-format-dialog-header-content + .ngx-large-format-dialog-header-action {
+        flex: 0 0 auto;
+      }
     }
 
     &__body {

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.spec.ts
@@ -1,0 +1,204 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+
+import { AlertService } from '../alert/alert.service';
+import { LargeFormatDialogContentComponent } from './large-format-dialog-content.component';
+import { LargeFormatDialogHeaderActionComponent } from './components/large-format-dialog-header-action/large-format-dialog-header-action.component';
+import { LargeFormatDialogHeaderTitleComponent } from './components/large-format-dialog-header-title/large-format-dialog-header-title.component';
+import { LargeFormatDialogStepperDirective } from './directives/large-format-dialog-stepper/large-format-dialog-stepper.directive';
+import { LargeFormatDialogTabsDirective } from './directives/large-format-dialog-tabs/large-format-dialog-tabs.directive';
+
+@Component({
+  selector: 'ngx-test-host-header-content',
+  standalone: false,
+  template: `
+    <ng-template #headerContentTpl>
+      <span class="header-content-test-marker">Extra Action</span>
+    </ng-template>
+    <ngx-large-format-dialog-content
+      dialogTitle="Title"
+      [largeFormatDialogHeaderContent]="headerContentTpl"
+      (closeOrCancel)="noop()"
+    >
+      <p>Body</p>
+    </ngx-large-format-dialog-content>
+  `
+})
+class TestHostWithHeaderContentComponent {
+  noop(): void {}
+}
+
+@Component({
+  selector: 'ngx-test-host-no-header-content',
+  standalone: false,
+  template: `
+    <ngx-large-format-dialog-content dialogTitle="Title" (closeOrCancel)="noop()">
+      <p>Body</p>
+    </ngx-large-format-dialog-content>
+  `
+})
+class TestHostWithoutHeaderContentComponent {
+  noop(): void {}
+}
+
+@Component({
+  selector: 'ngx-test-host-tabs-with-header-content',
+  standalone: false,
+  template: `
+    <ng-template #headerContentTpl>
+      <span class="header-content-test-marker">Extra Action</span>
+    </ng-template>
+    <ngx-large-format-dialog-content
+      dialogTitle="Title"
+      [largeFormatDialogHeaderContent]="headerContentTpl"
+      (closeOrCancel)="noop()"
+    >
+      <ng-template largeFormatDialogTabs>
+        <div class="tabs-stub">Tabs</div>
+      </ng-template>
+    </ngx-large-format-dialog-content>
+  `
+})
+class TestHostTabsWithHeaderContentComponent {
+  noop(): void {}
+}
+
+@Component({
+  selector: 'ngx-test-host-stepper-with-header-content',
+  standalone: false,
+  template: `
+    <ng-template #headerContentTpl>
+      <span class="header-content-test-marker">Extra Action</span>
+    </ng-template>
+    <ngx-large-format-dialog-content
+      dialogTitle="Title"
+      [largeFormatDialogHeaderContent]="headerContentTpl"
+      (closeOrCancel)="noop()"
+    >
+      <ng-template largeFormatDialogStepper>
+        <div class="stepper-stub">Stepper</div>
+      </ng-template>
+    </ngx-large-format-dialog-content>
+  `
+})
+class TestHostStepperWithHeaderContentComponent {
+  noop(): void {}
+}
+
+describe(LargeFormatDialogContentComponent.name, () => {
+  let fixture: ComponentFixture<LargeFormatDialogContentComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        LargeFormatDialogContentComponent,
+        LargeFormatDialogHeaderTitleComponent,
+        LargeFormatDialogHeaderActionComponent
+      ],
+      imports: [CommonModule, NoopAnimationsModule],
+      providers: [
+        {
+          provide: AlertService,
+          useValue: {
+            confirm: jasmine.createSpy('confirm').and.returnValue({
+              asObservable: () => of({ type: 'cancel' })
+            })
+          }
+        }
+      ]
+    })
+      .overrideComponent(LargeFormatDialogContentComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(LargeFormatDialogContentComponent);
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});
+
+describe(`${LargeFormatDialogContentComponent.name} largeFormatDialogHeaderContent`, () => {
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        LargeFormatDialogContentComponent,
+        LargeFormatDialogHeaderTitleComponent,
+        LargeFormatDialogHeaderActionComponent,
+        LargeFormatDialogTabsDirective,
+        LargeFormatDialogStepperDirective,
+        TestHostWithHeaderContentComponent,
+        TestHostWithoutHeaderContentComponent,
+        TestHostTabsWithHeaderContentComponent,
+        TestHostStepperWithHeaderContentComponent
+      ],
+      imports: [CommonModule, NoopAnimationsModule],
+      providers: [
+        {
+          provide: AlertService,
+          useValue: {
+            confirm: jasmine.createSpy('confirm').and.returnValue({
+              asObservable: () => of({ type: 'cancel' })
+            })
+          }
+        }
+      ]
+    })
+      .overrideComponent(LargeFormatDialogContentComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default }
+      })
+      .compileComponents();
+  }));
+
+  it('should accept largeFormatDialogHeaderContent input', () => {
+    const fixture = TestBed.createComponent(TestHostWithHeaderContentComponent);
+    fixture.detectChanges();
+
+    const content = fixture.debugElement.query(By.directive(LargeFormatDialogContentComponent));
+    expect(content.componentInstance.largeFormatDialogHeaderContent).toBeTruthy();
+  });
+
+  it('should render header content template inside the header content container', () => {
+    const fixture = TestBed.createComponent(TestHostWithHeaderContentComponent);
+    fixture.detectChanges();
+
+    const marker = fixture.nativeElement.querySelector('.header-content-test-marker');
+    expect(marker).toBeTruthy();
+    expect(marker.textContent).toContain('Extra Action');
+    expect(
+      fixture.nativeElement.querySelector('.ngx-large-format-dialog-header-content .header-content-test-marker')
+    ).toBeTruthy();
+  });
+
+  it('should not render header content template when largeFormatDialogHeaderContent is not provided', () => {
+    const fixture = TestBed.createComponent(TestHostWithoutHeaderContentComponent);
+    fixture.detectChanges();
+
+    const content = fixture.debugElement.query(By.directive(LargeFormatDialogContentComponent));
+    expect(content.componentInstance.largeFormatDialogHeaderContent).toBeFalsy();
+    expect(fixture.nativeElement.querySelector('.header-content-test-marker')).toBeFalsy();
+  });
+
+  it('should not render header content when tabs template is present', () => {
+    const fixture = TestBed.createComponent(TestHostTabsWithHeaderContentComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.tabs-stub')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.header-content-test-marker')).toBeFalsy();
+  });
+
+  it('should not render header content when stepper template is present', () => {
+    const fixture = TestBed.createComponent(TestHostStepperWithHeaderContentComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.stepper-stub')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.header-content-test-marker')).toBeFalsy();
+  });
+});

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/large-format-dialog-content.component.ts
@@ -41,6 +41,7 @@ export class LargeFormatDialogContentComponent implements OnInit {
   @Input() dialogActionTitle = 'Close';
   @Input() dirty = false;
   @Input() dialogDirtyActionTitle = 'Cancel';
+  @Input() largeFormatDialogHeaderContent?: TemplateRef<unknown> | null;
 
   // dirty alert options
   @Input() dirtyAlertOptions?: DialogOptions;

--- a/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.html
+++ b/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.html
@@ -1113,6 +1113,106 @@
         </ngx-tab>
       </ngx-tabs>
     </ngx-section>
+
+    <ngx-section class="shadow" sectionTitle="With Custom Header Content">
+      <p>
+        Use <code>[largeFormatDialogHeaderContent]</code> on <code>ngx-large-format-dialog-content</code> to pass an <code>ng-template</code> with extra header UI (for example actions or controls) rendered between the title block and the close area.
+      </p>
+      
+      <p>
+        <code>largeFormatDialogHeaderContent</code> is only applied in the default header layout. It is not rendered when the dialog uses the stepper or tabs variants (<code>LargeFormatDialogStepperDirective</code> or <code>LargeFormatDialogTabsDirective</code> on an <code>ng-template</code>), so custom header content cannot be combined with those modes.
+      </p>
+      
+      <p>
+        If you need tabs/stepper with custom content, use a custom template that contains the tab/stepper and custom content you need.
+      </p>
+
+      <ng-template #largeFormatWithCustomHeaderContent let-context="context">
+        <ngx-large-format-dialog-content 
+          dialogTitle="Title"
+          dialogSubtitle="Optional Subtitle" 
+          [largeFormatDialogHeaderContent]="largeFormatDialogHeaderContent"
+          (closeOrCancel)="onCloseOrCancel()"
+        >
+          <p>Content</p>
+          <button type="button" class="btn" (click)="headerContentPosition$.next('left')">Position Left</button>
+          <button type="button" class="btn" (click)="headerContentPosition$.next('center')">Position Center</button>
+          <button type="button" class="btn" (click)="headerContentPosition$.next('right')">Position Right</button>
+        </ngx-large-format-dialog-content>
+      </ng-template>
+    
+      <button type="button" class="btn" (click)="openDialog({ template: largeFormatWithCustomHeaderContent, format: 'large' })">
+        Open Large Dialog with Custom Header Content
+      </button>
+
+      <ng-template #largeFormatDialogHeaderContent let-context="context">
+        <div class="header-content" [ngClass]="{ 'position-left': (headerContentPosition$ | async) === 'left', 'position-center': (headerContentPosition$ | async) === 'center', 'position-right': (headerContentPosition$ | async) === 'right' }">
+          Custom Header Content
+          <button type="button" class="btn btn-link">
+            <i class="ngx-icon ngx-star"></i>
+          </button>
+          <button type="button" class="btn btn-link">
+            <i class="ngx-icon ngx-swap"></i>
+          </button>
+        </div>
+      </ng-template>
+    
+      <ngx-tabs>
+        <ngx-tab title="Markup">
+      <app-prism>
+    <![CDATA[<ng-template #largeFormatWithCustomHeaderContent let-context="context">
+        <ngx-large-format-dialog-content 
+          dialogTitle="Title"
+          dialogSubtitle="Optional Subtitle" 
+          [largeFormatDialogHeaderContent]="largeFormatDialogHeaderContent"
+          (closeOrCancel)="onCloseOrCancel()"
+        >
+          <p>Content</p>
+          <button type="button" class="btn" (click)="headerContentPosition$.next('left')">Position Left</button>
+          <button type="button" class="btn" (click)="headerContentPosition$.next('center')">Position Center</button>
+          <button type="button" class="btn" (click)="headerContentPosition$.next('right')">Position Right</button>
+        </ngx-large-format-dialog-content>
+      </ng-template>
+    
+      <button type="button" class="btn" (click)="openDialog({ template: largeFormatWithCustomHeaderContent, format: 'large' })">
+        Open Large Dialog with Custom Header Content
+      </button>
+
+      <ng-template #largeFormatDialogHeaderContent let-context="context">
+        <div class="header-content" [ngClass]="{ 'position-left': (headerContentPosition$ | async) === 'left', 'position-center': (headerContentPosition$ | async) === 'center', 'position-right': (headerContentPosition$ | async) === 'right' }">
+          Custom Header Content
+          <button type="button" class="btn btn-link">
+            <i class="ngx-icon ngx-star"></i>
+          </button>
+          <button type="button" class="btn btn-link">
+            <i class="ngx-icon ngx-swap"></i>
+          </button>
+        </div>
+      </ng-template>]]>
+      </app-prism>
+      </ngx-tab>
+      <ngx-tab title="SCSS">
+        <app-prism language="css">
+    <![CDATA[.header-content {
+        display: flex;
+        flex: 1;
+        gap: 12px;
+        align-items: center;
+
+        &.position-left {
+          justify-content: flex-start;
+        }
+        &.position-right {
+          justify-content: flex-end;
+        }
+        &.position-center {
+          justify-content: center;
+        }
+      }]]>
+        </app-prism>
+      </ngx-tab>
+    </ngx-tabs>
+    </ngx-section>
     
     <ng-template #dialogDrawerTemplate let-close="close" let-context="context">
       <app-parent-drawer (dismiss)="close.emit()"></app-parent-drawer>
@@ -1217,6 +1317,13 @@
             <code class="input-name">skipDirtyAlert: boolean</code>
           </th>
           <td>Whether the component should skip alerting the user when the component is closed in a dirty state.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code class="input-name">largeFormatDialogHeaderContent: TemplateRef&lt;unknown&gt;</code>
+          </th>
+          <td>Custom template to display additional actions/controls in the header action area, between the title and the close button. This cannot be used with the stepper or tabs variants.</td>
         </tr>
       </tbody>
     </table>

--- a/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.ts
+++ b/src/app/dialogs/dialog-large-format-page/dialog-large-format-dialog-page.component.ts
@@ -28,6 +28,23 @@ import { BehaviorSubject } from 'rxjs';
       .margin-left-12 {
         margin-left: 12px;
       }
+
+      .header-content {
+        display: flex;
+        flex: 1;
+        gap: 12px;
+        align-items: center;
+
+        &.position-left {
+          justify-content: flex-start;
+        }
+        &.position-right {
+          justify-content: flex-end;
+        }
+        &.position-center {
+          justify-content: center;
+        }
+      }
     `
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -38,6 +55,7 @@ export class DialogLargeFormatDialogPageComponent {
 
   dirty$ = new BehaviorSubject(false);
   skipDirty$ = new BehaviorSubject(false);
+  headerContentPosition$ = new BehaviorSubject<'left' | 'center' | 'right'>('left');
 
   @ViewChild('dialogDrawerTemplate') dialogDrawerTemplate: TemplateRef<unknown>;
 


### PR DESCRIPTION
## Summary

- Added a placeholder beside the Close/Cancel button in the dialog header.
- We can now pass a custom template that will be rendered in the header. This is an optional property.
- Moved the template of the header-action to a separate html file for cleanliness.


https://github.com/user-attachments/assets/e5c4d234-8569-42a7-ad33-3e2bfe31d4cf


## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
