### PR TITLE
feat(swim-ui): enhancements

### DIFF
--- a/.cursor/skills/use-swim-ui/SKILL.md
+++ b/.cursor/skills/use-swim-ui/SKILL.md
@@ -29,28 +29,57 @@ Ensure the `lit` specifier is available (e.g. via import map) so the swim-ui bun
 
 ## Events
 
-Listen with `@event-name` (Lit) or `addEventListener('event-name', ...)`. Events bubble unless noted. Use `event.detail` for payloads.
+### Host-only custom events (confirmed contract)
 
-| Element | Event | Detail |
-|--------|---------|--------|
-| swim-button | click | native |
-| swim-input | change | value / selection |
-| swim-select | change, dropdown-open, dropdown-close | value / selection; panel events do not bubble |
-| swim-checkbox, swim-toggle | change, checked-change | checked state |
-| swim-radio-group | change | selected value |
-| swim-button-toggle-group | value-change | selected value |
-| swim-tabs | select-tab, select | `{ tab }` |
-| swim-section | toggle | `boolean` (collapsed) |
-| swim-dialog | open, close | close: optional detail |
-| swim-drawer | close | optional detail |
-| swim-list | page-change, scroll | page number; scrollTop |
-| swim-card | select, outline-click | selected; — |
-| swim-tooltip | show, hide | — |
-| swim-navbar | active-change | index |
-| swim-slider | change | `{ value, percent }` |
-| swim-split | resize | — |
-| swim-calendar | change, day-key-enter | — |
-| swim-date-time | change, value-change, blur, focus | — |
+Swim-ui **custom events** are dispatched **only on the `swim-*` element host** (the custom element node: `event.target` is that element). They use **`bubbles: false`** and **`composed: false`**, so they **do not** propagate to ancestors, `document`, or past shadow boundaries.
+
+**How to listen**
+
+- **Lit:** use `@event` on the `swim-*` node that emits it (for example `@change` on `swim-input`, `@close` on `swim-dialog`), not on a wrapping `div` expecting the event to bubble up.
+- **Vanilla:** `element.addEventListener('change', ...)` where `element` is the `swim-*` reference from `querySelector`, `ref`, or `createElement`.
+
+**Do not** rely on **event delegation** on a parent, `document`, or `window` for these custom events—they will not fire there. (Native `click` on `swim-button` is separate: it behaves like a normal control.)
+
+**Naming:** Because custom events stay on the host, conventional names (`change`, `close`, `open`, `select`, etc.) are safe. If a future API ever required **`bubbles: true`**, prefer a **non-generic, swim-specific** event name to avoid clashes.
+
+Use `event.detail` for payloads where the component defines it.
+
+### Propagation summary (`bubbles` / `composed`)
+
+| | Value | Meaning |
+|--|-------|--------|
+| Custom events | `bubbles: false`, `composed: false` | Host-only; listen on that `swim-*` element. |
+
+**Repro:** The swim-ui demo **Event propagation** (`#event-bubbling-matrix`) shows `swim-checkbox` in light DOM vs inside another shadow root.
+
+### Per-event reference
+
+| Element | Event | Bubbles | Composed | Detail |
+|---------|-------|---------|----------|--------|
+| swim-button | `click` | native | native | — |
+| swim-input | `input`, `change`, `focus`, `blur` | no | no | value / validation |
+| swim-select | `change`, `filter-change` | no | no | value / `{ query }` |
+| swim-select | `dropdown-open`, `dropdown-close` | no | no | panel open state |
+| swim-checkbox | `change`, `checked-change`, `indeterminate-change`, `focus`, `blur` | no | no | checked / indeterminate |
+| swim-toggle | `change`, `focus`, `blur` | no | no | checked |
+| swim-radio | `change`, `focus`, `blur` | no | no | value |
+| swim-radio-group | `change`, `blur` | no | no | selected value |
+| swim-button-toggle | `value-change` | no | no | value |
+| swim-button-toggle-group | `value-change` | no | no | selected value |
+| swim-slider | `change` | no | no | `{ value, percent }` |
+| swim-calendar | `change`, `day-key-enter` | no | no | value / keyboard |
+| swim-date-time | `change`, `value-change`, `input-change`, `date-time-selected`, `focus`, `blur` | no | no | value / segments |
+| swim-tabs | `select-tab`, `select` | no | no | `{ tab }` |
+| swim-tab | `swim-tab-active-change` | no | no | — |
+| swim-section | `toggle` | no | no | collapsed boolean |
+| swim-dialog | `open`, `close` | no | no | optional detail on close |
+| swim-large-format-dialog-content | `close-or-cancel` | no | no | dirty boolean |
+| swim-drawer | `close` | no | no | optional detail |
+| swim-list | `page-change`, `scroll` | no | no | page / scrollTop |
+| swim-card | `select`, `outline-click` | no | no | selected / — |
+| swim-tooltip | `show`, `hide` | no | no | `true` |
+| swim-navbar, swim-navbar-item | `active-change` | no | no | index |
+| swim-split-handle | `dragstart`, `drag`, `dragend`, `dblclick` | no | no | `MouseEvent` detail |
 
 ## Slots
 
@@ -104,7 +133,7 @@ When using the CDN bundle, the drawer may be created with `document.createElemen
 | swim-navbar | Navbar; swim-navbar-item children; active-change |
 | swim-list | List/table; columns, headerLabels, dataSource, column-layout, height, default-row-status; page-change, scroll |
 | swim-progress-spinner | Spinner; mode, appearance; in-progress-icon, complete-icon, fail-icon slots |
-| swim-split | Resizable split; swim-split-area, swim-split-handle children; resize event |
+| swim-split | Resizable split; swim-split-area, swim-split-handle children; handle fires drag / dblclick |
 | swim-calendar | Calendar; change, day-key-enter |
 | swim-date-time | Date/time input + picker; change, value-change, blur, focus |
 

--- a/.cursor/skills/use-swim-ui/SKILL.md
+++ b/.cursor/skills/use-swim-ui/SKILL.md
@@ -34,7 +34,8 @@ Listen with `@event-name` (Lit) or `addEventListener('event-name', ...)`. Events
 | Element | Event | Detail |
 |--------|---------|--------|
 | swim-button | click | native |
-| swim-input, swim-select | change | value / selection |
+| swim-input | change | value / selection |
+| swim-select | change, dropdown-open, dropdown-close | value / selection; panel events do not bubble |
 | swim-checkbox, swim-toggle | change, checked-change | checked state |
 | swim-radio-group | change | selected value |
 | swim-button-toggle-group | value-change | selected value |
@@ -95,7 +96,7 @@ When using the CDN bundle, the drawer may be created with `document.createElemen
 | swim-section | Collapsible section; section-title, section-collapsed, section-collapsible, header slot |
 | swim-card | Card; orientation, status, selectable, selected, outline-text |
 | swim-card-header, swim-card-body, swim-card-footer, swim-card-avatar, swim-card-placeholder | Card structure |
-| swim-dialog | Modal; dialog-title, format (regular/medium/large), visible, show-backdrop, close-button |
+| swim-dialog | Modal; dialog-title, format (regular/medium/large), visible, show-backdrop, close-button, close-on-blur, close-on-escape |
 | swim-large-format-dialog-content, swim-large-format-dialog-footer | Large/medium dialog layout slots |
 | swim-drawer | Slide panel; direction (left/right/bottom), size, open, closeOnOutsideClick, isRoot; show()/hide() |
 | swim-tooltip | Tooltip/popover; content, placement, alignment, type, show-event |

--- a/.cursor/skills/use-swim-ui/reference.md
+++ b/.cursor/skills/use-swim-ui/reference.md
@@ -40,7 +40,7 @@ Use this when you need exact property names, attribute names, events, and slots 
 
 **Properties:** `label`, `placeholder`, `hint`, `empty-placeholder`, `filter-placeholder`, `options` (array of {name, value, …}), `value` (single or array if multiple), `name`, `id`, `disabled`, `required`, `appearance`, `size`, `marginless`, `withHint`, `filterable`, `multiple`.  
 **Slots:** default (swim-option children), `hint`.  
-**Events:** `change`, `open`, `close`.  
+**Events:** `change`, `dropdown-open`, `dropdown-close`.  
 **Parts:** `select`, `dropdown`.  
 **Options:** Use `<swim-option name="Label" value="val">` or `options` property.
 
@@ -113,7 +113,7 @@ Use this when you need exact property names, attribute names, events, and slots 
 
 ## swim-dialog
 
-**Properties:** `dialog-title`, `content`, `class`, `css-class`, `format` (regular|medium|large), `show-backdrop`, `close-button`, `visible`, `zIndex`.  
+**Properties:** `dialog-title`, `content`, `class`, `css-class`, `format` (regular|medium|large), `show-backdrop`, `close-button`, `close-on-blur`, `close-on-escape`, `visible`, `zIndex`.  
 **Slots:** default (body).  
 **Events:** `open`, `close` (detail optional).  
 **Parts:** `content`, `close-button`.  

--- a/.cursor/skills/use-swim-ui/reference.md
+++ b/.cursor/skills/use-swim-ui/reference.md
@@ -2,6 +2,8 @@
 
 Use this when you need exact property names, attribute names, events, and slots for `swim-*` elements. Source of truth: `projects/swimlane/swim-ui/src/components/<name>/*.component.ts`.
 
+**Custom events:** Dispatched **only on the `swim-*` element host** (`bubbles: false`, `composed: false`). Listen on that element—do not use `document` / parent delegation. Conventional event names are used because events do not leave the host. Full table: [SKILL.md](SKILL.md#per-event-reference) (Events section).
+
 ---
 
 ## swim-button
@@ -10,6 +12,38 @@ Use this when you need exact property names, attribute names, events, and slots 
 **Slots:** default (button content).  
 **Events:** `click` (native, when not disabled/in-progress).  
 **Parts:** `button`.
+
+**Icon-only:** put `<swim-icon font-icon="…">` in the default slot; set `aria-label` (or `title`) because there is no visible text. Slotted icons inherit `color` from `<swim-button>` (same `--swim-button-color` / variant defaults as labels).
+
+```html
+<script type="module">
+  import '@swimlane/swim-ui/button';
+  import '@swimlane/swim-ui/icon';
+</script>
+
+<swim-button variant="primary" aria-label="Save">
+  <swim-icon font-icon="check"></swim-icon>
+</swim-button>
+```
+
+**Host styling (CSS on `swim-button` or an ancestor):** `--swim-button-padding`, `--swim-button-background`, `--swim-button-hover-background`, `--swim-button-border-width`, `--swim-button-border-style`, `--swim-button-border-color`, `--swim-button-hover-border-color`, `--swim-button-color`, `--swim-button-hover-color`, `--swim-button-shadow`, `--swim-button-outline-color`, `--swim-button-hover-outline-color`. These override every `variant` (including hover).
+
+```html
+<swim-button
+  variant="primary"
+  style="
+    --swim-button-padding: 0.65em 1.1em;
+    --swim-button-background: linear-gradient(120deg, var(--purple-500), var(--blue-500));
+    --swim-button-hover-background: linear-gradient(120deg, var(--purple-600), var(--blue-600));
+    --swim-button-border-width: 2px;
+    --swim-button-border-color: rgba(255, 255, 255, 0.35);
+  "
+>
+  Gradient
+</swim-button>
+```
+
+(Full row + more examples: `projects/swimlane/swim-ui/demo/public/sections/buttons.html`.)
 
 ---
 
@@ -173,9 +207,9 @@ Use this when you need exact property names, attribute names, events, and slots 
 
 ## swim-split / swim-split-area / swim-split-handle
 
-**Split:** slot: swim-split-area, swim-split-handle. Event: `resize`.  
+**Split:** slot: swim-split-area, swim-split-handle. (The parent `swim-split` does not currently dispatch a `resize` custom event; panes update when the handle fires `drag` / `dblclick`.)  
 **Area:** `basis` (flex), slot: default.  
-**Handle:** events: `drag`, `dragstart`, `dragend`, `dblclick`.
+**Handle:** `drag`, `dragstart`, `dragend`, `dblclick` (bubble only, not composed).
 
 ---
 

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.scss
@@ -5,7 +5,6 @@
   &.ngx-medium-format-dialog-footer--default,
   &.ngx-large-format-dialog-footer--default {
     display: flex;
-    justify-content: center;
     align-items: center;
     gap: var(--item-gap);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.scss
@@ -5,6 +5,7 @@
   &.ngx-medium-format-dialog-footer--default,
   &.ngx-large-format-dialog-footer--default {
     display: flex;
+    justify-content: center;
     align-items: center;
     gap: var(--item-gap);
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.spec.ts
@@ -32,4 +32,20 @@ describe(LargeFormatDialogFooterComponent.name, () => {
   it('should have host class', () => {
     expect(nativeElement.classList.contains('ngx-large-format-dialog-footer')).toEqual(true);
   });
+
+  it('should map align start to flex-start on host', () => {
+    component.align = 'start';
+    fixture.detectChanges();
+    expect(nativeElement.style.justifyContent).toBe('flex-start');
+  });
+
+  it('should map align end to flex-end on host', () => {
+    component.align = 'end';
+    fixture.detectChanges();
+    expect(nativeElement.style.justifyContent).toBe('flex-end');
+  });
+
+  it('should use center as default justify-content', () => {
+    expect(nativeElement.style.justifyContent).toBe('center');
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.spec.ts
@@ -32,20 +32,4 @@ describe(LargeFormatDialogFooterComponent.name, () => {
   it('should have host class', () => {
     expect(nativeElement.classList.contains('ngx-large-format-dialog-footer')).toEqual(true);
   });
-
-  it('should map align start to flex-start on host', () => {
-    component.align = 'start';
-    fixture.detectChanges();
-    expect(nativeElement.style.justifyContent).toBe('flex-start');
-  });
-
-  it('should map align end to flex-end on host', () => {
-    component.align = 'end';
-    fixture.detectChanges();
-    expect(nativeElement.style.justifyContent).toBe('flex-end');
-  });
-
-  it('should use center as default justify-content', () => {
-    expect(nativeElement.style.justifyContent).toBe('center');
-  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.ts
@@ -1,5 +1,14 @@
 import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, ViewEncapsulation } from '@angular/core';
 
+/** Horizontal alignment of footer content (flex `justify-content`). */
+export type NgxLargeFormatDialogFooterAlign =
+  | 'start'
+  | 'center'
+  | 'end'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly';
+
 @Component({
   selector: 'ngx-large-format-dialog-footer, ngx-medium-format-dialog-footer',
   template: ' <ng-content></ng-content> ',
@@ -11,6 +20,21 @@ import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, Vie
 export class LargeFormatDialogFooterComponent {
   @Input() styleClass?: string;
   @Input() format: 'large' | 'medium' = 'large';
+
+  /** Maps to flex `justify-content` on the footer host. */
+  @Input() align: NgxLargeFormatDialogFooterAlign = 'center';
+
+  @HostBinding('style.justify-content')
+  get hostJustifyContent(): string {
+    switch (this.align) {
+      case 'start':
+        return 'flex-start';
+      case 'end':
+        return 'flex-end';
+      default:
+        return this.align;
+    }
+  }
 
   @HostBinding('class') get footerStyle() {
     if (this.styleClass) {

--- a/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dialog/large-format/components/large-format-dialog-footer/large-format-dialog-footer.component.ts
@@ -1,14 +1,5 @@
 import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, ViewEncapsulation } from '@angular/core';
 
-/** Horizontal alignment of footer content (flex `justify-content`). */
-export type NgxLargeFormatDialogFooterAlign =
-  | 'start'
-  | 'center'
-  | 'end'
-  | 'space-between'
-  | 'space-around'
-  | 'space-evenly';
-
 @Component({
   selector: 'ngx-large-format-dialog-footer, ngx-medium-format-dialog-footer',
   template: ' <ng-content></ng-content> ',
@@ -20,21 +11,6 @@ export type NgxLargeFormatDialogFooterAlign =
 export class LargeFormatDialogFooterComponent {
   @Input() styleClass?: string;
   @Input() format: 'large' | 'medium' = 'large';
-
-  /** Maps to flex `justify-content` on the footer host. */
-  @Input() align: NgxLargeFormatDialogFooterAlign = 'center';
-
-  @HostBinding('style.justify-content')
-  get hostJustifyContent(): string {
-    switch (this.align) {
-      case 'start':
-        return 'flex-start';
-      case 'end':
-        return 'flex-end';
-      default:
-        return this.align;
-    }
-  }
 
   @HostBinding('class') get footerStyle() {
     if (this.styleClass) {

--- a/projects/swimlane/swim-ui/.gitignore
+++ b/projects/swimlane/swim-ui/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 dist/
 dist-demo/
 dist-cdn/
+.cdn-local-serve/
 demo/src/*.js
 demo/src/*.d.ts
 demo/src/*.d.ts.map

--- a/projects/swimlane/swim-ui/README.md
+++ b/projects/swimlane/swim-ui/README.md
@@ -372,11 +372,11 @@ interface SelectOption {
 
 #### Events
 
-| Event    | Description                                    |
-| -------- | ---------------------------------------------- |
-| `change` | Fired when selection changes (detail: {value}) |
-| `open`   | Fired when dropdown opens                      |
-| `close`  | Fired when dropdown closes                     |
+| Event            | Description                                    |
+| ---------------- | ---------------------------------------------- |
+| `change`         | Fired when selection changes (detail: {value}) |
+| `dropdown-open`  | Fired when the options panel opens             |
+| `dropdown-close` | Fired when the options panel closes            |
 
 #### Slots
 

--- a/projects/swimlane/swim-ui/demo/index.html
+++ b/projects/swimlane/swim-ui/demo/index.html
@@ -710,6 +710,7 @@
               <li><a class="sub-nav-item" href="#dialog">Dialog</a></li>
               <li><a class="sub-nav-item" href="#drawer">Drawer</a></li>
               <li><a class="sub-nav-item" href="#scrollbars">Scrollbars</a></li>
+              <li><a class="sub-nav-item" href="#event-bubbling-matrix">Event propagation</a></li>
             </ul>
           </li>
         </ul>

--- a/projects/swimlane/swim-ui/demo/index.html
+++ b/projects/swimlane/swim-ui/demo/index.html
@@ -689,6 +689,7 @@
               <li><a class="sub-nav-item" href="#input">Inputs</a></li>
               <li><a class="sub-nav-item" href="#select">Selects</a></li>
               <li><a class="sub-nav-item" href="#datetime">Date Time</a></li>
+              <li><a class="sub-nav-item" href="#date-display">Date display</a></li>
               <li><a class="sub-nav-item" href="#checkbox">Checkbox</a></li>
               <li><a class="sub-nav-item" href="#radio">Radio</a></li>
               <li><a class="sub-nav-item" href="#toggle">Toggle</a></li>

--- a/projects/swimlane/swim-ui/demo/public/sections/buttons.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/buttons.html
@@ -1,8 +1,9 @@
 <hr class="section-divider" />
 <h1 id="buttons" class="page-title">Buttons</h1>
 <p class="subtitle">
-  Button component with variants (default, primary, warning, danger, link, bordered), sizes, and states (active,
-  in-progress, success, fail, disabled). Supports promise-based loading state.
+  Button component with variants (default, primary, warning, danger, link, bordered), sizes, icon-only usage, host
+  styling via <code>--swim-button-*</code> CSS variables, and states (active, in-progress, success, fail, disabled).
+  Supports promise-based loading state.
 </p>
 <p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/button.js';</code></p>
 
@@ -60,6 +61,208 @@
   </swim-section>
 </section>
 
+<!-- Icon-only buttons -->
+<section class="section">
+  <swim-section section-title="Icon-only buttons">
+    <p style="color: var(--grey-300); margin-bottom: 1rem">
+      Put a <code>&lt;swim-icon&gt;</code> in the default slot. Always set <code>aria-label</code> (or <code>title</code>) so the
+      control has an accessible name when there is no visible text.
+    </p>
+    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap">
+      <swim-button variant="default" aria-label="Add">
+        <swim-icon font-icon="plus"></swim-icon>
+      </swim-button>
+      <swim-button variant="primary" aria-label="Save">
+        <swim-icon font-icon="check"></swim-icon>
+      </swim-button>
+      <swim-button variant="warning" aria-label="Alert">
+        <swim-icon font-icon="warning-filled"></swim-icon>
+      </swim-button>
+      <swim-button variant="danger" aria-label="Delete">
+        <swim-icon font-icon="trash"></swim-icon>
+      </swim-button>
+      <swim-button variant="bordered" aria-label="Settings">
+        <swim-icon font-icon="cog"></swim-icon>
+      </swim-button>
+      <swim-button variant="link" aria-label="Open menu">
+        <swim-icon font-icon="ellipsis-v"></swim-icon>
+      </swim-button>
+      <swim-button size="small" variant="primary" aria-label="Search">
+        <swim-icon font-icon="search"></swim-icon>
+      </swim-button>
+      <swim-button size="large" variant="primary" aria-label="Upload">
+        <swim-icon font-icon="cloud-upload"></swim-icon>
+      </swim-button>
+    </div>
+    <p style="color: var(--grey-400); margin-top: 1.25rem; margin-bottom: 0.35rem; font-size: 0.875rem">
+      <strong>Code reference</strong> — import the icon entry when you use <code>&lt;swim-icon&gt;</code> (CDN or package path may differ).
+    </p>
+    <pre class="demo-pre"
+    ><code>&lt;script type="module"&gt;
+  import '@swimlane/swim-ui/button';
+  import '@swimlane/swim-ui/icon';
+&lt;/script&gt;
+
+&lt;swim-button variant="default" aria-label="Add"&gt;
+  &lt;swim-icon font-icon="plus"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;
+&lt;swim-button variant="primary" aria-label="Save"&gt;
+  &lt;swim-icon font-icon="check"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;
+&lt;swim-button variant="warning" aria-label="Alert"&gt;
+  &lt;swim-icon font-icon="warning-filled"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;
+&lt;swim-button variant="danger" aria-label="Delete"&gt;
+  &lt;swim-icon font-icon="trash"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;
+&lt;swim-button variant="bordered" aria-label="Settings"&gt;
+  &lt;swim-icon font-icon="cog"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;
+&lt;swim-button variant="link" aria-label="Open menu"&gt;
+  &lt;swim-icon font-icon="ellipsis-v"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;
+&lt;swim-button size="small" variant="primary" aria-label="Search"&gt;
+  &lt;swim-icon font-icon="search"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;
+&lt;swim-button size="large" variant="primary" aria-label="Upload"&gt;
+  &lt;swim-icon font-icon="cloud-upload"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;</code></pre>
+  </swim-section>
+</section>
+
+<!-- Host styling: CSS custom properties -->
+<section class="section">
+  <swim-section section-title="Host styling (CSS custom properties)">
+    <p style="color: var(--grey-300); margin-bottom: 1rem">
+      Set <code>--swim-button-*</code> on <code>&lt;swim-button&gt;</code> (or an ancestor). They override every
+      <code>variant</code>, including hover fallbacks, unless you rely on the built-in token defaults.
+    </p>
+    <div class="demo-grid">
+      <div class="demo-item">
+        <div class="demo-label">Gradient + border + shadow</div>
+        <swim-button
+          variant="primary"
+          aria-label="Gradient action"
+          style="
+            --swim-button-padding: 0.65em 1.1em;
+            --swim-button-background: linear-gradient(120deg, var(--purple-500), var(--blue-500));
+            --swim-button-hover-background: linear-gradient(120deg, var(--purple-600), var(--blue-600));
+            --swim-button-border-width: 2px;
+            --swim-button-border-style: solid;
+            --swim-button-border-color: rgba(255, 255, 255, 0.35);
+            --swim-button-hover-border-color: rgba(255, 255, 255, 0.55);
+            --swim-button-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
+          "
+        >
+          Gradient
+        </swim-button>
+      </div>
+      <div class="demo-item">
+        <div class="demo-label">Warning variant, custom surface</div>
+        <swim-button
+          variant="warning"
+          style="
+            --swim-button-background: var(--grey-700);
+            --swim-button-hover-background: var(--grey-650);
+            --swim-button-color: var(--white);
+            --swim-button-hover-color: var(--white);
+          "
+        >
+          Neutral on warning
+        </swim-button>
+      </div>
+      <div class="demo-item">
+        <div class="demo-label">Dense icon-only (padding, border, surface)</div>
+        <swim-button
+          variant="bordered"
+          aria-label="Filter"
+          style="
+            --swim-button-padding: 0.4em;
+            --swim-button-border-width: 2px;
+            --swim-button-border-color: var(--green-400);
+            --swim-button-hover-border-color: var(--green-500);
+            --swim-button-color: var(--green-400);
+            --swim-button-hover-color: var(--green-500);
+            --swim-button-background: var(--grey-800);
+            --swim-button-hover-background: var(--grey-750);
+          "
+        >
+          <swim-icon font-icon="filter"></swim-icon>
+        </swim-button>
+      </div>
+      <div class="demo-item">
+        <div class="demo-label">Pill-style primary (padding + outline)</div>
+        <swim-button
+          variant="primary"
+          style="
+            --swim-button-padding: 0.5em 1.5em;
+            --swim-button-outline-color: var(--orange-400);
+          "
+        >
+          Pill outline
+        </swim-button>
+      </div>
+    </div>
+    <p style="color: var(--grey-400); margin-top: 1.25rem; margin-bottom: 0.35rem; font-size: 0.875rem">
+      <strong>Code reference</strong> — same <code>style</code> values as the examples above (tokens such as <code>var(--purple-500)</code> come from swim-ui base styles on the host).
+    </p>
+    <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Gradient + border + shadow</p>
+    <pre class="demo-pre"
+    ><code>&lt;swim-button
+  variant="primary"
+  aria-label="Gradient action"
+  style="
+    --swim-button-padding: 0.65em 1.1em;
+    --swim-button-background: linear-gradient(120deg, var(--purple-500), var(--blue-500));
+    --swim-button-hover-background: linear-gradient(120deg, var(--purple-600), var(--blue-600));
+    --swim-button-border-width: 2px;
+    --swim-button-border-style: solid;
+    --swim-button-border-color: rgba(255, 255, 255, 0.35);
+    --swim-button-hover-border-color: rgba(255, 255, 255, 0.55);
+    --swim-button-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
+  "
+&gt;Gradient&lt;/swim-button&gt;</code></pre>
+    <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Warning variant, custom surface</p>
+    <pre class="demo-pre"
+    ><code>&lt;swim-button
+  variant="warning"
+  style="
+    --swim-button-background: var(--grey-700);
+    --swim-button-hover-background: var(--grey-650);
+    --swim-button-color: var(--white);
+    --swim-button-hover-color: var(--white);
+  "
+&gt;Neutral on warning&lt;/swim-button&gt;</code></pre>
+    <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Dense icon-only (padding, border, surface)</p>
+    <pre class="demo-pre"
+    ><code>&lt;swim-button
+  variant="bordered"
+  aria-label="Filter"
+  style="
+    --swim-button-padding: 0.4em;
+    --swim-button-border-width: 2px;
+    --swim-button-border-color: var(--green-400);
+    --swim-button-hover-border-color: var(--green-500);
+    --swim-button-color: var(--green-400);
+    --swim-button-hover-color: var(--green-500);
+    --swim-button-background: var(--grey-800);
+    --swim-button-hover-background: var(--grey-750);
+  "
+&gt;
+  &lt;swim-icon font-icon="filter"&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;</code></pre>
+    <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Pill-style primary (padding + focus ring)</p>
+    <pre class="demo-pre"
+    ><code>&lt;swim-button
+  variant="primary"
+  style="
+    --swim-button-padding: 0.5em 1.5em;
+    --swim-button-outline-color: var(--orange-400);
+  "
+&gt;Pill outline&lt;/swim-button&gt;</code></pre>
+  </swim-section>
+</section>
+
 <!-- Button States Section -->
 <section class="section">
   <swim-section section-title="Button States">
@@ -73,7 +276,18 @@
       </div>
       <div class="demo-item">
         <div class="demo-label">In Progress</div>
-        <swim-button state="in-progress" timeout="0" variant="primary" aria-label="Loading state">Loading...</swim-button>
+        <swim-button
+          state="in-progress"
+          timeout="0"
+          variant="primary"
+          loading-text="Saving…"
+          aria-label="Saving in progress"
+          >Submit</swim-button
+        >
+      </div>
+      <div class="demo-item">
+        <div class="demo-label">In Progress (icon only)</div>
+        <swim-button state="in-progress" timeout="0" variant="primary" aria-label="Loading">Submit</swim-button>
       </div>
       <div class="demo-item">
         <div class="demo-label">Success</div>
@@ -90,7 +304,8 @@
     </div>
     <pre class="demo-pre"
     ><code>&lt;swim-button variant="primary"&gt;Active&lt;/swim-button&gt;
-&lt;swim-button state="in-progress" timeout="0" variant="primary"&gt;Loading...&lt;/swim-button&gt;
+&lt;swim-button state="in-progress" timeout="0" variant="primary" loading-text="Saving…"&gt;Submit&lt;/swim-button&gt;
+&lt;swim-button state="in-progress" timeout="0" variant="primary"&gt;Submit&lt;/swim-button&gt;
 &lt;swim-button state="success" timeout="0" variant="primary"&gt;Success&lt;/swim-button&gt;
 &lt;swim-button state="fail" timeout="0" variant="primary"&gt;Failed&lt;/swim-button&gt;
 &lt;swim-button disabled variant="primary"&gt;Disabled&lt;/swim-button&gt;</code></pre>
@@ -199,9 +414,29 @@ setInterval(() =&gt; {
             <tr><td><code>size</code></td><td><code>'small' | 'medium' | 'large'</code></td><td><code>'medium'</code></td><td>Button size</td></tr>
             <tr><td><code>disabled</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Disables the button</td></tr>
             <tr><td><code>state</code></td><td><code>'active' | 'in-progress' | 'success' | 'fail'</code></td><td><code>'active'</code></td><td>Visual state of the button</td></tr>
+            <tr><td><code>loading-text</code></td><td><code>string</code></td><td><code>''</code></td><td>When <code>state</code> is <code>in-progress</code>, shown next to the spinner (default slot stays hidden until active)</td></tr>
             <tr><td><code>type</code></td><td><code>'button' | 'submit' | 'reset'</code></td><td><code>'button'</code></td><td>HTML button type</td></tr>
             <tr><td><code>.timeout</code></td><td><code>number</code></td><td><code>undefined</code></td><td>When state is set by a promise: duration (ms) before returning to active (default 3000). Use <code>0</code> to disable auto-reset. Static state buttons use <code>timeout="0"</code> so they do not auto-reset.</td></tr>
             <tr><td><code>.promise</code></td><td><code>Promise</code></td><td><code>undefined</code></td><td>Bind a promise to auto-manage in-progress / success / fail states</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <h4 class="api-heading">CSS custom properties (host)</h4>
+      <p style="color: var(--grey-300); margin: 0 0 0.75rem">
+        Set on <code>&lt;swim-button&gt;</code> or an ancestor. Override built-in variant defaults (including hover).
+      </p>
+      <div class="api-table-wrap">
+        <table class="api-table">
+          <thead><tr><th>Property</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>--swim-button-padding</code></td><td>Inner padding</td></tr>
+            <tr><td><code>--swim-button-background</code></td><td>Background (solid, gradient, etc.)</td></tr>
+            <tr><td><code>--swim-button-hover-background</code></td><td>Background when hovered</td></tr>
+            <tr><td><code>--swim-button-border-width</code>, <code>--swim-button-border-style</code>, <code>--swim-button-border-color</code></td><td>Border</td></tr>
+            <tr><td><code>--swim-button-hover-border-color</code></td><td>Border color on hover</td></tr>
+            <tr><td><code>--swim-button-color</code>, <code>--swim-button-hover-color</code></td><td>Label / icon foreground</td></tr>
+            <tr><td><code>--swim-button-shadow</code></td><td>Box shadow</td></tr>
+            <tr><td><code>--swim-button-outline-color</code>, <code>--swim-button-hover-outline-color</code></td><td>Focus ring and hover outline tint</td></tr>
           </tbody>
         </table>
       </div>

--- a/projects/swimlane/swim-ui/demo/public/sections/buttons.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/buttons.html
@@ -1,9 +1,9 @@
 <hr class="section-divider" />
 <h1 id="buttons" class="page-title">Buttons</h1>
 <p class="subtitle">
-  Button component with variants (default, primary, warning, danger, link, bordered), sizes, icon-only usage, host
-  styling via <code>--swim-button-*</code> CSS variables, and states (active, in-progress, success, fail, disabled).
-  Supports promise-based loading state.
+  Button component with variants (default, primary, warning, danger, link, bordered), sizes, labels with
+  <code>&lt;swim-icon&gt;</code> (leading, trailing, stacked, icon-only), host styling via <code>--swim-button-*</code> CSS
+  variables, and states (active, in-progress, success, fail, disabled). Supports promise-based loading state.
 </p>
 <p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/button.js';</code></p>
 
@@ -58,6 +58,126 @@
     ><code>&lt;swim-button size="small" variant="primary"&gt;Small&lt;/swim-button&gt;
 &lt;swim-button size="medium" variant="primary"&gt;Medium&lt;/swim-button&gt;
 &lt;swim-button size="large" variant="primary"&gt;Large&lt;/swim-button&gt;</code></pre>
+  </swim-section>
+</section>
+
+<!-- Buttons with text + swim-icons (mirrors ngx-ui "Buttons with Icons") -->
+<section class="section">
+  <swim-section section-title="Buttons with swim-icons">
+    <p style="color: var(--grey-300); margin-bottom: 1rem">
+      Combine label text with <code>&lt;swim-icon font-icon="…"&gt;</code> in the default slot. A short
+      <code>inline-flex</code> wrapper with <code>gap</code> matches ngx-ui spacing (<code>has-text</code> /
+      <code>has-text-left</code> on <code>ngx-icon</code>). Stacked icons use a JSON array on
+      <code>font-icon</code> (same as the Icons demo).
+    </p>
+    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.75rem">
+      <swim-button variant="primary">
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <swim-icon font-icon="plus"></swim-icon>
+          <span>Add</span>
+        </span>
+      </swim-button>
+      <swim-button variant="primary">
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <span>Next</span>
+          <swim-icon font-icon="chevron-bold-right"></swim-icon>
+        </span>
+      </swim-button>
+      <swim-button variant="primary" aria-label="Expand">
+        <swim-icon font-icon="arrow-bold-down"></swim-icon>
+      </swim-button>
+    </div>
+    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.75rem">
+      <swim-button variant="bordered">
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <swim-icon font-icon="plus"></swim-icon>
+          <span>Add</span>
+        </span>
+      </swim-button>
+      <swim-button variant="bordered">
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <span>Next</span>
+          <swim-icon font-icon="chevron-bold-right"></swim-icon>
+        </span>
+      </swim-button>
+      <swim-button variant="bordered" aria-label="Expand">
+        <swim-icon font-icon="arrow-bold-down"></swim-icon>
+      </swim-button>
+    </div>
+    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.75rem">
+      <swim-button variant="link">
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <swim-icon font-icon="plus"></swim-icon>
+          <span>Link</span>
+        </span>
+      </swim-button>
+      <swim-button variant="link">
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <span>Link</span>
+          <swim-icon font-icon="chevron-bold-right"></swim-icon>
+        </span>
+      </swim-button>
+      <swim-button variant="link" aria-label="Expand">
+        <swim-icon font-icon="arrow-bold-down"></swim-icon>
+      </swim-button>
+    </div>
+    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1rem">
+      <swim-button variant="primary" disabled>
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <swim-icon font-icon="plus"></swim-icon>
+          <span>Add</span>
+        </span>
+      </swim-button>
+      <swim-button variant="bordered" disabled>
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <span>Next</span>
+          <swim-icon font-icon="chevron-bold-right"></swim-icon>
+        </span>
+      </swim-button>
+      <swim-button variant="link" disabled aria-label="Expand">
+        <swim-icon font-icon="arrow-bold-down"></swim-icon>
+      </swim-button>
+    </div>
+    <p style="color: var(--grey-400); margin-bottom: 0.5rem; font-size: 0.875rem">
+      <strong>Stacked font icons</strong> — badge-style overlay (see Icons page for more stacks):
+    </p>
+    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1rem">
+      <swim-button variant="primary">
+        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+          <swim-icon font-icon='["field-users", "circle-filled :text-red :icon-fx-badge"]'></swim-icon>
+          <span>Assignees</span>
+        </span>
+      </swim-button>
+      <swim-button variant="bordered" aria-label="Notifications">
+        <swim-icon font-icon='["bell", "circle-filled :text-red :icon-fx-badge"]'></swim-icon>
+      </swim-button>
+    </div>
+    <pre class="demo-pre"
+    ><code>&lt;script type="module"&gt;
+  import '@swimlane/swim-ui/button';
+  import '@swimlane/swim-ui/icon';
+&lt;/script&gt;
+
+&lt;!-- Leading icon + text --&gt;
+&lt;swim-button variant="primary"&gt;
+  &lt;span style="display: inline-flex; align-items: center; gap: 0.35em"&gt;
+    &lt;swim-icon font-icon="plus"&gt;&lt;/swim-icon&gt;
+    &lt;span&gt;Add&lt;/span&gt;
+  &lt;/span&gt;
+&lt;/swim-button&gt;
+
+&lt;!-- Text + trailing icon --&gt;
+&lt;swim-button variant="primary"&gt;
+  &lt;span style="display: inline-flex; align-items: center; gap: 0.35em"&gt;
+    &lt;span&gt;Next&lt;/span&gt;
+    &lt;swim-icon font-icon="chevron-bold-right"&gt;&lt;/swim-icon&gt;
+  &lt;/span&gt;
+&lt;/swim-button&gt;
+
+&lt;!-- Stacked swim-icons (JSON array on font-icon) --&gt;
+&lt;swim-button variant="bordered" aria-label="Notifications"&gt;
+  &lt;swim-icon font-icon='["bell", "circle-filled :text-red :icon-fx-badge"]'&gt;&lt;/swim-icon&gt;
+&lt;/swim-button&gt;</code></pre>
   </swim-section>
 </section>
 
@@ -158,20 +278,6 @@
         </swim-button>
       </div>
       <div class="demo-item">
-        <div class="demo-label">Warning variant, custom surface</div>
-        <swim-button
-          variant="warning"
-          style="
-            --swim-button-background: var(--grey-700);
-            --swim-button-hover-background: var(--grey-650);
-            --swim-button-color: var(--white);
-            --swim-button-hover-color: var(--white);
-          "
-        >
-          Neutral on warning
-        </swim-button>
-      </div>
-      <div class="demo-item">
         <div class="demo-label">Dense icon-only (padding, border, surface)</div>
         <swim-button
           variant="bordered"
@@ -222,17 +328,6 @@
     --swim-button-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
   "
 &gt;Gradient&lt;/swim-button&gt;</code></pre>
-    <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Warning variant, custom surface</p>
-    <pre class="demo-pre"
-    ><code>&lt;swim-button
-  variant="warning"
-  style="
-    --swim-button-background: var(--grey-700);
-    --swim-button-hover-background: var(--grey-650);
-    --swim-button-color: var(--white);
-    --swim-button-hover-color: var(--white);
-  "
-&gt;Neutral on warning&lt;/swim-button&gt;</code></pre>
     <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Dense icon-only (padding, border, surface)</p>
     <pre class="demo-pre"
     ><code>&lt;swim-button

--- a/projects/swimlane/swim-ui/demo/public/sections/date-display.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/date-display.html
@@ -1,0 +1,103 @@
+<hr class="section-divider" />
+<h1 id="date-display" class="page-title">Date/Time Display</h1>
+<p class="subtitle">Read-only date and time with formats, relative mode, time zones, and optional multi-zone tooltip (ngx-time parity).</p>
+
+<section class="section">
+  <swim-section section-title="Basic">
+    <h4 class="demo-label">Default Date-Time</h4>
+    <swim-date-display id="dateDisplayBasic" datetime="2011-03-11T05:46:24Z"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z"&gt;&lt;/swim-date-display&gt;</code></pre>
+  </swim-section>
+</section>
+
+<section class="section">
+  <swim-section section-title="Formats">
+    <h4 class="demo-label">Format</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" format="dateTime"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" format="dateTime"&gt;&lt;/swim-date-display&gt;</code></pre>
+
+    <h4 class="demo-label demo-label--after">Custom format</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" format="YYYY MMM"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" format="YYYY MMM"&gt;&lt;/swim-date-display&gt;</code></pre>
+  </swim-section>
+</section>
+
+<section class="section">
+  <swim-section section-title="Modes">
+    <h4 class="demo-label">Human Readable Date-Time</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" mode="human"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" mode="human"&gt;&lt;/swim-date-display&gt;</code></pre>
+
+    <h4 class="demo-label demo-label--after">Local</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" mode="local"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" mode="local"&gt;&lt;/swim-date-display&gt;</code></pre>
+  </swim-section>
+</section>
+
+<section class="section">
+  <swim-section section-title="Types">
+    <h4 class="demo-label">Time</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" type="time"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" type="time"&gt;&lt;/swim-date-display&gt;</code></pre>
+
+    <h4 class="demo-label demo-label--after">Date</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" type="date"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" type="date"&gt;&lt;/swim-date-display&gt;</code></pre>
+  </swim-section>
+</section>
+
+<section class="section" id="dateDisplayDemoRoot">
+  <swim-section section-title="Time Zones">
+    <p class="demo-label">Local string (demo): <output id="dateDisplayLocalString"></output></p>
+
+    <h4 class="demo-label demo-label--after">Input and display TZ can be defined</h4>
+    <swim-date-display datetime="March 11, 2011 2:46:24 PM" timezone="Asia/Tokyo"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="March 11, 2011 2:46:24 PM" timezone="Asia/Tokyo"&gt;&lt;/swim-date-display&gt;</code></pre>
+
+    <h4 class="demo-label demo-label--after">Default input timezone can be specified separately from display</h4>
+    <swim-date-display datetime="March 11, 2011 2:46:24 PM" default-input-time-zone="Asia/Tokyo"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="March 11, 2011 2:46:24 PM" default-input-time-zone="Asia/Tokyo"&gt;&lt;/swim-date-display&gt;</code></pre>
+
+    <h4 class="demo-label demo-label--after">Explicit timezone in input value overrides default input timezone</h4>
+    <swim-date-display datetime="03/10/2011 9:46:24 PM -08:00" default-input-time-zone="Asia/Tokyo"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="03/10/2011 9:46:24 PM -08:00" default-input-time-zone="Asia/Tokyo"&gt;&lt;/swim-date-display&gt;</code></pre>
+  </swim-section>
+
+  <swim-section section-title="Popup">
+    <h4 class="demo-label">Native Tooltip</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" tooltip-disabled="true"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" tooltip-disabled="true"&gt;&lt;/swim-date-display&gt;</code></pre>
+
+    <h4 class="demo-label demo-label--after">Defined Timezones</h4>
+    <swim-date-display id="dateDisplayTimezonesCustom" datetime="2011-03-11T05:46:24Z"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;!-- set .timezones in JS or bind in Lit --&gt;
+&lt;swim-date-display id="ex" datetime="2011-03-11T05:46:24Z"&gt;&lt;/swim-date-display&gt;
+&lt;script&gt;
+  ex.timezones = { Local: '', GMT: 'Etc/UTC', Tokyo: 'Asia/Tokyo' };
+&lt;/script&gt;</code></pre>
+
+    <h4 class="demo-label demo-label--after">Popup Format</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" tooltip-format="localeTime"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" tooltip-format="localeTime"&gt;&lt;/swim-date-display&gt;</code></pre>
+
+    <h4 class="demo-label demo-label--after">Custom Popup Format</h4>
+    <swim-date-display datetime="2011-03-11T05:46:24Z" tooltip-format="YYYY MMM"></swim-date-display>
+    <pre class="demo-pre"><code>&lt;swim-date-display datetime="2011-03-11T05:46:24Z" tooltip-format="YYYY MMM"&gt;&lt;/swim-date-display&gt;</code></pre>
+
+    <p class="demo-label demo-label--after">Last copy (from row button or primary click): <output id="dateDisplayCopyLog">—</output></p>
+  </swim-section>
+
+  <swim-section section-title="Invalid">
+    <swim-date-display datetime="1/1/1/1970"></swim-date-display>
+  </swim-section>
+</section>
+
+<section class="section">
+  <swim-section section-title="Usage">
+    <pre class="demo-pre"><code>import '@swimlane/swim-ui/date-display.js';
+
+&lt;swim-date-display datetime="2011-03-11T05:46:24Z"&gt;&lt;/swim-date-display&gt;
+&lt;swim-date-display datetime="2011-03-11T05:46:24Z" mode="human"&gt;&lt;/swim-date-display&gt;
+&lt;swim-date-display datetime="2011-03-11T05:46:24Z" mode="local"&gt;&lt;/swim-date-display&gt;</code></pre>
+  </swim-section>
+</section>

--- a/projects/swimlane/swim-ui/demo/public/sections/dialog.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/dialog.html
@@ -101,25 +101,61 @@
 
 <section class="section">
   <swim-section section-title="Medium Format">
+    <p class="section-desc" style="margin-top: 0; max-width: 42rem; margin-left: auto; margin-right: auto; text-align: center">
+      This example uses the same <strong>Remote search (GitHub users)</strong> pattern as the Select demo: type at least
+      <strong>2 characters</strong> to query the
+      <a href="https://docs.github.com/en/rest/search/search#search-users" style="color: var(--blue-400)"
+        >Search users</a
+      >
+      API inside a medium-format dialog body.
+    </p>
     <swim-dialog id="dialogMediumFormatDemo" format="medium" close-button="false">
       <swim-large-format-dialog-content
         id="dialogMediumFormatContent"
         format="medium"
-        dialog-title="Medium Format Dialog"
-        dialog-subtitle="Optional subtitle"
+        dialog-title="Medium format dialog"
+        dialog-subtitle="Remote search (GitHub users)"
       >
-        <p>Medium format uses a smaller header and max height 75vh. Body is scrollable when content overflows.</p>
+        <div style="display: flex; flex-direction: column; align-items: center; width: 100%; box-sizing: border-box">
+          <p style="color: var(--grey-300); margin: 0 0 1rem 0; text-align: center; max-width: 36rem">
+            Type at least <strong>2 characters</strong> to search public GitHub users.<br />
+            Results load after the default <strong>500ms</strong> debounce on <code>filter-change</code>.
+          </p>
+          <div style="display: flex; flex-direction: column; gap: 0.75rem; width: 100%; max-width: 500px; margin: 0 auto">
+            <swim-select
+              id="dialogMediumGithubUserSelect"
+              label="GitHub user"
+              placeholder="Pick a user…"
+              filter-placeholder="Search by login…"
+              empty-placeholder="Open the list and type to search GitHub users."
+              filter-empty-placeholder="No users match that search."
+              filter-searching-placeholder="Searching GitHub…"
+              async-filter
+              filter-min-length="2"
+              dropdown-align="center"
+              hint="Uses https://api.github.com/search/users (rate limits apply without auth)."
+            ></swim-select>
+            <p style="font-size: var(--font-size-s); color: var(--grey-350); margin: 0; text-align: center">
+              Selected: <code id="dialogMediumGithubUserSelectValue" style="color: var(--grey-200)">—</code>
+            </p>
+          </div>
+        </div>
         <swim-large-format-dialog-footer slot="footer">
           <swim-button variant="bordered">Cancel</swim-button>
           <swim-button variant="primary">Confirm</swim-button>
         </swim-large-format-dialog-footer>
       </swim-large-format-dialog-content>
     </swim-dialog>
-    <swim-button type="button" id="dialogMediumFormatOpen">Open Medium Format Dialog</swim-button>
+    <div style="text-align: center; margin-top: 0.5rem">
+      <swim-button type="button" id="dialogMediumFormatOpen">Open Medium Format Dialog</swim-button>
+    </div>
     <br /><br />
     <pre class="demo-pre"><code>&lt;swim-dialog format="medium" close-button="false"&gt;
-  &lt;swim-large-format-dialog-content format="medium" dialog-title="Title" dialog-subtitle="Subtitle"&gt;
-    &lt;p&gt;Body...&lt;/p&gt;
+  &lt;swim-large-format-dialog-content format="medium" dialog-title="..." dialog-subtitle="..."&gt;
+    &lt;div style="display:flex; flex-direction:column; align-items:center; width:100%"&gt;
+      &lt;!-- intro + max-width column for swim-select --&gt;
+      &lt;swim-select id="dialogMediumGithubUserSelect" label="GitHub user" async-filter filter-min-length="2" /&gt;
+    &lt;/div&gt;
     &lt;swim-large-format-dialog-footer slot="footer"&gt;...&lt;/swim-large-format-dialog-footer&gt;
   &lt;/swim-large-format-dialog-content&gt;
 &lt;/swim-dialog&gt;</code></pre>

--- a/projects/swimlane/swim-ui/demo/public/sections/dialog.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/dialog.html
@@ -18,6 +18,27 @@
 </section>
 
 <section class="section">
+  <swim-section section-title="Backdrop and Escape">
+    <p class="section-desc" style="margin-top: 0; max-width: 42rem; margin-left: auto; margin-right: auto; text-align: center">
+      Match ngx <code>closeOnBlur</code> / <code>closeOnEscape</code> with <code>close-on-blur</code> and
+      <code>close-on-escape</code> on <code>swim-dialog</code>. This dialog keeps the dimmed backdrop but does
+      <strong>not</strong> close when you click it; use Escape, the close button, or programmatic <code>hide()</code>.
+    </p>
+    <swim-dialog id="dialogDismissBackdropDemo" dialog-title="No backdrop dismiss" close-on-blur="false">
+      <p>Try clicking outside this panel on the dimmed area — the dialog stays open.</p>
+      <p>Press <kbd>Escape</kbd> or the X control to close.</p>
+    </swim-dialog>
+    <swim-button type="button" id="dialogDismissBackdropOpen">Open dialog (close-on-blur false)</swim-button>
+    <br /><br />
+    <pre class="demo-pre"><code>&lt;swim-dialog dialog-title="..." close-on-blur="false"&gt;
+  ...
+&lt;/swim-dialog&gt;
+
+&lt;!-- Also: close-on-escape="false" to ignore Escape --&gt;</code></pre>
+  </swim-section>
+</section>
+
+<section class="section">
   <swim-section section-title="Component">
     <swim-dialog id="dialogComponentDemo" dialog-title="Attack Alert" show-backdrop="false">
       <p>Attack Found!</p>
@@ -71,7 +92,7 @@
 
 <section class="section">
   <swim-section section-title="Large Format">
-    <swim-dialog id="dialogLargeFormatDemo" format="large" close-button="false">
+    <swim-dialog id="dialogLargeFormatDemo" format="large">
       <swim-large-format-dialog-content
         id="dialogLargeFormatContent"
         format="large"
@@ -88,7 +109,7 @@
     </swim-dialog>
     <swim-button type="button" id="dialogLargeFormatOpen">Open Large Format Dialog</swim-button>
     <br /><br />
-    <pre class="demo-pre"><code>&lt;swim-dialog format="large" close-button="false"&gt;
+    <pre class="demo-pre"><code>&lt;swim-dialog format="large"&gt;
   &lt;swim-large-format-dialog-content format="large" dialog-title="Title" dialog-subtitle="Subtitle"&gt;
     &lt;p&gt;Body...&lt;/p&gt;
     &lt;swim-large-format-dialog-footer slot="footer"&gt;
@@ -96,6 +117,120 @@
     &lt;/swim-large-format-dialog-footer&gt;
   &lt;/swim-large-format-dialog-content&gt;
 &lt;/swim-dialog&gt;</code></pre>
+  </swim-section>
+</section>
+
+<section class="section">
+  <swim-section section-title="Theming (CSS variables)">
+    <p class="section-desc" style="margin-top: 0; max-width: 46rem; margin-left: auto; margin-right: auto; text-align: center">
+      Set <code>--swim-format-*</code> on <code>swim-dialog</code> or an ancestor; they inherit into
+      <code>swim-large-format-dialog-content</code> (padding, radius, dividers, footer gap, background). Regular dialogs
+      respect <code>--swim-dialog-bg</code>, <code>--swim-dialog-header-color</code>, and
+      <code>--swim-dialog-body-color</code>. Layout tokens such as <code>--spacing-40</code> from ngx-ui
+      <code>layouts/_vars.scss</code> work as values when your app defines them on <code>:root</code>.
+    </p>
+    <swim-dialog
+      id="dialogThemeVarsLargeDemo"
+      format="large"
+      style="
+        --swim-format-dialog-bg: var(--grey-900);
+        --swim-format-body-padding: var(--spacing-40, 2.5rem);
+        --swim-format-header-padding-x: var(--spacing-40, 2.5rem);
+        --swim-format-header-padding-end: var(--spacing-48, 3rem);
+        --swim-format-border-radius: var(--radius-24, 24px);
+        --swim-format-divider: 2px solid var(--blue-500);
+        --swim-format-footer-gap: var(--spacing-16, 1rem);
+      "
+    >
+      <swim-large-format-dialog-content
+        format="large"
+        dialog-title="Themed large dialog"
+        dialog-subtitle="Variables set on swim-dialog"
+      >
+        <p style="margin-top: 0">
+          This panel uses wider body padding, a larger corner radius, blue dividers, and a darker shell background via
+          inherited custom properties.
+        </p>
+        <swim-large-format-dialog-footer slot="footer" align="end">
+          <swim-button variant="bordered">Dismiss</swim-button>
+          <swim-button variant="primary">OK</swim-button>
+        </swim-large-format-dialog-footer>
+      </swim-large-format-dialog-content>
+    </swim-dialog>
+    <div class="demo-row" style="flex-wrap: wrap; justify-content: center; gap: 0.75rem">
+      <swim-button type="button" id="dialogThemeVarsLargeOpen">Open themed large dialog</swim-button>
+    </div>
+    <p class="section-desc" style="margin-top: 1.5rem; max-width: 46rem; margin-left: auto; margin-right: auto; text-align: center">
+      Regular format: panel colors from <code>--swim-dialog-*</code> on the host.
+    </p>
+    <swim-dialog
+      id="dialogThemeVarsRegularDemo"
+      dialog-title="Themed regular dialog"
+      style="
+        --swim-dialog-bg: var(--grey-725);
+        --swim-dialog-header-color: var(--lightblue-300);
+        --swim-dialog-body-color: var(--grey-100);
+      "
+    >
+      <p style="margin: 0">Header and body colors follow the variables above.</p>
+    </swim-dialog>
+    <div class="demo-row" style="flex-wrap: wrap; justify-content: center; gap: 0.75rem; margin-top: 0.5rem">
+      <swim-button type="button" id="dialogThemeVarsRegularOpen">Open themed regular dialog</swim-button>
+    </div>
+    <br /><br />
+    <pre class="demo-pre"><code>&lt;!-- Large / medium: set --swim-format-* on swim-dialog --&gt;
+&lt;swim-dialog format="large" style="
+  --swim-format-dialog-bg: var(--grey-900);
+  --swim-format-body-padding: var(--spacing-40, 2.5rem);
+  --swim-format-border-radius: var(--radius-24, 24px);
+  --swim-format-divider: 2px solid var(--blue-500);
+  --swim-format-footer-gap: var(--spacing-16, 1rem);
+"&gt;
+  &lt;swim-large-format-dialog-content format="large" dialog-title="..."&gt;...&lt;/swim-large-format-dialog-content&gt;
+&lt;/swim-dialog&gt;
+
+&lt;!-- Regular: --swim-dialog-bg, --swim-dialog-header-color, --swim-dialog-body-color --&gt;
+&lt;swim-dialog dialog-title="..." style="
+  --swim-dialog-bg: var(--grey-725);
+  --swim-dialog-header-color: var(--lightblue-300);
+  --swim-dialog-body-color: var(--grey-100);
+"&gt;...&lt;/swim-dialog&gt;</code></pre>
+  </swim-section>
+</section>
+
+<section class="section">
+  <swim-section section-title="Large format footer alignment">
+    <p class="section-desc" style="margin-top: 0; max-width: 42rem; margin-left: auto; margin-right: auto; text-align: center">
+      <code>swim-large-format-dialog-footer</code> uses the <code>align</code> attribute for horizontal layout
+      (<code>start</code> | <code>center</code> | <code>end</code> | <code>space-between</code> | <code>space-around</code> |
+      <code>space-evenly</code>). Open the same dialog with different values to compare the footer row.
+    </p>
+    <swim-dialog id="dialogFooterAlignDemo" format="medium">
+      <swim-large-format-dialog-content
+        format="medium"
+        dialog-title="Footer alignment"
+        dialog-subtitle="align maps to flex justify-content"
+      >
+        <p style="color: var(--grey-300); margin: 0">
+          Current <code>align</code> is set before the dialog opens. Default is <code>center</code>.
+        </p>
+        <swim-large-format-dialog-footer id="dialogFooterAlignFooter" slot="footer" format="medium" align="center">
+          <swim-button variant="bordered">Cancel</swim-button>
+          <swim-button variant="primary">Save</swim-button>
+        </swim-large-format-dialog-footer>
+      </swim-large-format-dialog-content>
+    </swim-dialog>
+    <div class="demo-row" style="flex-wrap: wrap; justify-content: center">
+      <swim-button type="button" id="dialogFooterAlignOpenStart">Open (align start)</swim-button>
+      <swim-button type="button" id="dialogFooterAlignOpenCenter">Open (align center)</swim-button>
+      <swim-button type="button" id="dialogFooterAlignOpenEnd">Open (align end)</swim-button>
+      <swim-button type="button" id="dialogFooterAlignOpenBetween">Open (align space-between)</swim-button>
+    </div>
+    <br /><br />
+    <pre class="demo-pre"><code>&lt;swim-large-format-dialog-footer slot="footer" format="medium" align="end"&gt;
+  &lt;swim-button variant="bordered"&gt;Cancel&lt;/swim-button&gt;
+  &lt;swim-button variant="primary"&gt;Save&lt;/swim-button&gt;
+&lt;/swim-large-format-dialog-footer&gt;</code></pre>
   </swim-section>
 </section>
 
@@ -109,7 +244,7 @@
       >
       API inside a medium-format dialog body.
     </p>
-    <swim-dialog id="dialogMediumFormatDemo" format="medium" close-button="false">
+    <swim-dialog id="dialogMediumFormatDemo" format="medium">
       <swim-large-format-dialog-content
         id="dialogMediumFormatContent"
         format="medium"
@@ -150,7 +285,7 @@
       <swim-button type="button" id="dialogMediumFormatOpen">Open Medium Format Dialog</swim-button>
     </div>
     <br /><br />
-    <pre class="demo-pre"><code>&lt;swim-dialog format="medium" close-button="false"&gt;
+    <pre class="demo-pre"><code>&lt;swim-dialog format="medium"&gt;
   &lt;swim-large-format-dialog-content format="medium" dialog-title="..." dialog-subtitle="..."&gt;
     &lt;div style="display:flex; flex-direction:column; align-items:center; width:100%"&gt;
       &lt;!-- intro + max-width column for swim-select --&gt;
@@ -170,12 +305,12 @@
       <swim-button type="button" id="dialogMediumFooterOpen">Open Medium Dialog w/ Footer</swim-button>
       <swim-button type="button" id="dialogMediumFooterContentOpen">Open Medium Dialog w/ Footer and Content</swim-button>
     </div>
-    <swim-dialog id="dialogMediumContentDemo" format="medium" close-button="false">
+    <swim-dialog id="dialogMediumContentDemo" format="medium">
       <swim-large-format-dialog-content format="medium" dialog-title="Medium Dialog" dialog-subtitle="Content only">
         <p>This medium dialog has body content only (no footer).</p>
       </swim-large-format-dialog-content>
     </swim-dialog>
-    <swim-dialog id="dialogMediumFooterDemo" format="medium" close-button="false">
+    <swim-dialog id="dialogMediumFooterDemo" format="medium">
       <swim-large-format-dialog-content format="medium" dialog-title="Medium Dialog" dialog-subtitle="Footer only">
         <swim-large-format-dialog-footer slot="footer">
           <swim-button variant="bordered">Cancel</swim-button>
@@ -183,7 +318,7 @@
         </swim-large-format-dialog-footer>
       </swim-large-format-dialog-content>
     </swim-dialog>
-    <swim-dialog id="dialogMediumFooterContentDemo" format="medium" close-button="false">
+    <swim-dialog id="dialogMediumFooterContentDemo" format="medium">
       <swim-large-format-dialog-content format="medium" dialog-title="Title">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         <swim-large-format-dialog-footer slot="footer">
@@ -242,7 +377,9 @@
 // Show: document.getElementById('myDialog').show();
 // Hide: document.getElementById('myDialog').hide();
 // Listen: myDialog.addEventListener('close', () => { ... });
-// Optional: myDialog.beforeClose = () => confirm('Discard?');</code></pre>
+// Optional: myDialog.beforeClose = () => confirm('Discard?');
+// Optional: myDialog.closeOnBlur = false; // or attribute close-on-blur="false"
+// Optional: myDialog.closeOnEscape = false;</code></pre>
   </swim-section>
 </section>
 
@@ -258,7 +395,9 @@
           <tbody>
             <tr><td><code>dialog-title</code></td><td><code>string</code></td><td><code>''</code></td><td>Title text in the dialog header</td></tr>
             <tr><td><code>format</code></td><td><code>'regular' | 'medium' | 'large'</code></td><td><code>'regular'</code></td><td>Dialog size format</td></tr>
-            <tr><td><code>close-button</code></td><td><code>boolean</code></td><td><code>true</code></td><td>Shows a close (X) button</td></tr>
+            <tr><td><code>close-button</code></td><td><code>boolean</code></td><td><code>true</code></td><td>When false, hides the regular-format X and the large/medium header close/cancel (dismiss via backdrop, Escape, or <code>hide()</code> unless disabled)</td></tr>
+            <tr><td><code>close-on-blur</code></td><td><code>boolean</code></td><td><code>true</code></td><td>When false, backdrop click does not close (ngx <code>closeOnBlur</code>)</td></tr>
+            <tr><td><code>close-on-escape</code></td><td><code>boolean</code></td><td><code>true</code></td><td>When false, Escape does not close (ngx <code>closeOnEscape</code>)</td></tr>
             <tr><td><code>visible</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Controls visibility (or call show()/hide())</td></tr>
             <tr><td><code>z-index</code></td><td><code>number</code></td><td><code>991</code></td><td>CSS z-index stacking order</td></tr>
           </tbody>

--- a/projects/swimlane/swim-ui/demo/public/sections/dialog.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/dialog.html
@@ -376,10 +376,56 @@
 
 // Show: document.getElementById('myDialog').show();
 // Hide: document.getElementById('myDialog').hide();
+// Listen: myDialog.addEventListener('open', () => { ... });
 // Listen: myDialog.addEventListener('close', () => { ... });
 // Optional: myDialog.beforeClose = () => confirm('Discard?');
 // Optional: myDialog.closeOnBlur = false; // or attribute close-on-blur="false"
 // Optional: myDialog.closeOnEscape = false;</code></pre>
+  </swim-section>
+</section>
+
+<section class="section">
+  <swim-section section-title="Events (open, close, close-or-cancel)">
+    <p class="section-desc" style="margin-top: 0; max-width: 46rem; margin-left: auto; margin-right: auto; text-align: center">
+      <code>swim-dialog</code> dispatches <code>open</code> when <code>visible</code> becomes true and <code>close</code> when it becomes false. Host events use
+      <code>bubbles: false</code> and <code>composed: false</code>, so attach listeners on the <code>swim-dialog</code> element itself, not on a parent for delegation.
+      For large/medium layout, <code>swim-large-format-dialog-content</code> dispatches <code>close-or-cancel</code> (detail: dirty boolean) from the header control — listen on
+      that element, then set the parent dialog’s <code>visible</code> to <code>false</code> if you want the overlay to dismiss.
+    </p>
+    <div class="demo-row" style="flex-wrap: wrap; justify-content: center; gap: 0.75rem">
+      <swim-button type="button" id="dialogEventsOpen">Open dialog</swim-button>
+      <swim-button type="button" variant="bordered" id="dialogEventsClearLog">Clear log</swim-button>
+    </div>
+    <pre
+      id="dialogEventsLog"
+      class="demo-pre"
+      style="margin-top: 1rem; max-height: 14rem; overflow: auto; text-align: left; white-space: pre-wrap; word-break: break-word"
+    >(no events yet — open the dialog and try closing from the header, backdrop, Escape, or the footer button)</pre>
+    <swim-dialog id="dialogEventsDemo" format="medium">
+      <swim-large-format-dialog-content
+        id="dialogEventsLargeContent"
+        format="medium"
+        dialog-title="Dialog events"
+        dialog-subtitle="Try different dismiss paths"
+      >
+        <p style="margin-top: 0">
+          Use the header close, click outside the panel, press <kbd>Escape</kbd>, or the footer button. Watch the log above.
+        </p>
+        <swim-large-format-dialog-footer slot="footer" format="medium">
+          <swim-button type="button" variant="bordered" id="dialogEventsFooterClose">Close from footer</swim-button>
+        </swim-large-format-dialog-footer>
+      </swim-large-format-dialog-content>
+    </swim-dialog>
+    <br /><br />
+    <pre class="demo-pre"><code>const dialog = document.querySelector('swim-dialog#myDialog');
+dialog.addEventListener('open', () => { /* shown */ });
+dialog.addEventListener('close', () => { dialog.visible = false; });
+
+const panel = dialog.querySelector('swim-large-format-dialog-content');
+panel?.addEventListener('close-or-cancel', e => {
+  console.log('dirty', e.detail);
+  dialog.visible = false;
+});</code></pre>
   </swim-section>
 </section>
 
@@ -408,8 +454,8 @@
         <table class="api-table">
           <thead><tr><th>Event</th><th>Detail</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>open</code></td><td>—</td><td>Fired when the dialog is shown</td></tr>
-            <tr><td><code>close</code></td><td>—</td><td>Fired when the dialog is closed</td></tr>
+            <tr><td><code>open</code></td><td>—</td><td>Fired when the dialog is shown; host-only (does not bubble)</td></tr>
+            <tr><td><code>close</code></td><td>—</td><td>Fired when the dialog is closed; host-only (does not bubble)</td></tr>
           </tbody>
         </table>
       </div>

--- a/projects/swimlane/swim-ui/demo/public/sections/event-bubbling-matrix.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/event-bubbling-matrix.html
@@ -1,0 +1,33 @@
+<section class="section" id="event-bubbling-matrix">
+  <h1 class="page-title">Event propagation matrix</h1>
+  <p class="section-desc">
+    Use this page to see where <code>change</code> / <code>checked-change</code> from <code>swim-checkbox</code> are observed.
+    swim-ui dispatches these with <code>bubbles: false</code> and <code>composed: false</code>, so they stay on the host:
+    attach listeners on the <code>swim-checkbox</code> (or a direct listener target), not on <code>document</code>, and not
+    from outside an enclosing shadow root unless you listen on the host inside that root.
+  </p>
+
+  <div id="eventBubblingMatrixRoot">
+    <h2 class="section-title">Case A – light DOM</h2>
+    <p class="section-desc">
+      Wrapper <code>.matrix-wrap-light</code> → <code>swim-checkbox</code>. Listeners: checkbox, wrapper (bubble), <code>document</code> (bubble).
+    </p>
+    <div class="matrix-wrap-light demo-card-container" style="margin-bottom: 2rem">
+      <swim-checkbox id="matrixCbLight" label="Toggle (light DOM)"></swim-checkbox>
+    </div>
+
+    <h2 class="section-title">Case B – swim-checkbox inside another shadow root</h2>
+    <p class="section-desc">
+      The checkbox lives in an element's shadow root. With non-bubbling events, a listener on <code>document</code> does
+      <strong>not</strong> receive <code>change</code> from inside the shadow subtree; listen on the checkbox node or the shadow host.
+    </p>
+    <div id="matrixShadowMount" class="demo-card-container" style="margin-bottom: 1rem"></div>
+
+    <div class="demo-row">
+      <swim-button id="matrixClearLog" variant="bordered">Clear log</swim-button>
+    </div>
+
+    <h3 class="style-header" style="margin-top: 1.5rem">Log</h3>
+    <pre id="eventBubblingMatrixLog" class="demo-pre" style="min-height: 12rem; white-space: pre-wrap"></pre>
+  </div>
+</section>

--- a/projects/swimlane/swim-ui/demo/public/sections/select.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.html
@@ -14,12 +14,25 @@
     <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
       <swim-select id="requiredSelect" label="Attack Type" required placeholder="Please select..."></swim-select>
     </div>
+    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Disabled</h4>
+    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+      <swim-select
+        id="singleSelectDisabled"
+        label="Attack Type"
+        disabled
+        placeholder="Select..."
+        value="breach"
+      ></swim-select>
+    </div>
     <pre class="demo-pre"
     ><code>&lt;!-- Basic --&gt;
 &lt;swim-select label="Attack Type" placeholder="Select..."&gt;&lt;/swim-select&gt;
 
 &lt;!-- Required --&gt;
 &lt;swim-select label="Attack Type" required placeholder="Please select..."&gt;&lt;/swim-select&gt;
+
+&lt;!-- Disabled (with pre-selected value) --&gt;
+&lt;swim-select label="Attack Type" disabled placeholder="Select..." value="breach"&gt;&lt;/swim-select&gt;
 
 &lt;script&gt;
   const options = [

--- a/projects/swimlane/swim-ui/demo/public/sections/select.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.html
@@ -68,6 +68,59 @@
   </swim-section>
 </section>
 
+<!-- Grouped options: group / category -->
+<section class="section">
+  <swim-section section-title="Grouped options">
+    <p style="color: var(--grey-300); margin-bottom: 1rem">
+      Enable section headers with the <code>grouped</code> attribute. Headers use each option’s <code>group</code> or
+      <code>category</code> (<code>.options</code> objects or <code>group</code> / <code>category</code> on
+      <code>&lt;swim-option&gt;</code>). When <code>grouped</code> is on and the list is filterable, the group name
+      participates in the filter. Without <code>grouped</code>, <code>group</code> / <code>category</code> are ignored
+      for the dropdown layout.
+    </p>
+    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+      <swim-select
+        id="groupedSelectProgrammatic"
+        grouped
+        label="Food by aisle"
+        placeholder="Pick an item…"
+        hint="Options set via JavaScript with a group on each row"
+      ></swim-select>
+      <swim-select grouped label="Drinks (declarative)" placeholder="Select…" filterable="false">
+        <swim-option group="Cold" name="Iced tea" value="iced-tea"></swim-option>
+        <swim-option group="Cold" name="Soda" value="soda"></swim-option>
+        <swim-option group="Hot" name="Coffee" value="coffee"></swim-option>
+        <swim-option group="Hot" name="Tea" value="hot-tea"></swim-option>
+      </swim-select>
+      <swim-select
+        id="groupedSelectMulti"
+        grouped
+        label="Multi-select with groups"
+        placeholder="Choose tools…"
+        multiple
+        hint="Same grouping rules as single select"
+      ></swim-select>
+    </div>
+    <pre class="demo-pre"
+    ><code>&lt;!-- Programmatic: `grouped` + group or category on each option --&gt;
+&lt;swim-select id="groupedSelectProgrammatic" grouped label="Food by aisle"&gt;&lt;/swim-select&gt;
+&lt;script&gt;
+  document.getElementById('groupedSelectProgrammatic').options = [
+    { name: 'Apples', value: 'apples', group: 'Produce' },
+    { name: 'Carrots', value: 'carrots', group: 'Produce' },
+    { name: 'Milk', value: 'milk', group: 'Dairy' },
+    { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
+  ];
+&lt;/script&gt;
+
+&lt;!-- Declarative: grouped + group on swim-option --&gt;
+&lt;swim-select grouped label="Drinks" filterable="false"&gt;
+  &lt;swim-option group="Cold" name="Soda" value="soda"&gt;&lt;/swim-option&gt;
+  &lt;swim-option group="Hot" name="Coffee" value="coffee"&gt;&lt;/swim-option&gt;
+&lt;/swim-select&gt;</code></pre>
+  </swim-section>
+</section>
+
 <!-- Select Appearances Section -->
 <section class="section">
   <swim-section section-title="Select Appearances">

--- a/projects/swimlane/swim-ui/demo/public/sections/select.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.html
@@ -71,53 +71,106 @@
 <!-- Grouped options: group / category -->
 <section class="section">
   <swim-section section-title="Grouped options">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
-      Enable section headers with the <code>grouped</code> attribute. Headers use each option’s <code>group</code> or
-      <code>category</code> (<code>.options</code> objects or <code>group</code> / <code>category</code> on
-      <code>&lt;swim-option&gt;</code>). When <code>grouped</code> is on and the list is filterable, the group name
-      participates in the filter. Without <code>grouped</code>, <code>group</code> / <code>category</code> are ignored
-      for the dropdown layout.
+    <p style="color: var(--grey-300); margin-bottom: 1.25rem">
+      Set <code>grouped</code> on <code>&lt;swim-select&gt;</code> to show section headers from each option’s
+      <code>group</code> or <code>category</code>. Omit <code>grouped</code> and the same data renders as a flat list
+      (metadata is still on each option). With <code>grouped</code> and filtering on, typing a section name (e.g.
+      “Pantry”) matches options in that section.
     </p>
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+
+    <h4 style="font-size: 1rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--grey-300)">
+      Programmatic, with <code>grouped</code>
+    </h4>
+    <div style="max-width: 500px; margin-bottom: 1rem">
       <swim-select
         id="groupedSelectProgrammatic"
         grouped
         label="Food by aisle"
         placeholder="Pick an item…"
-        hint="Options set via JavaScript with a group on each row"
+        hint="Open the list and try filtering by Produce, Dairy, or Pantry"
       ></swim-select>
+    </div>
+    <pre class="demo-pre"
+    ><code>&lt;swim-select id="groupedSelectProgrammatic" grouped label="Food by aisle"&gt;&lt;/swim-select&gt;
+&lt;script type="module"&gt;
+  document.getElementById('groupedSelectProgrammatic').options = [
+    { name: 'Apples', value: 'apples', group: 'Produce' },
+    { name: 'Carrots', value: 'carrots', group: 'Produce' },
+    { name: 'Spinach', value: 'spinach', group: 'Produce' },
+    { name: 'Milk', value: 'milk', group: 'Dairy' },
+    { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
+    { name: 'Yogurt', value: 'yogurt', group: 'Dairy' },
+    { name: 'Chips', value: 'chips', category: 'Pantry' },
+    { name: 'Rice', value: 'rice', category: 'Pantry' },
+  ];
+&lt;/script&gt;</code></pre>
+
+    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">
+      Same options without <code>grouped</code> (flat list)
+    </h4>
+    <div style="max-width: 500px; margin-bottom: 1rem">
+      <swim-select
+        id="groupedSelectFlat"
+        label="Food (flat)"
+        placeholder="Same data, no section headers…"
+        hint="Identical .options as above; group/category are ignored for layout"
+      ></swim-select>
+    </div>
+    <pre class="demo-pre"
+    ><code>&lt;!-- No `grouped` attribute — flat dropdown --&gt;
+&lt;swim-select id="groupedSelectFlat" label="Food (flat)"&gt;&lt;/swim-select&gt;
+&lt;script type="module"&gt;
+  document.getElementById('groupedSelectFlat').options = [
+    { name: 'Apples', value: 'apples', group: 'Produce' },
+    { name: 'Carrots', value: 'carrots', group: 'Produce' },
+    { name: 'Spinach', value: 'spinach', group: 'Produce' },
+    { name: 'Milk', value: 'milk', group: 'Dairy' },
+    { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
+    { name: 'Yogurt', value: 'yogurt', group: 'Dairy' },
+    { name: 'Chips', value: 'chips', category: 'Pantry' },
+    { name: 'Rice', value: 'rice', category: 'Pantry' },
+  ];
+&lt;/script&gt;</code></pre>
+
+    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Declarative</h4>
+    <div style="max-width: 500px; margin-bottom: 1rem">
       <swim-select grouped label="Drinks (declarative)" placeholder="Select…" filterable="false">
         <swim-option group="Cold" name="Iced tea" value="iced-tea"></swim-option>
         <swim-option group="Cold" name="Soda" value="soda"></swim-option>
         <swim-option group="Hot" name="Coffee" value="coffee"></swim-option>
         <swim-option group="Hot" name="Tea" value="hot-tea"></swim-option>
       </swim-select>
+    </div>
+    <pre class="demo-pre"
+    ><code>&lt;swim-select grouped label="Drinks" placeholder="Select…" filterable="false"&gt;
+  &lt;swim-option group="Cold" name="Iced tea" value="iced-tea"&gt;&lt;/swim-option&gt;
+  &lt;swim-option group="Cold" name="Soda" value="soda"&gt;&lt;/swim-option&gt;
+  &lt;swim-option group="Hot" name="Coffee" value="coffee"&gt;&lt;/swim-option&gt;
+  &lt;swim-option group="Hot" name="Tea" value="hot-tea"&gt;&lt;/swim-option&gt;
+&lt;/swim-select&gt;</code></pre>
+
+    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Multi-select</h4>
+    <div style="max-width: 500px; margin-bottom: 1rem">
       <swim-select
         id="groupedSelectMulti"
         grouped
         label="Multi-select with groups"
         placeholder="Choose tools…"
         multiple
-        hint="Same grouping rules as single select"
+        hint="Section headers work the same with multiple"
       ></swim-select>
     </div>
     <pre class="demo-pre"
-    ><code>&lt;!-- Programmatic: `grouped` + group or category on each option --&gt;
-&lt;swim-select id="groupedSelectProgrammatic" grouped label="Food by aisle"&gt;&lt;/swim-select&gt;
-&lt;script&gt;
-  document.getElementById('groupedSelectProgrammatic').options = [
-    { name: 'Apples', value: 'apples', group: 'Produce' },
-    { name: 'Carrots', value: 'carrots', group: 'Produce' },
-    { name: 'Milk', value: 'milk', group: 'Dairy' },
-    { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
+    ><code>&lt;swim-select id="groupedSelectMulti" grouped multiple label="Multi-select with groups"&gt;
+&lt;/swim-select&gt;
+&lt;script type="module"&gt;
+  document.getElementById('groupedSelectMulti').options = [
+    { name: 'Drill', value: 'drill', group: 'Power tools' },
+    { name: 'Sander', value: 'sander', group: 'Power tools' },
+    { name: 'Hammer', value: 'hammer', group: 'Hand tools' },
+    { name: 'Wrench', value: 'wrench', group: 'Hand tools' },
   ];
-&lt;/script&gt;
-
-&lt;!-- Declarative: grouped + group on swim-option --&gt;
-&lt;swim-select grouped label="Drinks" filterable="false"&gt;
-  &lt;swim-option group="Cold" name="Soda" value="soda"&gt;&lt;/swim-option&gt;
-  &lt;swim-option group="Hot" name="Coffee" value="coffee"&gt;&lt;/swim-option&gt;
-&lt;/swim-select&gt;</code></pre>
+&lt;/script&gt;</code></pre>
   </swim-section>
 </section>
 
@@ -210,6 +263,7 @@
         filter-searching-placeholder="Searching GitHub…"
         async-filter
         filter-min-length="2"
+        dropdown-align="center"
         hint="Uses https://api.github.com/search/users (rate limits apply without auth)."
       ></swim-select>
       <p style="font-size: var(--font-size-s); color: var(--grey-350); margin: 0">
@@ -223,6 +277,7 @@
   placeholder="Pick a user…"
   async-filter
   filter-min-length="2"
+  dropdown-align="center"
   loading
 &gt;&lt;/swim-select&gt;
 
@@ -404,9 +459,11 @@
             <tr><td><code>label</code></td><td><code>string</code></td><td><code>''</code></td><td>Label text</td></tr>
             <tr><td><code>placeholder</code></td><td><code>string</code></td><td><code>'Select...'</code></td><td>Placeholder when no value selected</td></tr>
             <tr><td><code>hint</code></td><td><code>string</code></td><td><code>''</code></td><td>Hint text below the select</td></tr>
-            <tr><td><code>.options</code></td><td><code>Array&lt;{name, value}&gt;</code></td><td><code>[]</code></td><td>Array of selectable options</td></tr>
+            <tr><td><code>.options</code></td><td><code>Array&lt;SelectOption&gt;</code></td><td><code>[]</code></td><td>Options; may include <code>group</code> / <code>category</code> when <code>grouped</code> is set</td></tr>
             <tr><td><code>multiple</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Enable multi-select mode</td></tr>
             <tr><td><code>filterable</code></td><td><code>boolean</code></td><td><code>true</code></td><td>Enable type-to-filter</td></tr>
+            <tr><td><code>dropdown-align</code></td><td><code>'start' | 'center'</code></td><td><code>'start'</code></td><td>With popover layer: <code>center</code> sizes and anchors the panel to the host (centered columns / dialogs)</td></tr>
+            <tr><td><code>grouped</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Show section headers from each option’s <code>group</code> or <code>category</code></td></tr>
             <tr><td><code>allow-clear</code></td><td><code>boolean</code></td><td><code>true</code></td><td>Show clear button when value selected</td></tr>
             <tr><td><code>appearance</code></td><td><code>'legacy' | 'fill'</code></td><td><code>'legacy'</code></td><td>Visual appearance style</td></tr>
             <tr><td><code>size</code></td><td><code>'sm' | 'md' | 'lg'</code></td><td><code>'sm'</code></td><td>Select size</td></tr>
@@ -425,6 +482,8 @@
             <tr><td><code>value</code></td><td><code>any</code></td><td><code>undefined</code></td><td>Value of the option (defaults to name if not set)</td></tr>
             <tr><td><code>disabled</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Whether the option is disabled</td></tr>
             <tr><td><code>hidden</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Whether the option is hidden from the list</td></tr>
+            <tr><td><code>group</code></td><td><code>string</code></td><td><code>''</code></td><td>Section label (with parent <code>grouped</code> on <code>swim-select</code>)</td></tr>
+            <tr><td><code>category</code></td><td><code>string</code></td><td><code>''</code></td><td>Alias for section label if <code>group</code> is not set</td></tr>
           </tbody>
         </table>
       </div>
@@ -436,6 +495,7 @@
             <tr><td><code>change</code></td><td><code>any | any[]</code></td><td>Fired when the selection changes</td></tr>
             <tr><td><code>open</code></td><td>—</td><td>Fired when the dropdown opens</td></tr>
             <tr><td><code>close</code></td><td>—</td><td>Fired when the dropdown closes</td></tr>
+            <tr><td><code>filter-change</code></td><td><code>{ query: string }</code></td><td>With <code>async-filter</code>: debounced search text (empty below min length)</td></tr>
           </tbody>
         </table>
       </div>

--- a/projects/swimlane/swim-ui/demo/public/sections/select.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.html
@@ -136,6 +136,66 @@
   </swim-section>
 </section>
 
+<!-- Remote search: GitHub users -->
+<section class="section">
+  <swim-section section-title="Remote search (GitHub users)">
+    <p style="color: var(--grey-300); margin-bottom: 1rem">
+      Type at least <strong>2 characters</strong> to search public GitHub users via the
+      <a href="https://docs.github.com/en/rest/search/search#search-users" style="color: var(--blue-400)"
+        >Search users</a
+      >
+      API. Results load after the default <strong>500ms</strong> debounce on <code>filter-change</code>.
+    </p>
+    <div style="display: flex; flex-direction: column; gap: 0.75rem; max-width: 500px">
+      <swim-select
+        id="githubUserSelect"
+        label="GitHub user"
+        placeholder="Pick a user…"
+        filter-placeholder="Search by login…"
+        empty-placeholder="Open the list and type to search GitHub users."
+        filter-empty-placeholder="No users match that search."
+        filter-searching-placeholder="Searching GitHub…"
+        async-filter
+        filter-min-length="2"
+        hint="Uses https://api.github.com/search/users (rate limits apply without auth)."
+      ></swim-select>
+      <p style="font-size: var(--font-size-s); color: var(--grey-350); margin: 0">
+        Selected: <code id="githubUserSelectValue" style="color: var(--grey-200)">—</code>
+      </p>
+    </div>
+    <pre class="demo-pre"
+    ><code>&lt;swim-select
+  id="githubUserSelect"
+  label="GitHub user"
+  placeholder="Pick a user…"
+  async-filter
+  filter-min-length="2"
+  loading
+&gt;&lt;/swim-select&gt;
+
+&lt;script type="module"&gt;
+  const el = document.getElementById('githubUserSelect');
+  el.addEventListener('filter-change', async (e) => {
+    const q = e.detail.query;
+    if (!q) { el.options = []; el.loading = false; return; }
+    el.loading = true;
+    const res = await fetch(
+      `https://api.github.com/search/users?q=${encodeURIComponent(q)}&amp;per_page=15`,
+      { headers: { Accept: 'application/vnd.github+json' } }
+    );
+    const data = await res.json();
+    el.options = (data.items ?? []).map((u) => ({
+      name: u.login,
+      value: u.login,
+      title: u.login,
+      description: u.type === 'Organization' ? 'Organization' : 'User',
+    }));
+    el.loading = false;
+  });
+&lt;/script&gt;</code></pre>
+  </swim-section>
+</section>
+
 <!-- Filtering Section -->
 <section class="section">
   <swim-section section-title="With Filtering">

--- a/projects/swimlane/swim-ui/demo/public/sections/select.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.html
@@ -81,12 +81,12 @@
   </swim-section>
 </section>
 
-<!-- Grouped options: group / category -->
+<!-- Grouped options: group -->
 <section class="section">
   <swim-section section-title="Grouped options">
     <p style="color: var(--grey-300); margin-bottom: 1.25rem">
       Set <code>grouped</code> on <code>&lt;swim-select&gt;</code> to show section headers from each option’s
-      <code>group</code> or <code>category</code>. Omit <code>grouped</code> and the same data renders as a flat list
+      <code>group</code>. Omit <code>grouped</code> and the same data renders as a flat list
       (metadata is still on each option). With <code>grouped</code> and filtering on, typing a section name (e.g.
       “Pantry”) matches options in that section.
     </p>
@@ -113,8 +113,8 @@
     { name: 'Milk', value: 'milk', group: 'Dairy' },
     { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
     { name: 'Yogurt', value: 'yogurt', group: 'Dairy' },
-    { name: 'Chips', value: 'chips', category: 'Pantry' },
-    { name: 'Rice', value: 'rice', category: 'Pantry' },
+    { name: 'Chips', value: 'chips', group: 'Pantry' },
+    { name: 'Rice', value: 'rice', group: 'Pantry' },
   ];
 &lt;/script&gt;</code></pre>
 
@@ -126,7 +126,7 @@
         id="groupedSelectFlat"
         label="Food (flat)"
         placeholder="Same data, no section headers…"
-        hint="Identical .options as above; group/category are ignored for layout"
+        hint="Identical .options as above; group is ignored for layout"
       ></swim-select>
     </div>
     <pre class="demo-pre"
@@ -140,8 +140,8 @@
     { name: 'Milk', value: 'milk', group: 'Dairy' },
     { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
     { name: 'Yogurt', value: 'yogurt', group: 'Dairy' },
-    { name: 'Chips', value: 'chips', category: 'Pantry' },
-    { name: 'Rice', value: 'rice', category: 'Pantry' },
+    { name: 'Chips', value: 'chips', group: 'Pantry' },
+    { name: 'Rice', value: 'rice', group: 'Pantry' },
   ];
 &lt;/script&gt;</code></pre>
 
@@ -472,11 +472,11 @@
             <tr><td><code>label</code></td><td><code>string</code></td><td><code>''</code></td><td>Label text</td></tr>
             <tr><td><code>placeholder</code></td><td><code>string</code></td><td><code>'Select...'</code></td><td>Placeholder when no value selected</td></tr>
             <tr><td><code>hint</code></td><td><code>string</code></td><td><code>''</code></td><td>Hint text below the select</td></tr>
-            <tr><td><code>.options</code></td><td><code>Array&lt;SelectOption&gt;</code></td><td><code>[]</code></td><td>Options; may include <code>group</code> / <code>category</code> when <code>grouped</code> is set</td></tr>
+            <tr><td><code>.options</code></td><td><code>Array&lt;SelectOption&gt;</code></td><td><code>[]</code></td><td>Options; may include <code>group</code> when <code>grouped</code> is set</td></tr>
             <tr><td><code>multiple</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Enable multi-select mode</td></tr>
             <tr><td><code>filterable</code></td><td><code>boolean</code></td><td><code>true</code></td><td>Enable type-to-filter</td></tr>
             <tr><td><code>dropdown-align</code></td><td><code>'start' | 'center'</code></td><td><code>'start'</code></td><td>With popover layer: <code>center</code> sizes and anchors the panel to the host (centered columns / dialogs)</td></tr>
-            <tr><td><code>grouped</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Show section headers from each option’s <code>group</code> or <code>category</code></td></tr>
+            <tr><td><code>grouped</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Show section headers from each option’s <code>group</code></td></tr>
             <tr><td><code>allow-clear</code></td><td><code>boolean</code></td><td><code>true</code></td><td>Show clear button when value selected</td></tr>
             <tr><td><code>appearance</code></td><td><code>'legacy' | 'fill'</code></td><td><code>'legacy'</code></td><td>Visual appearance style</td></tr>
             <tr><td><code>size</code></td><td><code>'sm' | 'md' | 'lg'</code></td><td><code>'sm'</code></td><td>Select size</td></tr>
@@ -496,7 +496,6 @@
             <tr><td><code>disabled</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Whether the option is disabled</td></tr>
             <tr><td><code>hidden</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Whether the option is hidden from the list</td></tr>
             <tr><td><code>group</code></td><td><code>string</code></td><td><code>''</code></td><td>Section label (with parent <code>grouped</code> on <code>swim-select</code>)</td></tr>
-            <tr><td><code>category</code></td><td><code>string</code></td><td><code>''</code></td><td>Alias for section label if <code>group</code> is not set</td></tr>
           </tbody>
         </table>
       </div>

--- a/projects/swimlane/swim-ui/demo/solutions/component-showcase-solution.js
+++ b/projects/swimlane/swim-ui/demo/solutions/component-showcase-solution.js
@@ -848,8 +848,13 @@ export default class ComponentShowcaseSolution extends SwimlaneElement {
               </div>
               <div class="demo-item">
                 <span class="demo-label">In Progress</span>
-                <swim-button state="in-progress" timeout="0" variant="primary" aria-label="Loading state"
-                  >Loading</swim-button
+                <swim-button
+                  state="in-progress"
+                  timeout="0"
+                  variant="primary"
+                  loading-text="Loading…"
+                  aria-label="Operation in progress"
+                  >Submit</swim-button
                 >
               </div>
               <div class="demo-item">

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -423,18 +423,25 @@ function setupSelectDemos(): void {
   const basicSelect = document.getElementById('basicSelect') as any;
   if (basicSelect) basicSelect.options = attackTypeOptions;
 
+  const groupedOptionsDemo = [
+    { name: 'Apples', value: 'apples', group: 'Produce' },
+    { name: 'Carrots', value: 'carrots', group: 'Produce' },
+    { name: 'Spinach', value: 'spinach', group: 'Produce' },
+    { name: 'Milk', value: 'milk', group: 'Dairy' },
+    { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
+    { name: 'Yogurt', value: 'yogurt', group: 'Dairy' },
+    { name: 'Chips', value: 'chips', category: 'Pantry' },
+    { name: 'Rice', value: 'rice', category: 'Pantry' }
+  ];
+
   const groupedSelectProgrammatic = document.getElementById('groupedSelectProgrammatic') as any;
   if (groupedSelectProgrammatic) {
-    groupedSelectProgrammatic.options = [
-      { name: 'Apples', value: 'apples', group: 'Produce' },
-      { name: 'Carrots', value: 'carrots', group: 'Produce' },
-      { name: 'Spinach', value: 'spinach', group: 'Produce' },
-      { name: 'Milk', value: 'milk', group: 'Dairy' },
-      { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
-      { name: 'Yogurt', value: 'yogurt', group: 'Dairy' },
-      { name: 'Chips', value: 'chips', category: 'Pantry' },
-      { name: 'Rice', value: 'rice', category: 'Pantry' }
-    ];
+    groupedSelectProgrammatic.options = groupedOptionsDemo;
+  }
+
+  const groupedSelectFlat = document.getElementById('groupedSelectFlat') as any;
+  if (groupedSelectFlat) {
+    groupedSelectFlat.options = groupedOptionsDemo;
   }
 
   const groupedSelectMulti = document.getElementById('groupedSelectMulti') as any;

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -1027,6 +1027,58 @@ function setupDemos(): void {
   setupListDemos();
 
   // Dialog demos
+  /** `close-or-cancel` is emitted from `swim-large-format-dialog-content`, not from `swim-dialog`. */
+  const wireLargeFormatHeaderClose = (dialogEl: HTMLElement & { visible?: boolean }) => {
+    dialogEl.querySelector('swim-large-format-dialog-content')?.addEventListener('close-or-cancel', () => {
+      dialogEl.visible = false;
+    });
+  };
+
+  const dialogEventsDemo = document.getElementById('dialogEventsDemo') as
+    | (HTMLElement & {
+        visible: boolean;
+      })
+    | null;
+  const dialogEventsLog = document.getElementById('dialogEventsLog');
+  const dialogEventsLargeContent = document.getElementById('dialogEventsLargeContent');
+  const dialogEventsLines: string[] = [];
+  const maxDialogEventLines = 50;
+  const appendDialogEventLine = (line: string) => {
+    const stamp = new Date().toISOString().slice(11, 23);
+    dialogEventsLines.push(`${stamp} ${line}`);
+    if (dialogEventsLines.length > maxDialogEventLines) {
+      dialogEventsLines.splice(0, dialogEventsLines.length - maxDialogEventLines);
+    }
+    if (dialogEventsLog) dialogEventsLog.textContent = dialogEventsLines.join('\n');
+  };
+
+  if (dialogEventsDemo && dialogEventsLog) {
+    dialogEventsDemo.addEventListener('open', e => {
+      appendDialogEventLine(`swim-dialog open (bubbles=${e.bubbles}, composed=${e.composed})`);
+    });
+    dialogEventsDemo.addEventListener('close', e => {
+      appendDialogEventLine(`swim-dialog close (bubbles=${e.bubbles}, composed=${e.composed})`);
+      dialogEventsDemo.visible = false;
+    });
+  }
+  if (dialogEventsLargeContent) {
+    dialogEventsLargeContent.addEventListener('close-or-cancel', e => {
+      const dirty = (e as CustomEvent<boolean>).detail;
+      appendDialogEventLine(`swim-large-format-dialog-content close-or-cancel (detail dirty=${dirty})`);
+      if (dialogEventsDemo) dialogEventsDemo.visible = false;
+    });
+  }
+  document.getElementById('dialogEventsOpen')?.addEventListener('click', () => {
+    if (dialogEventsDemo) dialogEventsDemo.visible = true;
+  });
+  document.getElementById('dialogEventsClearLog')?.addEventListener('click', () => {
+    dialogEventsLines.length = 0;
+    if (dialogEventsLog) dialogEventsLog.textContent = '(log cleared)';
+  });
+  document.getElementById('dialogEventsFooterClose')?.addEventListener('click', () => {
+    if (dialogEventsDemo) dialogEventsDemo.visible = false;
+  });
+
   const dialogContentOpen = document.getElementById('dialogContentOpen');
   const dialogContentDemo = document.getElementById('dialogContentDemo') as any;
   if (dialogContentOpen && dialogContentDemo) {
@@ -1100,13 +1152,15 @@ function setupDemos(): void {
     dialogLargeFormatOpen.addEventListener('click', () => {
       dialogLargeFormatDemo.visible = true;
     });
-    dialogLargeFormatDemo.addEventListener('close-or-cancel', () => {
-      dialogLargeFormatDemo.visible = false;
-    });
+    wireLargeFormatHeaderClose(dialogLargeFormatDemo);
   }
 
   const dialogThemeVarsLargeOpen = document.getElementById('dialogThemeVarsLargeOpen');
-  const dialogThemeVarsLargeDemo = document.getElementById('dialogThemeVarsLargeDemo') as { visible?: boolean } | null;
+  const dialogThemeVarsLargeDemo = document.getElementById('dialogThemeVarsLargeDemo') as
+    | (HTMLElement & {
+        visible?: boolean;
+      })
+    | null;
   if (dialogThemeVarsLargeOpen && dialogThemeVarsLargeDemo) {
     const hideThemedLarge = () => {
       dialogThemeVarsLargeDemo.visible = false;
@@ -1114,14 +1168,18 @@ function setupDemos(): void {
     dialogThemeVarsLargeOpen.addEventListener('click', () => {
       dialogThemeVarsLargeDemo.visible = true;
     });
-    dialogThemeVarsLargeDemo.addEventListener('close-or-cancel', hideThemedLarge);
+    dialogThemeVarsLargeDemo
+      .querySelector('swim-large-format-dialog-content')
+      ?.addEventListener('close-or-cancel', hideThemedLarge);
     dialogThemeVarsLargeDemo.addEventListener('close', hideThemedLarge);
   }
 
   const dialogThemeVarsRegularOpen = document.getElementById('dialogThemeVarsRegularOpen');
-  const dialogThemeVarsRegularDemo = document.getElementById('dialogThemeVarsRegularDemo') as {
-    visible?: boolean;
-  } | null;
+  const dialogThemeVarsRegularDemo = document.getElementById('dialogThemeVarsRegularDemo') as
+    | (HTMLElement & {
+        visible?: boolean;
+      })
+    | null;
   if (dialogThemeVarsRegularOpen && dialogThemeVarsRegularDemo) {
     dialogThemeVarsRegularOpen.addEventListener('click', () => {
       dialogThemeVarsRegularDemo.visible = true;
@@ -1131,7 +1189,11 @@ function setupDemos(): void {
     });
   }
 
-  const dialogFooterAlignDemo = document.getElementById('dialogFooterAlignDemo') as { visible?: boolean } | null;
+  const dialogFooterAlignDemo = document.getElementById('dialogFooterAlignDemo') as
+    | (HTMLElement & {
+        visible?: boolean;
+      })
+    | null;
   const dialogFooterAlignFooter = document.getElementById('dialogFooterAlignFooter') as {
     align?: string;
     setAttribute(name: string, value: string): void;
@@ -1150,9 +1212,7 @@ function setupDemos(): void {
   wireDialogFooterAlignOpen('dialogFooterAlignOpenEnd', 'end');
   wireDialogFooterAlignOpen('dialogFooterAlignOpenBetween', 'space-between');
   if (dialogFooterAlignDemo) {
-    dialogFooterAlignDemo.addEventListener('close-or-cancel', () => {
-      dialogFooterAlignDemo.visible = false;
-    });
+    wireLargeFormatHeaderClose(dialogFooterAlignDemo);
   }
 
   const dialogMediumFormatOpen = document.getElementById('dialogMediumFormatOpen');
@@ -1161,9 +1221,7 @@ function setupDemos(): void {
     dialogMediumFormatOpen.addEventListener('click', () => {
       dialogMediumFormatDemo.visible = true;
     });
-    dialogMediumFormatDemo.addEventListener('close-or-cancel', () => {
-      dialogMediumFormatDemo.visible = false;
-    });
+    wireLargeFormatHeaderClose(dialogMediumFormatDemo);
   }
 
   const dialogMediumContentOpen = document.getElementById('dialogMediumContentOpen');
@@ -1172,9 +1230,7 @@ function setupDemos(): void {
     dialogMediumContentOpen.addEventListener('click', () => {
       dialogMediumContentDemo.visible = true;
     });
-    dialogMediumContentDemo.addEventListener('close-or-cancel', () => {
-      dialogMediumContentDemo.visible = false;
-    });
+    wireLargeFormatHeaderClose(dialogMediumContentDemo);
   }
 
   const dialogMediumFooterOpen = document.getElementById('dialogMediumFooterOpen');
@@ -1183,9 +1239,7 @@ function setupDemos(): void {
     dialogMediumFooterOpen.addEventListener('click', () => {
       dialogMediumFooterDemo.visible = true;
     });
-    dialogMediumFooterDemo.addEventListener('close-or-cancel', () => {
-      dialogMediumFooterDemo.visible = false;
-    });
+    wireLargeFormatHeaderClose(dialogMediumFooterDemo);
   }
 
   const dialogMediumFooterContentOpen = document.getElementById('dialogMediumFooterContentOpen');
@@ -1194,9 +1248,7 @@ function setupDemos(): void {
     dialogMediumFooterContentOpen.addEventListener('click', () => {
       dialogMediumFooterContentDemo.visible = true;
     });
-    dialogMediumFooterContentDemo.addEventListener('close-or-cancel', () => {
-      dialogMediumFooterContentDemo.visible = false;
-    });
+    wireLargeFormatHeaderClose(dialogMediumFooterContentDemo);
   }
 
   // Drawer demos

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -430,8 +430,8 @@ function setupSelectDemos(): void {
     { name: 'Milk', value: 'milk', group: 'Dairy' },
     { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
     { name: 'Yogurt', value: 'yogurt', group: 'Dairy' },
-    { name: 'Chips', value: 'chips', category: 'Pantry' },
-    { name: 'Rice', value: 'rice', category: 'Pantry' }
+    { name: 'Chips', value: 'chips', group: 'Pantry' },
+    { name: 'Rice', value: 'rice', group: 'Pantry' }
   ];
 
   const groupedSelectProgrammatic = document.getElementById('groupedSelectProgrammatic') as any;

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -6,6 +6,7 @@
 
 import { ICON_NAMES } from './icon-names';
 import { openDrawer } from '../../src/components/drawer/drawer-controller';
+import { formatDate, parseDate } from '../../src/components/date-time/date-format';
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -139,6 +140,7 @@ const SECTION_FILES = [
   'input',
   'select',
   'datetime',
+  'date-display',
   'checkbox',
   'radio',
   'toggle',
@@ -563,6 +565,33 @@ function setupSelectDemos(): void {
   if (formSelect2) formSelect2.options = tags;
 }
 
+function setupDateDisplayDemo(): void {
+  type DdEl = HTMLElement & {
+    timezones?: Record<string, string>;
+  };
+
+  const customTz = document.getElementById('dateDisplayTimezonesCustom') as DdEl | null;
+  if (customTz) {
+    customTz.timezones = { Local: '', GMT: 'Etc/UTC', Tokyo: 'Asia/Tokyo' };
+  }
+
+  const localOut = document.getElementById('dateDisplayLocalString');
+  const quake = parseDate('2011-03-11T05:46:24Z');
+  if (localOut && quake) {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    localOut.textContent = JSON.stringify(formatDate(quake, 'MMMM D, YYYY h:mm:ss A', tz));
+  }
+
+  const log = document.getElementById('dateDisplayCopyLog');
+  const root = document.getElementById('dateDisplayDemoRoot');
+  if (log && root) {
+    root.addEventListener('date-copied', (e: Event) => {
+      const d = (e as CustomEvent<{ message?: string }>).detail;
+      log.textContent = d?.message ?? '—';
+    });
+  }
+}
+
 function setupDateTimeDemos(): void {
   type DtEl = HTMLElement & { value: Date | string | null };
   const TOHOKU_EARTHQUAKE = '2011-03-11T05:46:24Z';
@@ -831,6 +860,7 @@ function setupDemos(): void {
 
   setupSelectDemos();
   setupDateTimeDemos();
+  setupDateDisplayDemo();
 
   // Card demos
   const selectableCardDemo = document.getElementById('selectableCardDemo') as any;

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -946,6 +946,17 @@ function setupDemos(): void {
     });
   }
 
+  const dialogDismissBackdropOpen = document.getElementById('dialogDismissBackdropOpen');
+  const dialogDismissBackdropDemo = document.getElementById('dialogDismissBackdropDemo') as any;
+  if (dialogDismissBackdropOpen && dialogDismissBackdropDemo) {
+    dialogDismissBackdropOpen.addEventListener('click', () => {
+      dialogDismissBackdropDemo.visible = true;
+    });
+    dialogDismissBackdropDemo.addEventListener('close', () => {
+      dialogDismissBackdropDemo.visible = false;
+    });
+  }
+
   const dialogComponentToggle = document.getElementById('dialogComponentToggle');
   const dialogComponentDemo = document.getElementById('dialogComponentDemo') as any;
   if (dialogComponentToggle && dialogComponentDemo) {
@@ -999,6 +1010,56 @@ function setupDemos(): void {
     });
     dialogLargeFormatDemo.addEventListener('close-or-cancel', () => {
       dialogLargeFormatDemo.visible = false;
+    });
+  }
+
+  const dialogThemeVarsLargeOpen = document.getElementById('dialogThemeVarsLargeOpen');
+  const dialogThemeVarsLargeDemo = document.getElementById('dialogThemeVarsLargeDemo') as { visible?: boolean } | null;
+  if (dialogThemeVarsLargeOpen && dialogThemeVarsLargeDemo) {
+    const hideThemedLarge = () => {
+      dialogThemeVarsLargeDemo.visible = false;
+    };
+    dialogThemeVarsLargeOpen.addEventListener('click', () => {
+      dialogThemeVarsLargeDemo.visible = true;
+    });
+    dialogThemeVarsLargeDemo.addEventListener('close-or-cancel', hideThemedLarge);
+    dialogThemeVarsLargeDemo.addEventListener('close', hideThemedLarge);
+  }
+
+  const dialogThemeVarsRegularOpen = document.getElementById('dialogThemeVarsRegularOpen');
+  const dialogThemeVarsRegularDemo = document.getElementById('dialogThemeVarsRegularDemo') as {
+    visible?: boolean;
+  } | null;
+  if (dialogThemeVarsRegularOpen && dialogThemeVarsRegularDemo) {
+    dialogThemeVarsRegularOpen.addEventListener('click', () => {
+      dialogThemeVarsRegularDemo.visible = true;
+    });
+    dialogThemeVarsRegularDemo.addEventListener('close', () => {
+      dialogThemeVarsRegularDemo.visible = false;
+    });
+  }
+
+  const dialogFooterAlignDemo = document.getElementById('dialogFooterAlignDemo') as { visible?: boolean } | null;
+  const dialogFooterAlignFooter = document.getElementById('dialogFooterAlignFooter') as {
+    align?: string;
+    setAttribute(name: string, value: string): void;
+  } | null;
+  const wireDialogFooterAlignOpen = (buttonId: string, align: string) => {
+    const btn = document.getElementById(buttonId);
+    if (!btn || !dialogFooterAlignDemo || !dialogFooterAlignFooter) return;
+    btn.addEventListener('click', () => {
+      dialogFooterAlignFooter.setAttribute('align', align);
+      dialogFooterAlignFooter.align = align;
+      dialogFooterAlignDemo.visible = true;
+    });
+  };
+  wireDialogFooterAlignOpen('dialogFooterAlignOpenStart', 'start');
+  wireDialogFooterAlignOpen('dialogFooterAlignOpenCenter', 'center');
+  wireDialogFooterAlignOpen('dialogFooterAlignOpenEnd', 'end');
+  wireDialogFooterAlignOpen('dialogFooterAlignOpenBetween', 'space-between');
+  if (dialogFooterAlignDemo) {
+    dialogFooterAlignDemo.addEventListener('close-or-cancel', () => {
+      dialogFooterAlignDemo.visible = false;
     });
   }
 

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -269,6 +269,62 @@ function setupIconsDemo(): void {
   }
 }
 
+/** GitHub user search for swim-select (Select demo + Medium dialog demo). */
+function setupGithubUserAsyncSelect(selectId: string, valueElementId: string | null): void {
+  const githubUserSelect = document.getElementById(selectId) as any;
+  const githubUserSelectValue = valueElementId ? document.getElementById(valueElementId) : null;
+  if (!githubUserSelect) {
+    return;
+  }
+  githubUserSelect.options = [];
+  let githubRequestId = 0;
+  githubUserSelect.addEventListener('filter-change', async (e: CustomEvent<{ query: string }>) => {
+    const q = (e.detail?.query ?? '').trim();
+    if (!q) {
+      githubUserSelect.options = [];
+      githubUserSelect.loading = false;
+      return;
+    }
+    const reqId = ++githubRequestId;
+    githubUserSelect.loading = true;
+    try {
+      const res = await fetch(`https://api.github.com/search/users?q=${encodeURIComponent(q)}&per_page=15`, {
+        headers: { Accept: 'application/vnd.github+json' }
+      });
+      if (!res.ok) {
+        throw new Error(`GitHub API ${res.status}`);
+      }
+      const data = (await res.json()) as {
+        items?: Array<{ login: string; type?: string }>;
+      };
+      if (reqId !== githubRequestId) {
+        return;
+      }
+      githubUserSelect.options = (data.items ?? []).map(u => ({
+        name: u.login,
+        value: u.login,
+        title: u.login,
+        description: u.type === 'Organization' ? 'Organization' : 'User'
+      }));
+    } catch (err) {
+      console.error('GitHub user search failed', err);
+      if (reqId === githubRequestId) {
+        githubUserSelect.options = [];
+      }
+    } finally {
+      if (reqId === githubRequestId) {
+        githubUserSelect.loading = false;
+      }
+    }
+  });
+  githubUserSelect.addEventListener('change', () => {
+    if (githubUserSelectValue) {
+      githubUserSelectValue.textContent =
+        githubUserSelect.value != null && githubUserSelect.value !== '' ? String(githubUserSelect.value) : '—';
+    }
+  });
+}
+
 function setupSelectDemos(): void {
   const attackTypeOptions = [
     { name: 'Breach', value: 'breach' },
@@ -367,57 +423,8 @@ function setupSelectDemos(): void {
   const filterableSelect = document.getElementById('filterableSelect') as any;
   if (filterableSelect) filterableSelect.options = countries;
 
-  const githubUserSelect = document.getElementById('githubUserSelect') as any;
-  const githubUserSelectValue = document.getElementById('githubUserSelectValue');
-  if (githubUserSelect) {
-    githubUserSelect.options = [];
-    let githubRequestId = 0;
-    githubUserSelect.addEventListener('filter-change', async (e: CustomEvent<{ query: string }>) => {
-      const q = (e.detail?.query ?? '').trim();
-      if (!q) {
-        githubUserSelect.options = [];
-        githubUserSelect.loading = false;
-        return;
-      }
-      const reqId = ++githubRequestId;
-      githubUserSelect.loading = true;
-      try {
-        const res = await fetch(`https://api.github.com/search/users?q=${encodeURIComponent(q)}&per_page=15`, {
-          headers: { Accept: 'application/vnd.github+json' }
-        });
-        if (!res.ok) {
-          throw new Error(`GitHub API ${res.status}`);
-        }
-        const data = (await res.json()) as {
-          items?: Array<{ login: string; type?: string }>;
-        };
-        if (reqId !== githubRequestId) {
-          return;
-        }
-        githubUserSelect.options = (data.items ?? []).map(u => ({
-          name: u.login,
-          value: u.login,
-          title: u.login,
-          description: u.type === 'Organization' ? 'Organization' : 'User'
-        }));
-      } catch (err) {
-        console.error('GitHub user search failed', err);
-        if (reqId === githubRequestId) {
-          githubUserSelect.options = [];
-        }
-      } finally {
-        if (reqId === githubRequestId) {
-          githubUserSelect.loading = false;
-        }
-      }
-    });
-    githubUserSelect.addEventListener('change', () => {
-      if (githubUserSelectValue) {
-        githubUserSelectValue.textContent =
-          githubUserSelect.value != null && githubUserSelect.value !== '' ? String(githubUserSelect.value) : '—';
-      }
-    });
-  }
+  setupGithubUserAsyncSelect('githubUserSelect', 'githubUserSelectValue');
+  setupGithubUserAsyncSelect('dialogMediumGithubUserSelect', 'dialogMediumGithubUserSelectValue');
 
   const noFilterSelect = document.getElementById('noFilterSelect') as any;
   if (noFilterSelect) noFilterSelect.options = fruits;

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -343,6 +343,58 @@ function setupSelectDemos(): void {
   const filterableSelect = document.getElementById('filterableSelect') as any;
   if (filterableSelect) filterableSelect.options = countries;
 
+  const githubUserSelect = document.getElementById('githubUserSelect') as any;
+  const githubUserSelectValue = document.getElementById('githubUserSelectValue');
+  if (githubUserSelect) {
+    githubUserSelect.options = [];
+    let githubRequestId = 0;
+    githubUserSelect.addEventListener('filter-change', async (e: CustomEvent<{ query: string }>) => {
+      const q = (e.detail?.query ?? '').trim();
+      if (!q) {
+        githubUserSelect.options = [];
+        githubUserSelect.loading = false;
+        return;
+      }
+      const reqId = ++githubRequestId;
+      githubUserSelect.loading = true;
+      try {
+        const res = await fetch(`https://api.github.com/search/users?q=${encodeURIComponent(q)}&per_page=15`, {
+          headers: { Accept: 'application/vnd.github+json' }
+        });
+        if (!res.ok) {
+          throw new Error(`GitHub API ${res.status}`);
+        }
+        const data = (await res.json()) as {
+          items?: Array<{ login: string; type?: string }>;
+        };
+        if (reqId !== githubRequestId) {
+          return;
+        }
+        githubUserSelect.options = (data.items ?? []).map(u => ({
+          name: u.login,
+          value: u.login,
+          title: u.login,
+          description: u.type === 'Organization' ? 'Organization' : 'User'
+        }));
+      } catch (err) {
+        console.error('GitHub user search failed', err);
+        if (reqId === githubRequestId) {
+          githubUserSelect.options = [];
+        }
+      } finally {
+        if (reqId === githubRequestId) {
+          githubUserSelect.loading = false;
+        }
+      }
+    });
+    githubUserSelect.addEventListener('change', () => {
+      if (githubUserSelectValue) {
+        githubUserSelectValue.textContent =
+          githubUserSelect.value != null && githubUserSelect.value !== '' ? String(githubUserSelect.value) : '—';
+      }
+    });
+  }
+
   const noFilterSelect = document.getElementById('noFilterSelect') as any;
   if (noFilterSelect) noFilterSelect.options = fruits;
 

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -57,6 +57,82 @@ const LIST_LARGE_DATA = [
   ...LIST_DATA
 ];
 
+/** Demo: log swim-checkbox propagation (light DOM vs nested shadow) for bubbles/composed. */
+function setupEventBubblingMatrixDemo(): void {
+  const root = document.getElementById('eventBubblingMatrixRoot');
+  if (!root) return;
+
+  const logEl = document.getElementById('eventBubblingMatrixLog');
+  const lines: string[] = [];
+  const maxLines = 100;
+
+  const log = (msg: string) => {
+    lines.push(`${new Date().toISOString().slice(11, 23)} ${msg}`);
+    if (lines.length > maxLines) lines.splice(0, lines.length - maxLines);
+    if (logEl) logEl.textContent = lines.join('\n');
+  };
+
+  document.getElementById('matrixClearLog')?.addEventListener('click', () => {
+    lines.length = 0;
+    if (logEl) logEl.textContent = '';
+    log('(log cleared)');
+  });
+
+  const types = ['change', 'checked-change'] as const;
+
+  const wire = (caseLabel: string, target: EventTarget, listenerLabel: string) => {
+    for (const t of types) {
+      target.addEventListener(
+        t,
+        (e: Event) => {
+          const tgt = e.target as HTMLElement | null;
+          const tag = tgt?.tagName?.toLowerCase() ?? '?';
+          log(
+            `${caseLabel} | ${listenerLabel} | type=${e.type} bubbles=${e.bubbles} composed=${e.composed} target=${tag}`
+          );
+        },
+        false
+      );
+    }
+  };
+
+  const cbLight = document.getElementById('matrixCbLight');
+  const wrapLight = root.querySelector('.matrix-wrap-light');
+  if (cbLight && wrapLight) {
+    wire('light', cbLight, 'onCheckbox');
+    wire('light', wrapLight, 'onWrapper(parent)');
+    wire('light', document, 'onDocument');
+  }
+
+  const mount = document.getElementById('matrixShadowMount');
+  if (mount && !mount.querySelector('[data-matrix-shadow-demo]')) {
+    const host = document.createElement('div');
+    host.dataset.matrixShadowDemo = '';
+    host.setAttribute(
+      'style',
+      'padding:1rem;background:var(--grey-800);border-radius:4px;border:1px solid var(--grey-600)'
+    );
+    const title = document.createElement('div');
+    title.style.cssText = 'font-size:0.875rem;color:var(--grey-300);margin-bottom:0.5rem';
+    title.textContent = 'Shadow host (open shadow contains swim-checkbox below)';
+    host.appendChild(title);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const cb = document.createElement('swim-checkbox');
+    cb.id = 'matrixCbShadow';
+    cb.setAttribute('label', 'Toggle (inside shadow)');
+    shadow.appendChild(cb);
+    mount.appendChild(host);
+
+    wire('shadow', cb, 'onCheckbox');
+    wire('shadow', host, 'onShadowHost(light parent)');
+    wire('shadow', document, 'onDocument');
+  }
+
+  log(
+    'Toggle a checkbox above. Expect: events on the checkbox and wrapper; document only sees the light-DOM case (events do not bubble from the host). Shadow case: document does not receive events from inside the nested shadow root.'
+  );
+}
+
 const SECTION_FILES = [
   'home',
   'buttons',
@@ -80,7 +156,8 @@ const SECTION_FILES = [
   'dialog',
   'drawer',
   'scrollbars',
-  'icons'
+  'icons',
+  'event-bubbling-matrix'
 ];
 
 const SECTION_SET = new Set([...SECTION_FILES, 'datetime', 'drawer']);
@@ -372,6 +449,12 @@ function setupSelectDemos(): void {
 
   const requiredSelect = document.getElementById('requiredSelect') as any;
   if (requiredSelect) requiredSelect.options = attackTypeOptions;
+
+  const singleSelectDisabled = document.getElementById('singleSelectDisabled') as any;
+  if (singleSelectDisabled) {
+    singleSelectDisabled.options = attackTypeOptions;
+    singleSelectDisabled.value = 'breach';
+  }
 
   const legacySelect = document.getElementById('legacySelect') as any;
   if (legacySelect) legacySelect.options = fruits;
@@ -671,6 +754,8 @@ function setupListDemos(): void {
  * Called after each section is injected into #page-sections.
  */
 function setupDemos(): void {
+  setupEventBubblingMatrixDemo();
+
   // Button demos (promise handling)
   const successBtn = document.getElementById('successBtn');
   if (successBtn) {

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -290,6 +290,30 @@ function setupSelectDemos(): void {
   const basicSelect = document.getElementById('basicSelect') as any;
   if (basicSelect) basicSelect.options = attackTypeOptions;
 
+  const groupedSelectProgrammatic = document.getElementById('groupedSelectProgrammatic') as any;
+  if (groupedSelectProgrammatic) {
+    groupedSelectProgrammatic.options = [
+      { name: 'Apples', value: 'apples', group: 'Produce' },
+      { name: 'Carrots', value: 'carrots', group: 'Produce' },
+      { name: 'Spinach', value: 'spinach', group: 'Produce' },
+      { name: 'Milk', value: 'milk', group: 'Dairy' },
+      { name: 'Cheddar', value: 'cheddar', group: 'Dairy' },
+      { name: 'Yogurt', value: 'yogurt', group: 'Dairy' },
+      { name: 'Chips', value: 'chips', category: 'Pantry' },
+      { name: 'Rice', value: 'rice', category: 'Pantry' }
+    ];
+  }
+
+  const groupedSelectMulti = document.getElementById('groupedSelectMulti') as any;
+  if (groupedSelectMulti) {
+    groupedSelectMulti.options = [
+      { name: 'Drill', value: 'drill', group: 'Power tools' },
+      { name: 'Sander', value: 'sander', group: 'Power tools' },
+      { name: 'Hammer', value: 'hammer', group: 'Hand tools' },
+      { name: 'Wrench', value: 'wrench', group: 'Hand tools' }
+    ];
+  }
+
   const requiredSelect = document.getElementById('requiredSelect') as any;
   if (requiredSelect) requiredSelect.options = attackTypeOptions;
 

--- a/projects/swimlane/swim-ui/demo/src/main.ts
+++ b/projects/swimlane/swim-ui/demo/src/main.ts
@@ -41,6 +41,7 @@ import '../../src/components/dialog/dialog.component';
 import '../../src/components/dialog/large-format-dialog-content/large-format-dialog-content.component';
 import '../../src/components/dialog/large-format-dialog-footer/large-format-dialog-footer.component';
 import '../../src/components/date-time/date-time.component';
+import '../../src/components/date-display/date-display.component';
 import '../../src/components/drawer/drawer.component';
 import { scrollbarStyles } from '../../src/styles';
 

--- a/projects/swimlane/swim-ui/package.json
+++ b/projects/swimlane/swim-ui/package.json
@@ -114,6 +114,7 @@
     "build": "yarn copy:icon-font && tsc && vite build",
     "build:lib": "tsc --project tsconfig.lib.json",
     "build:cdn": "node scripts/build-cdn.mjs",
+    "serve:cdn-local": "yarn copy:icon-font && yarn build:cdn && rm -rf .cdn-local-serve && mkdir -p .cdn-local-serve/swim-ui && cp -r dist-cdn/. .cdn-local-serve/swim-ui/ && npx --yes serve .cdn-local-serve -l 8765 --cors",
     "deploy:gh-pages": "yarn build && yarn build:cdn && cp -r dist-cdn/* dist-demo/ && yarn exec gh-pages -d dist-demo -r https://github.com/surya-pabbineedi/swim-ui.git",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/projects/swimlane/swim-ui/package.json
+++ b/projects/swimlane/swim-ui/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/components/date-time/index.d.ts",
       "default": "./dist/components/date-time/index.js"
     },
+    "./date-display": {
+      "types": "./dist/components/date-display/index.d.ts",
+      "default": "./dist/components/date-display/index.js"
+    },
     "./dialog": {
       "types": "./dist/components/dialog/index.d.ts",
       "default": "./dist/components/dialog/index.js"

--- a/projects/swimlane/swim-ui/src/components/button-group/button-group.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/button-group/button-group.styles.ts
@@ -11,23 +11,23 @@ export const buttonGroupStyles = css`
     position: relative;
     box-sizing: border-box;
 
-    /* Default colors - slotted buttons inherit via --button-* (swim-button uses these with fallbacks) */
-    --button-bg: var(--grey-600);
-    --button-border: var(--grey-600);
-    --button-text: var(--white);
-    --button-hover: var(--grey-700);
+    /* Default colors - slotted swim-button inherits via --swim-button-* */
+    --swim-button-background: var(--grey-600);
+    --swim-button-border-color: var(--grey-600);
+    --swim-button-color: var(--white);
+    --swim-button-hover-background: var(--grey-700);
   }
 
   :host([button-group-style='primary']) {
-    --button-bg: var(--blue-400);
-    --button-border: var(--blue-400);
-    --button-text: var(--white);
-    --button-hover: var(--blue-500);
+    --swim-button-background: var(--blue-400);
+    --swim-button-border-color: var(--blue-400);
+    --swim-button-color: var(--white);
+    --swim-button-hover-background: var(--blue-500);
   }
 
   /* Contained group: slotted buttons use group colors and no individual shadow */
   :host([variant='contained']) {
-    --button-shadow: none;
+    --swim-button-shadow: none;
   }
 
   /* Horizontal: align items */

--- a/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle-group.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle-group.component.ts
@@ -190,8 +190,8 @@ export class SwimButtonToggleGroup extends LitElement {
     this.dispatchEvent(
       new CustomEvent('value-change', {
         detail: newValue,
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle-group.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle-group.component.ts
@@ -2,7 +2,7 @@ import { LitElement, html, PropertyValues } from 'lit';
 import { property, state, query } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { buttonToggleGroupStyles } from './button-toggle-group.styles';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 import type { SwimButtonToggle } from './button-toggle.component';
 
 let nextId = 0;
@@ -67,7 +67,7 @@ export class SwimButtonToggleGroup extends LitElement {
   /**
    * Whether the entire group is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }

--- a/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle.component.ts
@@ -100,8 +100,9 @@ export class SwimButtonToggle extends LitElement {
     this.dispatchEvent(
       new CustomEvent('value-change', {
         detail: this.value,
-        bubbles: false,
-        composed: false
+        // Must bubble so swim-button-toggle-group (light-DOM parent) receives selection.
+        bubbles: true,
+        composed: true
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle.component.ts
@@ -100,8 +100,8 @@ export class SwimButtonToggle extends LitElement {
     this.dispatchEvent(
       new CustomEvent('value-change', {
         detail: this.value,
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button-toggle/button-toggle.component.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { buttonToggleStyles } from './button-toggle.styles';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 let nextId = 0;
 
@@ -48,7 +48,7 @@ export class SwimButtonToggle extends LitElement {
   /**
    * Whether this toggle is currently selected
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get checked(): boolean {
     return this._checked;
   }
@@ -65,7 +65,7 @@ export class SwimButtonToggle extends LitElement {
   /**
    * Whether the toggle is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }

--- a/projects/swimlane/swim-ui/src/components/button/button.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button/button.component.ts
@@ -3,7 +3,12 @@ import { property, state } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { buttonStyles } from './button.styles';
 import { ButtonState } from './button-state.enum';
-import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
+import {
+  coerceBooleanProperty,
+  coerceNumberProperty,
+  litBooleanAttrDefaultFalse,
+  litBooleanAttrDefaultTrue
+} from '../../utils/coerce';
 import '../icon/icon.component';
 
 const BUTTON_TAG = 'swim-button';
@@ -25,9 +30,16 @@ const BUTTON_TAG = 'swim-button';
  *   `--swim-button-hover-border-color`
  * - `--swim-button-color`, `--swim-button-hover-color` — label color; slotted children (e.g. swim-icon)
  *   inherit from the host, so these variables keep icons aligned with text
+ * - `--swim-button-in-progress-color` — foreground for `state='in-progress'` (loading text and button
+ *   `color`); defaults to `--swim-button-color` then the variant fallback
+ * - `--swim-button-loading-icon-color` — optional override for the in-progress spinner only; defaults
+ *   to `--swim-button-in-progress-color` then the same chain as label color
  * - `--swim-button-shadow` — box shadow (omitted on link / bordered unless set)
  * - `--swim-button-outline-color` — focus-visible ring color
  * - `--swim-button-hover-outline-color` — hover ring color (falls back to `--swim-button-hover-background` then variant default)
+ *
+ * Long labels wrap to multiple lines by default (`wrap-text` defaults to on). Set `wrap-text="false"`
+ * on the host for single-line truncation with an ellipsis in constrained widths.
  */
 export class SwimButton extends LitElement {
   static styles = [baseStyles, buttonStyles];
@@ -98,6 +110,13 @@ export class SwimButton extends LitElement {
    */
   @property({ type: String, attribute: 'loading-text' })
   loadingText = '';
+
+  /**
+   * When true (default), the default slot label may wrap to multiple lines. When false, overflow
+   * is truncated with an ellipsis in constrained widths (`wrap-text="false"` in HTML).
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'wrap-text', converter: litBooleanAttrDefaultTrue })
+  wrapText = true;
 
   /**
    * Promise to track - automatically updates state based on promise resolution

--- a/projects/swimlane/swim-ui/src/components/button/button.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button/button.component.ts
@@ -25,6 +25,7 @@ const BUTTON_TAG = 'swim-button';
  * Hosts can tune the inner button via CSS custom properties on `swim-button` (or an ancestor).
  * These apply for every `variant` (they override the variant’s built-in defaults):
  * - `--swim-button-padding` — padding (default `0.35em 0.55em`)
+ * - `--swim-button-font-weight` — label font weight (default `--font-weight-bold`)
  * - `--swim-button-background`, `--swim-button-hover-background`
  * - `--swim-button-border-width`, `--swim-button-border-style`, `--swim-button-border-color`,
  *   `--swim-button-hover-border-color`

--- a/projects/swimlane/swim-ui/src/components/button/button.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button/button.component.ts
@@ -11,11 +11,23 @@ const BUTTON_TAG = 'swim-button';
 /**
  * SwimButton - A button component matching @swimlane/ngx-ui design system
  *
- * @slot - Button content
+ * @slot - Button content (hidden visually while `state` is in-progress, success, or fail; use `loading-text` for an in-progress label)
  *
  * @fires click - Native click event (when not disabled or in progress)
  *
  * @csspart button - The native button element
+ *
+ * Hosts can tune the inner button via CSS custom properties on `swim-button` (or an ancestor).
+ * These apply for every `variant` (they override the variant’s built-in defaults):
+ * - `--swim-button-padding` — padding (default `0.35em 0.55em`)
+ * - `--swim-button-background`, `--swim-button-hover-background`
+ * - `--swim-button-border-width`, `--swim-button-border-style`, `--swim-button-border-color`,
+ *   `--swim-button-hover-border-color`
+ * - `--swim-button-color`, `--swim-button-hover-color` — label color; slotted children (e.g. swim-icon)
+ *   inherit from the host, so these variables keep icons aligned with text
+ * - `--swim-button-shadow` — box shadow (omitted on link / bordered unless set)
+ * - `--swim-button-outline-color` — focus-visible ring color
+ * - `--swim-button-hover-outline-color` — hover ring color (falls back to `--swim-button-hover-background` then variant default)
  */
 export class SwimButton extends LitElement {
   static styles = [baseStyles, buttonStyles];
@@ -81,6 +93,13 @@ export class SwimButton extends LitElement {
   private _timeout: number | undefined;
 
   /**
+   * Text shown while `state` is in-progress. Default slot content stays hidden during
+   * loading (same as ngx-ui); set this to surface a visible loading label next to the spinner.
+   */
+  @property({ type: String, attribute: 'loading-text' })
+  loadingText = '';
+
+  /**
    * Promise to track - automatically updates state based on promise resolution
    */
   @property({ attribute: false })
@@ -121,8 +140,14 @@ export class SwimButton extends LitElement {
 
   render() {
     return html`
-      <button part="button" type="button" ?disabled="${this.disabled}" @click="${this._handleClick}">
-        <span class="content">
+      <button
+        part="button"
+        type="button"
+        ?disabled="${this.disabled}"
+        ?aria-busy="${this._inProgress}"
+        @click="${this._handleClick}"
+      >
+        <span class="content" ?aria-hidden="${this._inProgress || this._success || this._fail}">
           <slot></slot>
         </span>
         <span class="state-icon">${this._renderStateIcon()}</span>
@@ -132,7 +157,12 @@ export class SwimButton extends LitElement {
 
   private _renderStateIcon() {
     if (this._inProgress) {
-      return html`<swim-icon class="state-icon" font-icon="loading"></swim-icon>`;
+      return html`
+        <span class="state-icon-group">
+          <swim-icon class="icon" font-icon="loading"></swim-icon>
+          ${this.loadingText ? html`<span class="state-loading-text">${this.loadingText}</span>` : nothing}
+        </span>
+      `;
     }
     if (this._success) {
       return html`<swim-icon class="state-icon" font-icon="check"></swim-icon>`;

--- a/projects/swimlane/swim-ui/src/components/button/button.component.ts
+++ b/projects/swimlane/swim-ui/src/components/button/button.component.ts
@@ -3,7 +3,7 @@ import { property, state } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { buttonStyles } from './button.styles';
 import { ButtonState } from './button-state.enum';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 import '../icon/icon.component';
 
 const BUTTON_TAG = 'swim-button';
@@ -38,7 +38,7 @@ export class SwimButton extends LitElement {
   /**
    * Whether the button is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }

--- a/projects/swimlane/swim-ui/src/components/button/button.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/button/button.styles.ts
@@ -119,7 +119,7 @@ export const buttonStyles = css`
     user-select: none;
     font: inherit;
     font-size: var(--font-size-m);
-    font-weight: var(--font-weight-bold);
+    font-weight: var(--swim-button-font-weight, var(--font-weight-bold));
     outline: none;
     line-height: var(--font-line-height-100);
     outline-offset: 2px;

--- a/projects/swimlane/swim-ui/src/components/button/button.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/button/button.styles.ts
@@ -2,11 +2,94 @@ import { css } from 'lit';
 
 /**
  * Button styles matching @swimlane/ngx-ui design system
+ *
+ * Variant appearance is driven by `--_swim-fallback-*` on :host (private).
+ * Host-facing `--swim-button-*` always take precedence in the inner `button` rules.
  */
 export const buttonStyles = css`
   :host {
     display: inline-block;
     cursor: pointer;
+
+    /* Private fallbacks — overridden per [variant] with higher specificity */
+    --_swim-fallback-bg: var(--grey-600);
+    --_swim-fallback-hover-bg: var(--grey-700);
+    --_swim-fallback-border-color: transparent;
+    --_swim-fallback-hover-border-color: transparent;
+    --_swim-fallback-color: var(--white);
+    --_swim-fallback-hover-color: var(--white);
+    --_swim-fallback-shadow: var(--shadow-1);
+    --_swim-fallback-outline: var(--grey-600);
+
+    /* Slotted nodes (e.g. swim-icon) inherit color from this host, not from the shadow button. */
+    color: var(--swim-button-color, var(--_swim-fallback-color));
+  }
+
+  :host([variant='primary']:not([bordered])) {
+    --_swim-fallback-bg: var(--blue-400);
+    --_swim-fallback-hover-bg: var(--blue-500);
+    --_swim-fallback-border-color: var(--blue-400);
+    --_swim-fallback-hover-border-color: var(--blue-500);
+    --_swim-fallback-color: var(--white);
+    --_swim-fallback-hover-color: var(--white);
+    --_swim-fallback-outline: var(--blue-500);
+  }
+
+  :host([variant='primary'][bordered]) {
+    --_swim-fallback-bg: transparent;
+    --_swim-fallback-hover-bg: var(--blue-500);
+    --_swim-fallback-border-color: var(--blue-400);
+    --_swim-fallback-hover-border-color: var(--blue-200);
+    --_swim-fallback-color: var(--blue-400);
+    --_swim-fallback-hover-color: var(--blue-200);
+    --_swim-fallback-shadow: none;
+    --_swim-fallback-outline: var(--blue-400);
+  }
+
+  :host([variant='bordered']) {
+    --_swim-fallback-bg: transparent;
+    --_swim-fallback-hover-bg: transparent;
+    --_swim-fallback-border-color: var(--blue-400);
+    --_swim-fallback-hover-border-color: var(--blue-200);
+    --_swim-fallback-color: var(--blue-400);
+    --_swim-fallback-hover-color: var(--blue-200);
+    --_swim-fallback-shadow: none;
+    --_swim-fallback-outline: var(--blue-400);
+  }
+
+  :host([variant='warning']) {
+    --_swim-fallback-bg: var(--orange-400);
+    --_swim-fallback-hover-bg: var(--orange-500);
+    --_swim-fallback-border-color: transparent;
+    --_swim-fallback-hover-border-color: transparent;
+    --_swim-fallback-color: var(--grey-900);
+    --_swim-fallback-hover-color: var(--grey-900);
+    --_swim-fallback-outline: var(--orange-500);
+  }
+
+  :host([variant='danger']) {
+    --_swim-fallback-bg: var(--red-400);
+    --_swim-fallback-hover-bg: var(--red-500);
+    --_swim-fallback-border-color: transparent;
+    --_swim-fallback-hover-border-color: transparent;
+    --_swim-fallback-color: var(--white);
+    --_swim-fallback-hover-color: var(--white);
+    --_swim-fallback-outline: var(--red-400);
+  }
+
+  :host([variant='link']) {
+    --_swim-fallback-bg: transparent;
+    --_swim-fallback-hover-bg: transparent;
+    --_swim-fallback-border-color: transparent;
+    --_swim-fallback-hover-border-color: transparent;
+    --_swim-fallback-color: var(--white);
+    --_swim-fallback-hover-color: var(--white);
+    --_swim-fallback-shadow: none;
+    --_swim-fallback-outline: var(--grey-600);
+  }
+
+  :host(:not([disabled]):hover) {
+    color: var(--swim-button-hover-color, var(--_swim-fallback-hover-color));
   }
 
   :host([disabled]) {
@@ -21,9 +104,13 @@ export const buttonStyles = css`
 
   button {
     box-sizing: border-box;
-    color: var(--button-text, var(--white));
-    display: inline-block;
-    padding: 0.35em 0.55em;
+    color: var(--swim-button-color, var(--_swim-fallback-color));
+    display: inline-grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+    justify-items: stretch;
+    align-items: center;
+    padding: var(--swim-button-padding, 0.35em 0.55em);
     position: relative;
     text-align: center;
     text-decoration: none;
@@ -37,11 +124,12 @@ export const buttonStyles = css`
     cursor: inherit;
     width: 100%;
 
-    background: var(--button-bg, var(--grey-600));
-    border: solid 1px transparent;
-    border-color: var(--button-border, transparent);
+    background: var(--swim-button-background, var(--_swim-fallback-bg));
+    border-width: var(--swim-button-border-width, 1px);
+    border-style: var(--swim-button-border-style, solid);
+    border-color: var(--swim-button-border-color, var(--_swim-fallback-border-color));
     border-radius: var(--radius-4);
-    box-shadow: var(--button-shadow, var(--shadow-1));
+    box-shadow: var(--swim-button-shadow, var(--_swim-fallback-shadow));
     transition: background-color 200ms, box-shadow 200ms;
     text-shadow: 1px 1px rgba(0, 0, 0, 0.07);
   }
@@ -52,14 +140,19 @@ export const buttonStyles = css`
   }
 
   button:focus-visible {
-    outline: 2px solid var(--grey-600);
+    outline: 2px solid var(--swim-button-outline-color, var(--_swim-fallback-outline));
   }
 
-  /* Hover states (--button-hover set by swim-button-group when used inside a group) */
+  /* One hover layer so generic grey hover never leaks into bordered / link / etc. */
   :host(:not([disabled])) button:hover {
     cursor: pointer;
-    background: var(--button-hover, var(--grey-700));
-    outline-color: var(--button-hover, var(--grey-700));
+    background: var(--swim-button-hover-background, var(--_swim-fallback-hover-bg));
+    border-color: var(--swim-button-hover-border-color, var(--_swim-fallback-hover-border-color));
+    color: var(--swim-button-hover-color, var(--_swim-fallback-hover-color));
+    outline-color: var(
+      --swim-button-hover-outline-color,
+      var(--swim-button-hover-background, var(--_swim-fallback-hover-bg))
+    );
   }
 
   /* Size variants */
@@ -71,85 +164,14 @@ export const buttonStyles = css`
     font-size: 1.3em;
   }
 
-  /* Variant: Primary (--button-* overrides when inside swim-button-group) */
-  :host([variant='primary']) button {
-    background-color: var(--button-bg, var(--blue-400));
-    border-color: var(--button-border, var(--blue-400));
-    color: var(--button-text, var(--white));
-    outline-color: var(--button-border, var(--blue-500));
+  /* Icon-only: slotted swim-icon uses 1em — inherit the button font-size for small/large parity */
+  slot::slotted(swim-icon) {
+    font-size: inherit;
   }
 
-  :host([variant='primary']) button:focus-visible {
-    outline-color: var(--button-border, var(--blue-500));
-  }
-
-  :host([variant='primary']:not([disabled])) button:hover {
-    background-color: var(--button-hover, var(--blue-500));
-    border-color: var(--button-hover, var(--blue-500));
-  }
-
-  /* Variant: Warning */
-  :host([variant='warning']) button {
-    background-color: var(--orange-400);
-    color: var(--grey-900);
-    outline-color: var(--orange-500);
-  }
-
-  :host([variant='warning']) button:focus-visible {
-    outline-color: var(--orange-500);
-  }
-
-  :host([variant='warning']:not([disabled])) button:hover {
-    background-color: var(--orange-500);
-  }
-
-  /* Variant: Danger */
-  :host([variant='danger']) button {
-    background-color: var(--red-400);
-    outline-color: var(--red-400);
-  }
-
-  :host([variant='danger']) button:focus-visible {
-    outline-color: var(--red-400);
-  }
-
-  :host([variant='danger']:not([disabled])) button:hover {
-    background-color: var(--red-500);
-  }
-
-  /* Variant: Link */
-  :host([variant='link']) button {
-    background-color: transparent;
-    box-shadow: none;
-  }
-
-  :host([variant='link']:not([disabled])) button:hover {
-    background-color: transparent;
-  }
-
-  /* Variant: Bordered */
-  :host([variant='bordered']) button,
-  :host([variant='primary'][bordered]) button {
-    border: 1px solid var(--blue-400);
-    color: var(--blue-400);
-    background-color: transparent;
-    box-shadow: none;
-    outline-color: var(--blue-400);
-  }
-
-  :host([variant='bordered']) button:focus-visible,
-  :host([variant='primary'][bordered]) button:focus-visible {
-    outline-color: var(--blue-400);
-  }
-
-  :host([variant='bordered']:not([disabled])) button:hover,
-  :host([variant='primary'][bordered]:not([disabled])) button:hover {
-    border-color: var(--blue-200);
-    color: var(--blue-200);
-  }
-
-  /* Button content and state icon container */
+  /* Button content and state icon: same grid cell so intrinsic width is max(label, state) */
   .content {
+    grid-area: 1 / 1;
     text-overflow: ellipsis;
     overflow-x: clip;
     overflow-y: visible;
@@ -160,13 +182,28 @@ export const buttonStyles = css`
   }
 
   .state-icon {
-    position: absolute;
-    inset: 0;
+    grid-area: 1 / 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    justify-self: center;
+    width: max-content;
+    box-sizing: border-box;
     opacity: 0;
     pointer-events: none;
+  }
+
+  .state-icon-group {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35em;
+    box-sizing: border-box;
+    padding: 0 0.35em;
+  }
+
+  .state-loading-text {
+    white-space: nowrap;
   }
 
   /* State: In Progress */

--- a/projects/swimlane/swim-ui/src/components/button/button.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/button/button.styles.ts
@@ -10,6 +10,8 @@ export const buttonStyles = css`
   :host {
     display: inline-block;
     cursor: pointer;
+    /* Allow constrained layouts (flex/grid) to shrink below label intrinsic width so ellipsis can apply */
+    min-width: 0;
 
     /* Private fallbacks — overridden per [variant] with higher specificity */
     --_swim-fallback-bg: var(--grey-600);
@@ -123,6 +125,7 @@ export const buttonStyles = css`
     outline-offset: 2px;
     cursor: inherit;
     width: 100%;
+    min-width: 0;
 
     background: var(--swim-button-background, var(--_swim-fallback-bg));
     border-width: var(--swim-button-border-width, 1px);
@@ -172,13 +175,25 @@ export const buttonStyles = css`
   /* Button content and state icon: same grid cell so intrinsic width is max(label, state) */
   .content {
     grid-area: 1 / 1;
-    text-overflow: ellipsis;
-    overflow-x: clip;
-    overflow-y: visible;
+    min-width: 0;
+    max-width: 100%;
     width: 100%;
     display: block;
-    white-space: nowrap;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
     transition: opacity 0.25s ease-out;
+  }
+
+  /* Single-line + ellipsis: wrap-text="false" (wrap-text attribute omitted when wrapping is on) */
+  :host([wrap-text='false']) .content {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-wrap: normal;
+    overflow-wrap: normal;
   }
 
   .state-icon {
@@ -216,6 +231,10 @@ export const buttonStyles = css`
   :host([state='in-progress']) button {
     opacity: 1;
     pointer-events: none;
+    /* Loading + host disabled: UA button:disabled grays out inherited color (hurts loading-text).
+ Re-apply variant foreground; !important aligns with ngx-ui .in-progress vs. UA.
+ Override with --swim-button-in-progress-color on :host. */
+    color: var(--swim-button-in-progress-color, var(--swim-button-color, var(--_swim-fallback-color))) !important;
   }
 
   :host([state='in-progress']) .content {
@@ -224,6 +243,14 @@ export const buttonStyles = css`
 
   :host([state='in-progress']) .state-icon {
     opacity: 1;
+  }
+
+  /* Loading glyph: same var chain as in-progress button color (explicit so it does not rely on currentColor / stale builds). */
+  :host([state='in-progress']) swim-icon.icon {
+    color: var(
+      --swim-button-loading-icon-color,
+      var(--swim-button-in-progress-color, var(--swim-button-color, var(--_swim-fallback-color)))
+    );
   }
 
   /* State: Success */
@@ -270,12 +297,11 @@ export const buttonStyles = css`
     color: var(--white);
   }
 
-  /* Icon styles */
+  /* Loading swim-icon sizing (color set on :host([state='in-progress']) swim-icon.icon) */
   .icon {
     height: 1em;
     width: 1em;
     font-weight: var(--font-weight-bold);
-    color: var(--white);
     overflow: hidden;
     font-size: var(--font-size-m);
     display: inline-block;

--- a/projects/swimlane/swim-ui/src/components/button/button.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/button/button.styles.ts
@@ -167,9 +167,12 @@ export const buttonStyles = css`
     font-size: 1.3em;
   }
 
-  /* Icon-only: slotted swim-icon uses 1em — inherit the button font-size for small/large parity */
+  /* Slotted swim-icon: 1em sizing + vertical center with label text (flex on .content). */
   slot::slotted(swim-icon) {
     font-size: inherit;
+    flex-shrink: 0;
+    align-self: center;
+    line-height: 1;
   }
 
   /* Button content and state icon: same grid cell so intrinsic width is max(label, state) */
@@ -178,7 +181,10 @@ export const buttonStyles = css`
     min-width: 0;
     max-width: 100%;
     width: 100%;
-    display: block;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
     white-space: normal;
     overflow: visible;
     text-overflow: clip;
@@ -189,6 +195,7 @@ export const buttonStyles = css`
 
   /* Single-line + ellipsis: wrap-text="false" (wrap-text attribute omitted when wrapping is on) */
   :host([wrap-text='false']) .content {
+    flex-wrap: nowrap;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/projects/swimlane/swim-ui/src/components/calendar/calendar.component.ts
+++ b/projects/swimlane/swim-ui/src/components/calendar/calendar.component.ts
@@ -472,7 +472,7 @@ export class SwimCalendar extends LitElement {
     }
 
     this.requestUpdate();
-    this.dispatchEvent(new CustomEvent('change', { detail: this._value, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('change', { detail: this._value, bubbles: false, composed: false }));
   }
 
   private _onMonthClick(month: number): void {
@@ -487,7 +487,7 @@ export class SwimCalendar extends LitElement {
     }
 
     this.requestUpdate();
-    this.dispatchEvent(new CustomEvent('change', { detail: this._value, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('change', { detail: this._value, bubbles: false, composed: false }));
   }
 
   private _onYearClick(year: number): void {
@@ -502,7 +502,7 @@ export class SwimCalendar extends LitElement {
     }
 
     this.requestUpdate();
-    this.dispatchEvent(new CustomEvent('change', { detail: this._value, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('change', { detail: this._value, bubbles: false, composed: false }));
   }
 
   // ---------------------------------------------------------------------------
@@ -595,7 +595,7 @@ export class SwimCalendar extends LitElement {
       }
       case 'Enter':
         setTimeout(() => {
-          this.dispatchEvent(new CustomEvent('day-key-enter', { bubbles: true, composed: true }));
+          this.dispatchEvent(new CustomEvent('day-key-enter', { bubbles: false, composed: false }));
         }, 200);
         break;
     }
@@ -635,7 +635,7 @@ export class SwimCalendar extends LitElement {
         break;
       case 'Enter':
         setTimeout(() => {
-          this.dispatchEvent(new CustomEvent('day-key-enter', { bubbles: true, composed: true }));
+          this.dispatchEvent(new CustomEvent('day-key-enter', { bubbles: false, composed: false }));
         }, 200);
         break;
     }
@@ -674,7 +674,7 @@ export class SwimCalendar extends LitElement {
         break;
       case 'Enter':
         setTimeout(() => {
-          this.dispatchEvent(new CustomEvent('day-key-enter', { bubbles: true, composed: true }));
+          this.dispatchEvent(new CustomEvent('day-key-enter', { bubbles: false, composed: false }));
         }, 200);
         break;
     }

--- a/projects/swimlane/swim-ui/src/components/calendar/calendar.component.ts
+++ b/projects/swimlane/swim-ui/src/components/calendar/calendar.component.ts
@@ -15,6 +15,7 @@ import {
 } from './calendar-utils';
 import type { CalendarMonth } from './calendar-utils';
 import { parseDate, isValidDate } from '../date-time/date-format';
+import { litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 /**
  * Calendar view modes.
@@ -67,7 +68,7 @@ export class SwimCalendar extends LitElement {
   maxDate?: string | Date;
 
   /** Whether the calendar is disabled. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   disabled = false;
 
   /** IANA timezone name. */

--- a/projects/swimlane/swim-ui/src/components/card/card-avatar.component.ts
+++ b/projects/swimlane/swim-ui/src/components/card/card-avatar.component.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
+import { litBooleanAttrDefaultFalse } from '../../utils/coerce';
 import { cardAvatarComponentStyles } from './card-avatar.styles';
 import { CardStatus } from './card-status.enum';
 
@@ -21,7 +22,7 @@ export class SwimCardAvatar extends LitElement {
   status?: CardStatus | 'success' | 'error' | 'disabled';
 
   /** When true, image has transparent background instead of white. */
-  @property({ type: Boolean, attribute: 'remove-image-background' })
+  @property({ type: Boolean, attribute: 'remove-image-background', converter: litBooleanAttrDefaultFalse })
   removeImageBackground = false;
 
   render() {

--- a/projects/swimlane/swim-ui/src/components/card/card.component.ts
+++ b/projects/swimlane/swim-ui/src/components/card/card.component.ts
@@ -12,8 +12,8 @@ import '../checkbox/checkbox.component';
  *
  * @slot - Default slot for card content (header, sections, body, footer).
  *
- * @fires select - Fired when the selectable checkbox is toggled (detail: boolean selected).
- * @fires outline-click - Fired when the outline text label is clicked.
+ * @fires select - Fired when the selectable checkbox is toggled (detail: boolean selected). Does not bubble.
+ * @fires outline-click - Fired when the outline text label is clicked. Does not bubble.
  *
  * @csspart outline-text - The clickable outline text inner element (when outlineText is set).
  */
@@ -93,7 +93,7 @@ export class SwimCard extends LitElement {
 
   private _onOutlineClick(e: Event) {
     e.stopPropagation();
-    this.dispatchEvent(new CustomEvent('outline-click', { bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('outline-click', { bubbles: false, composed: false }));
   }
 
   private _onSelectChange(e: CustomEvent) {
@@ -103,8 +103,8 @@ export class SwimCard extends LitElement {
     this.dispatchEvent(
       new CustomEvent('select', {
         detail: this.selected,
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/card/card.component.ts
+++ b/projects/swimlane/swim-ui/src/components/card/card.component.ts
@@ -4,7 +4,7 @@ import { cardComponentStyles } from './card.styles';
 import { CardStatus } from './card-status.enum';
 import { CardOrientation } from './card-orientation.enum';
 import { CardAppearance } from './card-appearance.enum';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 import '../checkbox/checkbox.component';
 
 /**
@@ -22,7 +22,7 @@ export class SwimCard extends LitElement {
   static styles = cardComponentStyles;
 
   /** When true, card is non-interactive. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -44,7 +44,7 @@ export class SwimCard extends LitElement {
   statusTooltip = '';
 
   /** When true, shows a checkbox to select the card. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get selectable(): boolean {
     return this._selectable;
   }
@@ -54,7 +54,7 @@ export class SwimCard extends LitElement {
   private _selectable = false;
 
   /** When true (and selectable), card appears selected. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get selected(): boolean {
     return this._selected;
   }
@@ -64,7 +64,7 @@ export class SwimCard extends LitElement {
   private _selected = false;
 
   /** When true, outline and outline text use error color. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get error(): boolean {
     return this._error;
   }
@@ -82,7 +82,7 @@ export class SwimCard extends LitElement {
   appearance: CardAppearance | 'normal' | 'flat' = CardAppearance.Normal;
 
   /** When true, the accent bar is hidden. */
-  @property({ type: Boolean, attribute: 'hide-accent' })
+  @property({ type: Boolean, attribute: 'hide-accent', converter: litBooleanAttrDefaultFalse })
   get hideAccent(): boolean {
     return this._hideAccent;
   }

--- a/projects/swimlane/swim-ui/src/components/checkbox/checkbox.component.ts
+++ b/projects/swimlane/swim-ui/src/components/checkbox/checkbox.component.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { checkboxStyles } from './checkbox.styles';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 let nextId = 0;
 
@@ -51,7 +51,7 @@ export class SwimCheckbox extends LitElement {
   /**
    * Checked state (alias: value from ngx-ui)
    */
-  @property({ type: Boolean, reflect: true, attribute: 'checked' })
+  @property({ type: Boolean, reflect: true, attribute: 'checked', converter: litBooleanAttrDefaultFalse })
   get checked(): boolean {
     return this._checked;
   }
@@ -67,7 +67,7 @@ export class SwimCheckbox extends LitElement {
   /**
    * Indeterminate state (e.g. "select all" partial state)
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get indeterminate(): boolean {
     return this._indeterminate;
   }
@@ -100,7 +100,7 @@ export class SwimCheckbox extends LitElement {
   /**
    * Whether the checkbox is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -112,7 +112,7 @@ export class SwimCheckbox extends LitElement {
   /**
    * Use round (circular) box instead of square
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get round(): boolean {
     return this._round;
   }

--- a/projects/swimlane/swim-ui/src/components/checkbox/checkbox.component.ts
+++ b/projects/swimlane/swim-ui/src/components/checkbox/checkbox.component.ts
@@ -60,7 +60,7 @@ export class SwimCheckbox extends LitElement {
     if (this._checked === next) return;
     this._checked = next;
     this._syncFormValue();
-    this.dispatchEvent(new CustomEvent('checked-change', { detail: this._checked, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('checked-change', { detail: this._checked, bubbles: false, composed: false }));
   }
   private _checked = false;
 
@@ -78,8 +78,8 @@ export class SwimCheckbox extends LitElement {
     this.dispatchEvent(
       new CustomEvent('indeterminate-change', {
         detail: this._indeterminate,
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }
@@ -173,18 +173,18 @@ export class SwimCheckbox extends LitElement {
           timeStamp: Date.now(),
           target: { checked: this._checked }
         },
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }
 
   private _onFocus(ev: FocusEvent) {
-    this.dispatchEvent(new FocusEvent('focus', { ...ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('focus', { ...ev, bubbles: false, composed: false }));
   }
 
   private _onBlur(ev: FocusEvent) {
-    this.dispatchEvent(new FocusEvent('blur', { ...ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('blur', { ...ev, bubbles: false, composed: false }));
   }
 
   render() {

--- a/projects/swimlane/swim-ui/src/components/date-display/date-display.component.ts
+++ b/projects/swimlane/swim-ui/src/components/date-display/date-display.component.ts
@@ -1,0 +1,422 @@
+import { LitElement, html, nothing, PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { baseStyles } from '../../styles/base';
+import { dateDisplayStyles } from './date-display.styles';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
+import {
+  formatDate,
+  parseDate,
+  isValidDate,
+  roundToPrecision,
+  resolveFormat,
+  getEffectiveDisplayFormat,
+  getEffectiveInputFormat,
+  normalizeTimezone
+} from '../date-time/date-format';
+import { DateDisplayType } from '../date-time/date-time-display.enum';
+import { DateTimeType } from '../date-time/date-time-type.enum';
+import '../tooltip/tooltip.component';
+import '../button/button.component';
+import '../icon/icon.component';
+import { PlacementType } from '../tooltip/placement-type.enum';
+import { StyleType } from '../tooltip/style-type.enum';
+
+const TAG = 'swim-date-display';
+
+/** Sentinel: `clickable` attribute omitted — use ngx-style default from timezones / default-copy-key. */
+const CLICKABLE_AUTO = Symbol('swim-date-display-clickable-auto');
+
+function guessTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+function formatRelativeTime(date: Date): string {
+  const diffSec = Math.round((date.getTime() - Date.now()) / 1000);
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+  const diffMin = Math.round(diffSec / 60);
+  if (Math.abs(diffSec) < 60) return rtf.format(diffSec, 'second');
+  const diffHour = Math.round(diffMin / 60);
+  if (Math.abs(diffMin) < 60) return rtf.format(diffMin, 'minute');
+  const diffDay = Math.round(diffHour / 24);
+  if (Math.abs(diffHour) < 24) return rtf.format(diffHour, 'hour');
+  const diffWeek = Math.round(diffDay / 7);
+  if (Math.abs(diffDay) < 7) return rtf.format(diffDay, 'day');
+  if (Math.abs(diffWeek) < 5) return rtf.format(diffWeek, 'week');
+  const diffMonth = Math.round(diffDay / 30);
+  if (Math.abs(diffMonth) < 12) return rtf.format(diffMonth, 'month');
+  const diffYear = Math.round(diffDay / 365);
+  return rtf.format(diffYear, 'year');
+}
+
+function resolveInputDate(datelike: string | Date | undefined | null): Date | null {
+  if (datelike == null) return null;
+  if (datelike instanceof Date) return isValidDate(datelike) ? datelike : null;
+  return parseDate(datelike);
+}
+
+function normalizeDisplayMode(mode: string | undefined): DateDisplayType {
+  const v = (mode ?? '').toLowerCase();
+  if (v === DateDisplayType.HUMAN) return DateDisplayType.HUMAN;
+  if (v === DateDisplayType.LOCAL) return DateDisplayType.LOCAL;
+  if (v === DateDisplayType.CUSTOM) return DateDisplayType.CUSTOM;
+  return DateDisplayType.TIMEZONE;
+}
+
+function normalizeDateTimeType(type: string | undefined): DateTimeType {
+  const v = (type ?? '').toLowerCase();
+  if (v === DateTimeType.date) return DateTimeType.date;
+  if (v === DateTimeType.time) return DateTimeType.time;
+  return DateTimeType.datetime;
+}
+
+export type ZoneValue = { key: string; clip: string; display: string };
+
+/**
+ * SwimDateDisplay — read-only date/time text with optional multi-zone tooltip and clipboard copy,
+ * matching **ngx-time** (`ngx-time` / time-display) from @swimlane/ngx-ui.
+ *
+ * @slot - Not used (text is generated from `datetime`).
+ *
+ * @fires date-copied - Fired after a timezone string is copied (`bubbles: true`, `composed: true`).
+ *   `detail`: `{ key: string, clip: string, message: string }`.
+ *
+ * @csspart - None (inner `<time>` is not part-exposed).
+ */
+@customElement(TAG)
+export class SwimDateDisplay extends LitElement {
+  static styles = [baseStyles, dateDisplayStyles];
+
+  @property({ attribute: 'datetime' })
+  datetime: string | Date | undefined;
+
+  @property({ type: String })
+  precision?: string;
+
+  @property({ type: String, reflect: true })
+  timezone = '';
+
+  @property({ type: String, attribute: 'default-input-time-zone' })
+  defaultInputTimeZone = '';
+
+  @property({ type: String, reflect: true })
+  mode = DateDisplayType.TIMEZONE;
+
+  @property({ type: String, reflect: true })
+  type = DateTimeType.datetime;
+
+  @property({ type: String })
+  format = '';
+
+  @property({ type: String, attribute: 'tooltip-format' })
+  tooltipFormat = '';
+
+  @property({ type: String, attribute: 'clip-format' })
+  clipFormat = '';
+
+  private _timezones: Record<string, string> = {
+    UTC: 'Etc/UTC',
+    Local: ''
+  };
+
+  @property({ type: Object, attribute: 'timezones' })
+  get timezones(): Record<string, string> {
+    return this._timezones;
+  }
+  set timezones(val: Record<string, string> | null | undefined) {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      this._timezones = val;
+    }
+  }
+
+  @property({ type: Boolean, reflect: true, attribute: 'tooltip-disabled', converter: litBooleanAttrDefaultFalse })
+  get tooltipDisabled(): boolean {
+    return this._tooltipDisabled;
+  }
+  set tooltipDisabled(v: boolean) {
+    this._tooltipDisabled = coerceBooleanProperty(v);
+  }
+  private _tooltipDisabled = false;
+
+  @property({ type: String, attribute: 'tooltip-css-class' })
+  tooltipCssClass = 'date-tip-tooltip swim-date-display-tip';
+
+  @property({ type: String, attribute: 'tooltip-placement' })
+  tooltipPlacement: PlacementType | string = PlacementType.top;
+
+  @property({ type: String, attribute: 'default-copy-key' })
+  defaultCopyKey = 'Local';
+
+  @property({ type: String, attribute: 'invalid-date-message' })
+  invalidDateMessage = 'Invalid date';
+
+  @property({
+    attribute: 'clickable',
+    reflect: true,
+    converter: {
+      fromAttribute(value: string | null): boolean | symbol {
+        if (value === null) return CLICKABLE_AUTO;
+        return value !== 'false';
+      },
+      toAttribute(value: boolean | symbol): string | null {
+        if (value === CLICKABLE_AUTO) return null;
+        return value ? '' : 'false';
+      }
+    }
+  })
+  clickable: boolean | symbol = CLICKABLE_AUTO;
+
+  @state() private _displayText = '';
+  @state() private _dateInvalid = true;
+  @state() private _utcDatetimeAttr = '';
+  @state() private _zoneList: ZoneValue[] = [];
+  @state() private _rawDatetimeEcho = '';
+  @state() private _titleValue = '';
+
+  private _zoneValues: Record<string, ZoneValue> = {};
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._recompute();
+  }
+
+  protected willUpdate(cp: PropertyValues): void {
+    if (
+      cp.has('datetime') ||
+      cp.has('precision') ||
+      cp.has('timezone') ||
+      cp.has('defaultInputTimeZone') ||
+      cp.has('mode') ||
+      cp.has('type') ||
+      cp.has('format') ||
+      cp.has('tooltipFormat') ||
+      cp.has('clipFormat') ||
+      cp.has('timezones')
+    ) {
+      this._recompute();
+    }
+  }
+
+  private _effectiveTimezone(): string {
+    return normalizeTimezone(this.timezone) || guessTimeZone();
+  }
+
+  private _recompute(): void {
+    this._rawDatetimeEcho = typeof this.datetime === 'string' ? this.datetime : '';
+    this._zoneValues = {};
+    this._zoneList = [];
+    this._utcDatetimeAttr = '';
+    this._titleValue = '';
+    this._dateInvalid = true;
+    this._displayText = '';
+
+    if (this.datetime == null || this.datetime === '') {
+      return;
+    }
+
+    const parsed = resolveInputDate(this.datetime as string | Date);
+    if (!parsed) {
+      this._dateInvalid = true;
+      this._rawDatetimeEcho = String(this.datetime);
+      return;
+    }
+
+    const working = this.precision ? roundToPrecision(parsed, this.precision) : parsed;
+    const displayMode = normalizeDisplayMode(this.mode);
+    const inputType = normalizeDateTimeType(this.type);
+
+    const resolvedFormat =
+      (this.format && resolveFormat(this.format)) || getEffectiveDisplayFormat(displayMode, inputType, this.precision);
+    const resolvedTooltipFormat = (this.tooltipFormat && resolveFormat(this.tooltipFormat)) || resolvedFormat;
+    const resolvedClipFormat =
+      (this.clipFormat && resolveFormat(this.clipFormat)) ||
+      getEffectiveInputFormat(displayMode, inputType, this.precision);
+
+    const tzDisplay = this._effectiveTimezone();
+
+    this._dateInvalid = false;
+
+    if (displayMode === DateDisplayType.LOCAL) {
+      this._utcDatetimeAttr = formatDate(working, 'YYYY-MM-DD[T]HH:mm:ss.SSS', undefined);
+      this._displayText = formatDate(working, resolvedFormat, tzDisplay);
+      return;
+    }
+
+    this._utcDatetimeAttr = working.toISOString();
+
+    if (displayMode === DateDisplayType.HUMAN) {
+      this._displayText = formatRelativeTime(working);
+    } else {
+      this._displayText = formatDate(working, resolvedFormat, tzDisplay);
+    }
+
+    this._zoneValues = this._buildZoneValues(working, resolvedTooltipFormat, resolvedClipFormat);
+    this._zoneList = Object.keys(this.timezones)
+      .map(k => this._zoneValues[k])
+      .filter((v): v is ZoneValue => !!v);
+
+    this._titleValue = Object.keys(this.timezones)
+      .map(key => {
+        const z = this._zoneValues[key];
+        return z ? `${z.display} [${key}]` : '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private _buildZoneValues(instant: Date, tooltipFmt: string, clipFmt: string): Record<string, ZoneValue> {
+    const out: Record<string, ZoneValue> = {};
+    for (const key of Object.keys(this.timezones)) {
+      const tzRaw = this.timezones[key];
+      const tz = normalizeTimezone(tzRaw) || guessTimeZone();
+      out[key] = {
+        key,
+        clip: formatDate(instant, clipFmt, tz),
+        display: formatDate(instant, tooltipFmt, tz)
+      };
+    }
+    return out;
+  }
+
+  private get _displayMode(): DateDisplayType {
+    return normalizeDisplayMode(this.mode);
+  }
+
+  /** ngx `hasPopup`: underline + zone tooltip (non-local, valid). */
+  private get _hasPopup(): boolean {
+    return !this._dateInvalid && this._displayMode !== DateDisplayType.LOCAL;
+  }
+
+  private get _showTooltipPanel(): boolean {
+    return this._hasPopup && !this.tooltipDisabled;
+  }
+
+  private _effectiveClickable(): boolean {
+    if (this.clickable !== CLICKABLE_AUTO) {
+      return coerceBooleanProperty(this.clickable as boolean);
+    }
+    const v = this._zoneValues[this.defaultCopyKey];
+    return !!this.defaultCopyKey && !!v?.clip;
+  }
+
+  private _onTimeActivate(e: Event): void {
+    if (!this._effectiveClickable() || this._dateInvalid) return;
+    e.preventDefault();
+    e.stopPropagation();
+    void this._copyRow(this.defaultCopyKey);
+  }
+
+  private _onTimeKeyDown(e: KeyboardEvent): void {
+    if (!this._effectiveClickable() || this._dateInvalid) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      void this._copyRow(this.defaultCopyKey);
+    }
+  }
+
+  private async _copyRow(key: string): Promise<void> {
+    const row = this._zoneValues[key];
+    if (!row?.clip) return;
+    try {
+      await navigator.clipboard.writeText(row.clip);
+    } catch {
+      /* clipboard may be denied */
+    }
+    this.dispatchEvent(
+      new CustomEvent('date-copied', {
+        detail: { key, clip: row.clip, message: `${key} date copied to clipboard` },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  render() {
+    const invalid = this._dateInvalid;
+    const showPanel = this._showTooltipPanel;
+    const underline = this._hasPopup && !invalid;
+    const clickOn = this._effectiveClickable() && !invalid;
+    const nativeTitle = this.tooltipDisabled && underline && this._titleValue ? this._titleValue : '';
+
+    const timeClasses = [
+      'swim-date-display__time',
+      underline ? 'swim-date-display__time--popup' : '',
+      clickOn ? 'swim-date-display__time--clickable' : ''
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const timeTpl = html`
+      <time
+        class="${timeClasses}"
+        datetime="${ifDefined(invalid || !this._utcDatetimeAttr ? undefined : this._utcDatetimeAttr)}"
+        title="${nativeTitle}"
+        tabindex="${clickOn ? 0 : nothing}"
+        role="${clickOn ? 'button' : nothing}"
+        aria-invalid="${invalid ? 'true' : 'false'}"
+        @click="${this._onTimeActivate}"
+        @keydown="${this._onTimeKeyDown}"
+      >
+        ${invalid ? html`${this.invalidDateMessage} &quot;${this._rawDatetimeEcho}&quot;` : this._displayText}
+      </time>
+    `;
+
+    return html`
+      <div class="swim-date-display__root">
+        ${showPanel
+          ? html`
+              <swim-tooltip
+                type="${StyleType.popover}"
+                placement="${this.tooltipPlacement as PlacementType}"
+                css-class="${this.tooltipCssClass}"
+                show-timeout="400"
+                show-caret="true"
+              >
+                ${timeTpl}
+                <div slot="content" class="swim-date-display__tooltip-body">
+                  ${repeat(
+                    this._zoneList,
+                    z => z.key,
+                    z => html`
+                      <div class="swim-date-display__zone-row">
+                        <span class="swim-date-display__zone-label">${z.display}</span>
+                        <swim-button
+                          class="swim-date-display__copy-btn"
+                          variant="bordered"
+                          size="small"
+                          type="button"
+                          @click="${(e: Event) => {
+                            e.stopPropagation();
+                            void this._copyRow(z.key);
+                          }}"
+                        >
+                          <swim-icon font-icon="copy"></swim-icon>
+                          ${z.key}
+                        </swim-button>
+                      </div>
+                    `
+                  )}
+                </div>
+              </swim-tooltip>
+            `
+          : timeTpl}
+      </div>
+    `;
+  }
+
+  protected updated(_changed: PropertyValues): void {
+    super.updated(_changed);
+    this.toggleAttribute('invalid', this._dateInvalid);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [TAG]: SwimDateDisplay;
+  }
+}

--- a/projects/swimlane/swim-ui/src/components/date-display/date-display.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/date-display/date-display.styles.ts
@@ -1,0 +1,100 @@
+import { css } from 'lit';
+
+/**
+ * Styles for swim-date-display (read-only date/time presentation, ngx-time parity).
+ */
+export const dateDisplayStyles = css`
+  :host {
+    display: inline;
+    vertical-align: baseline;
+  }
+
+  .swim-date-display__root {
+    display: inline;
+  }
+
+  .swim-date-display__time {
+    display: inline;
+    margin: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    border: none;
+    background: transparent;
+    text-align: inherit;
+  }
+
+  :host([invalid]) .swim-date-display__time {
+    color: var(--red-500);
+  }
+
+  .swim-date-display__time--popup {
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+    text-decoration-thickness: from-font;
+    cursor: copy;
+    color: inherit;
+  }
+
+  .swim-date-display__time--clickable {
+    cursor: pointer;
+  }
+
+  .swim-date-display__time--clickable:active {
+    transform: translate(1px, 1px);
+    color: var(--grey-600);
+  }
+
+  .swim-date-display__time--clickable:focus-visible {
+    outline: 2px solid var(--blue-500);
+    outline-offset: 2px;
+    border-radius: var(--radius-2);
+  }
+
+  swim-tooltip {
+    display: inline;
+  }
+
+  /* Tooltip panel content (swim-tooltip exposes part="content") */
+  swim-tooltip::part(content) {
+    padding: var(--spacing-2);
+  }
+
+  .swim-date-display__zone-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-2);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-m);
+    color: var(--grey-800);
+    margin-bottom: var(--spacing-2);
+  }
+
+  .swim-date-display__zone-row:last-child {
+    margin-bottom: 0;
+  }
+
+  .swim-date-display__zone-label {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .swim-date-display__copy-btn {
+    flex: 0 0 auto;
+    text-transform: uppercase;
+    font-size: var(--font-size-xs);
+    line-height: 1.25;
+    min-width: 4.5rem;
+    width: 30px;
+    --swim-button-background: var(--grey-200);
+    --swim-button-hover-background: var(--white);
+    --swim-button-border-color: var(--grey-400);
+    --swim-button-hover-border-color: var(--grey-350);
+    --swim-button-color: var(--grey-700);
+    --swim-button-hover-color: var(--grey-800);
+    --swim-button-outline-color: var(--blue-500);
+    --swim-button-hover-outline-color: var(--blue-500);
+    --swim-button-shadow: none;
+  }
+`;

--- a/projects/swimlane/swim-ui/src/components/date-display/index.ts
+++ b/projects/swimlane/swim-ui/src/components/date-display/index.ts
@@ -1,0 +1,3 @@
+export { SwimDateDisplay } from './date-display.component';
+export { DateDisplayType } from '../date-time/date-time-display.enum';
+export { DateTimeType } from '../date-time/date-time-type.enum';

--- a/projects/swimlane/swim-ui/src/components/date-time/date-time.component.ts
+++ b/projects/swimlane/swim-ui/src/components/date-time/date-time.component.ts
@@ -9,7 +9,7 @@ import { baseStyles } from '../../styles/base';
 import { dateTimeStyles } from './date-time.styles';
 import { DateTimeType } from './date-time-type.enum';
 import { DateDisplayType } from './date-time-display.enum';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 import {
   formatDate,
   parseDate,
@@ -83,7 +83,7 @@ export class SwimDateTime extends LitElement {
   appearance: 'legacy' | 'fill' = 'legacy';
 
   /** Whether the component is disabled. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -95,7 +95,7 @@ export class SwimDateTime extends LitElement {
   private _disabled = false;
 
   /** Whether a value is required. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get required(): boolean {
     return this._required;
   }
@@ -111,7 +111,7 @@ export class SwimDateTime extends LitElement {
   requiredIndicator: string | boolean = '*';
 
   /** Auto-focus on mount. */
-  @property({ type: Boolean })
+  @property({ type: Boolean, converter: litBooleanAttrDefaultFalse })
   get autofocus(): boolean {
     return this._autofocus;
   }
@@ -121,7 +121,7 @@ export class SwimDateTime extends LitElement {
   private _autofocus = false;
 
   /** Auto-size the component width to content. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get autosize(): boolean {
     return this._autosize;
   }
@@ -183,7 +183,7 @@ export class SwimDateTime extends LitElement {
   format?: string;
 
   /** Remove default margins. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get marginless(): boolean {
     return this._marginless;
   }

--- a/projects/swimlane/swim-ui/src/components/date-time/date-time.component.ts
+++ b/projects/swimlane/swim-ui/src/components/date-time/date-time.component.ts
@@ -674,8 +674,10 @@ export class SwimDateTime extends LitElement {
     if (this._dialogModel) {
       this.value = this._dialogModel;
       this._update();
-      this.dispatchEvent(new CustomEvent('date-time-selected', { detail: this.value, bubbles: true, composed: true }));
-      this.dispatchEvent(new CustomEvent('change', { detail: this.value, bubbles: true, composed: true }));
+      this.dispatchEvent(
+        new CustomEvent('date-time-selected', { detail: this.value, bubbles: false, composed: false })
+      );
+      this.dispatchEvent(new CustomEvent('change', { detail: this.value, bubbles: false, composed: false }));
     }
     this._close();
   };
@@ -683,8 +685,8 @@ export class SwimDateTime extends LitElement {
   private _clear = (): void => {
     this.value = undefined;
     this._update();
-    this.dispatchEvent(new CustomEvent('date-time-selected', { detail: undefined, bubbles: true, composed: true }));
-    this.dispatchEvent(new CustomEvent('change', { detail: undefined, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('date-time-selected', { detail: undefined, bubbles: false, composed: false }));
+    this.dispatchEvent(new CustomEvent('change', { detail: undefined, bubbles: false, composed: false }));
     this._close();
   };
 
@@ -808,23 +810,23 @@ export class SwimDateTime extends LitElement {
 
     this._updateFormValue();
 
-    this.dispatchEvent(new CustomEvent('input-change', { detail: this._value, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('input-change', { detail: this._value, bubbles: false, composed: false }));
 
     // Fire value-change on any value mutation
     if (this._value !== oldValue) {
-      this.dispatchEvent(new CustomEvent('value-change', { detail: this._value, bubbles: true, composed: true }));
+      this.dispatchEvent(new CustomEvent('value-change', { detail: this._value, bubbles: false, composed: false }));
     }
 
     // Fire change only when value is valid or cleared
     if (!this._dateInvalid && this._value !== oldValue) {
-      this.dispatchEvent(new CustomEvent('change', { detail: this._value, bubbles: true, composed: true }));
+      this.dispatchEvent(new CustomEvent('change', { detail: this._value, bubbles: false, composed: false }));
     }
   }
 
   private _handleFocus(e: Event): void {
     e.stopPropagation();
     this._focused = true;
-    this.dispatchEvent(new FocusEvent('focus', { bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('focus', { bubbles: false, composed: false }));
   }
 
   private _handleBlur(e: Event): void {
@@ -837,7 +839,7 @@ export class SwimDateTime extends LitElement {
       this._swimInput.value = this._displayValue;
     }
 
-    this.dispatchEvent(new FocusEvent('blur', { bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('blur', { bubbles: false, composed: false }));
   }
 
   private _handleKeyDown(e: KeyboardEvent): void {

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
@@ -2,7 +2,12 @@ import { LitElement, html, nothing } from 'lit';
 import { property, state, query } from 'lit/decorators.js';
 import { dialogStyles } from './dialog.styles';
 import { DialogFormat } from './dialog-format.enum';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import {
+  coerceBooleanProperty,
+  coerceNumberProperty,
+  litBooleanAttrDefaultFalse,
+  litBooleanAttrDefaultTrue
+} from '../../utils/coerce';
 import '../icon/icon.component';
 
 /**
@@ -62,7 +67,7 @@ export class SwimDialog extends LitElement {
   showBackdrop = true;
 
   /** Whether to show the close button */
-  @property({ type: Boolean, attribute: 'close-button' })
+  @property({ type: Boolean, attribute: 'close-button', converter: litBooleanAttrDefaultTrue })
   get closeButton(): boolean {
     return this._closeButton;
   }
@@ -72,7 +77,7 @@ export class SwimDialog extends LitElement {
   private _closeButton = true;
 
   /** Whether the dialog is visible */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get visible(): boolean {
     return this._visible;
   }

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
@@ -25,9 +25,11 @@ import '../icon/icon.component';
  *
  * @csspart content - The dialog content panel
  * @csspart close-button - The close button
+ * @csspart header - The regular-format title wrapper (use with `::part(header)` for layout overrides)
  *
  * @cssprop [--swim-dialog-border] - Panel outline; default none (Figma modal has no stroke on the panel).
  * @cssprop [--swim-dialog-box-shadow] - Panel elevation; defaults to `--shadow-dialog-panel` (Figma drop shadow).
+ * @cssprop [--swim-dialog-header-text-align] - Title block alignment in regular format (`start` default). Set `center` to center the header.
  * @cssprop [--swim-dialog-header-action-display] - Set on this host when `close-button` is false (`none`). Slotted
  *   `swim-large-format-dialog-content` uses it to hide the header Close/Cancel. Override on a child host with `flex` if needed.
  */
@@ -279,7 +281,7 @@ export class SwimDialog extends LitElement {
                   : nothing}
                 ${this.dialogTitle
                   ? html`
-                      <div class="swim-dialog__header">
+                      <div class="swim-dialog__header" part="header">
                         <h2 id="${this._titleId}" class="swim-dialog__title">${this.dialogTitle}</h2>
                       </div>
                     `

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
@@ -15,8 +15,8 @@ import '../icon/icon.component';
  *
  * @slot - Default content (body). Use with dialog-title and optional header/footer.
  *
- * @fires open - Fired when the dialog is shown
- * @fires close - Fired when the dialog is closed (detail: boolean | void)
+ * @fires open - Fired when the dialog is shown (does not bubble; listen on this element).
+ * @fires close - Fired when the dialog is closed (detail: boolean | void). Does not bubble.
  *
  * @attr close-button - When false, hides all header dismiss controls: the regular-format X and the large/medium
  *   header action on `swim-large-format-dialog-content` (via inherited `--swim-dialog-header-action-display`). Default: true.
@@ -26,7 +26,8 @@ import '../icon/icon.component';
  * @csspart content - The dialog content panel
  * @csspart close-button - The close button
  *
- * @cssprop [--swim-dialog-box-shadow] - Panel elevation; defaults to ngx `shadow-3` via `--shadow-3`.
+ * @cssprop [--swim-dialog-border] - Panel outline; default none (Figma modal has no stroke on the panel).
+ * @cssprop [--swim-dialog-box-shadow] - Panel elevation; defaults to `--shadow-dialog-panel` (Figma drop shadow).
  * @cssprop [--swim-dialog-header-action-display] - Set on this host when `close-button` is false (`none`). Slotted
  *   `swim-large-format-dialog-content` uses it to hide the header Close/Cancel. Override on a child host with `flex` if needed.
  */
@@ -119,10 +120,10 @@ export class SwimDialog extends LitElement {
     if (next) {
       this._previousActiveElement =
         typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
-      this.dispatchEvent(new CustomEvent('open', { bubbles: true }));
+      this.dispatchEvent(new CustomEvent('open', { bubbles: false, composed: false }));
     } else {
       this._restoreFocus();
-      this.dispatchEvent(new CustomEvent('close', { detail: undefined, bubbles: true }));
+      this.dispatchEvent(new CustomEvent('close', { detail: undefined, bubbles: false, composed: false }));
     }
   }
   private _visible = false;

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
@@ -18,8 +18,17 @@ import '../icon/icon.component';
  * @fires open - Fired when the dialog is shown
  * @fires close - Fired when the dialog is closed (detail: boolean | void)
  *
+ * @attr close-button - When false, hides all header dismiss controls: the regular-format X and the large/medium
+ *   header action on `swim-large-format-dialog-content` (via inherited `--swim-dialog-header-action-display`). Default: true.
+ * @attr close-on-blur - When false, clicking the backdrop does not close (ngx closeOnBlur parity). Default: true.
+ * @attr close-on-escape - When false, Escape does not close (ngx closeOnEscape parity). Default: true.
+ *
  * @csspart content - The dialog content panel
  * @csspart close-button - The close button
+ *
+ * @cssprop [--swim-dialog-box-shadow] - Panel elevation; defaults to ngx `shadow-3` via `--shadow-3`.
+ * @cssprop [--swim-dialog-header-action-display] - Set on this host when `close-button` is false (`none`). Slotted
+ *   `swim-large-format-dialog-content` uses it to hide the header Close/Cancel. Override on a child host with `flex` if needed.
  */
 const DIALOG_TAG = 'swim-dialog';
 export class SwimDialog extends LitElement {
@@ -66,7 +75,9 @@ export class SwimDialog extends LitElement {
   })
   showBackdrop = true;
 
-  /** Whether to show the close button */
+  /**
+   * When false, hides the regular-format X and the large/medium format header close/cancel (see `--swim-dialog-header-action-display`).
+   */
   @property({ type: Boolean, attribute: 'close-button', converter: litBooleanAttrDefaultTrue })
   get closeButton(): boolean {
     return this._closeButton;
@@ -75,6 +86,26 @@ export class SwimDialog extends LitElement {
     this._closeButton = coerceBooleanProperty(value);
   }
   private _closeButton = true;
+
+  /** When false, clicking the dimmed backdrop does not dismiss the dialog (ngx `closeOnBlur`). */
+  @property({ type: Boolean, attribute: 'close-on-blur', converter: litBooleanAttrDefaultTrue })
+  get closeOnBlur(): boolean {
+    return this._closeOnBlur;
+  }
+  set closeOnBlur(value: boolean) {
+    this._closeOnBlur = coerceBooleanProperty(value);
+  }
+  private _closeOnBlur = true;
+
+  /** When false, the Escape key does not dismiss the dialog (ngx `closeOnEscape`). */
+  @property({ type: Boolean, attribute: 'close-on-escape', converter: litBooleanAttrDefaultTrue })
+  get closeOnEscape(): boolean {
+    return this._closeOnEscape;
+  }
+  set closeOnEscape(value: boolean) {
+    this._closeOnEscape = coerceBooleanProperty(value);
+  }
+  private _closeOnEscape = true;
 
   /** Whether the dialog is visible */
   @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
@@ -151,14 +182,35 @@ export class SwimDialog extends LitElement {
   }
 
   private _onBackdropClick(): void {
+    if (!this.closeOnBlur) return;
     this.hide();
   }
 
   private _onKeydown(e: KeyboardEvent): void {
     if (e.key === 'Escape') {
       e.stopPropagation();
+      if (!this.closeOnEscape) return;
       this.hide();
     }
+  }
+
+  /** Large/medium slotted content reads `--swim-dialog-header-action-display` (inherited). */
+  private _syncCloseButtonCustomProperty(): void {
+    if (!this.closeButton) {
+      this.style.setProperty('--swim-dialog-header-action-display', 'none');
+    } else {
+      this.style.removeProperty('--swim-dialog-header-action-display');
+    }
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this._syncCloseButtonCustomProperty();
+  }
+
+  override disconnectedCallback(): void {
+    this.style.removeProperty('--swim-dialog-header-action-display');
+    super.disconnectedCallback();
   }
 
   protected firstUpdated(): void {
@@ -168,6 +220,9 @@ export class SwimDialog extends LitElement {
   }
 
   protected updated(changedProperties: Map<string, unknown>): void {
+    if (changedProperties.has('closeButton')) {
+      this._syncCloseButtonCustomProperty();
+    }
     if (changedProperties.has('visible') && this.visible && this._contentEl) {
       requestAnimationFrame(() => {
         this._contentEl?.focus({ preventScroll: true });

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
@@ -213,12 +213,6 @@ export class SwimDialog extends LitElement {
     super.disconnectedCallback();
   }
 
-  protected firstUpdated(): void {
-    if (this.visible && this._contentEl) {
-      this._contentEl.focus({ preventScroll: true });
-    }
-  }
-
   protected updated(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('closeButton')) {
       this._syncCloseButtonCustomProperty();

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.component.ts
@@ -191,8 +191,8 @@ export class SwimDialog extends LitElement {
 
   private _onKeydown(e: KeyboardEvent): void {
     if (e.key === 'Escape') {
-      e.stopPropagation();
       if (!this.closeOnEscape) return;
+      e.stopPropagation();
       this.hide();
     }
   }

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.styles.ts
@@ -46,6 +46,18 @@ export const dialogStyles = [
       cursor: default;
     }
 
+    /* ngx-dialog visibilityTransition void=>*: 0.2s ease-out, opacity 0→1, scale3d(1.2)→(1) */
+    @keyframes swim-dialog-content-enter {
+      from {
+        opacity: 0;
+        transform: scale3d(1.2, 1.2, 1.2);
+      }
+      to {
+        opacity: 1;
+        transform: scale3d(1, 1, 1);
+      }
+    }
+
     .swim-dialog__content {
       pointer-events: auto;
       position: relative;
@@ -57,16 +69,19 @@ export const dialogStyles = [
       min-width: 250px;
       font-size: var(--font-size-m);
       color: var(--swim-dialog-body-color, var(--grey-200));
-      animation-fill-mode: forwards;
-      opacity: 0;
-      transform: scale3d(1.2, 1.2, 1);
-      transition: opacity 0.2s ease-out, transform 0.2s ease-out;
       z-index: calc(var(--swim-dialog-z, 991) + 1);
     }
 
     .swim-dialog.swim-dialog--open .swim-dialog__content {
-      opacity: 1;
-      transform: scale3d(1, 1, 1);
+      animation: swim-dialog-content-enter 0.2s ease-out forwards;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .swim-dialog.swim-dialog--open .swim-dialog__content {
+        animation: none;
+        opacity: 1;
+        transform: none;
+      }
     }
 
     .swim-dialog__content--large,

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.styles.ts
@@ -9,12 +9,16 @@ import { scrollbarStyles } from '../../styles/scrollbars';
  *
  * Optional theme overrides (set on a parent or this host; inherit into shadow):
  * --swim-dialog-bg, --swim-dialog-border, --swim-dialog-header-color, --swim-dialog-body-color,
- * --swim-dialog-box-shadow
+ * --swim-dialog-box-shadow, --swim-dialog-header-text-align (e.g. center)
  */
 export const dialogStyles = [
   baseStyles,
   scrollbarStyles,
   css`
+    :host {
+      outline: none;
+    }
+
     .swim-dialog {
       position: fixed;
       display: flex;
@@ -60,6 +64,7 @@ export const dialogStyles = [
     }
 
     .swim-dialog__content {
+      outline: none;
       pointer-events: auto;
       position: relative;
       border-radius: var(--radius-8);
@@ -150,6 +155,7 @@ export const dialogStyles = [
 
     .swim-dialog__header {
       margin: 0 0 1.4rem 0;
+      text-align: var(--swim-dialog-header-text-align, start);
     }
 
     .swim-dialog__title,
@@ -159,6 +165,7 @@ export const dialogStyles = [
       font-weight: 400;
       margin: 0 0 1.4rem 0;
       color: var(--swim-dialog-header-color, var(--grey-050));
+      text-align: inherit;
     }
 
     .swim-dialog__content--medium .swim-dialog__header,
@@ -235,14 +242,6 @@ export const dialogStyles = [
       padding: 1.4rem;
       margin-top: 0;
       display: block;
-    }
-
-    /* Parity with swim-dialog.run-all-swim-dialog::part(content) from light DOM */
-    :host(.run-all-swim-dialog) .swim-dialog__content,
-    :host(.run-all-swim-dialog) .swim-dialog__content:focus-visible,
-    .swim-dialog.run-all-swim-dialog .swim-dialog__content,
-    .swim-dialog.run-all-swim-dialog .swim-dialog__content:focus-visible {
-      outline: none;
     }
   `
 ];

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.styles.ts
@@ -8,7 +8,8 @@ import { scrollbarStyles } from '../../styles/scrollbars';
  * Includes scrollbar styles so .swim-scroll on the body works inside shadow DOM.
  *
  * Optional theme overrides (set on a parent or this host; inherit into shadow):
- * --swim-dialog-bg, --swim-dialog-header-color, --swim-dialog-body-color, --swim-dialog-box-shadow
+ * --swim-dialog-bg, --swim-dialog-border, --swim-dialog-header-color, --swim-dialog-body-color,
+ * --swim-dialog-box-shadow
  */
 export const dialogStyles = [
   baseStyles,
@@ -62,9 +63,9 @@ export const dialogStyles = [
       pointer-events: auto;
       position: relative;
       border-radius: var(--radius-8);
-      /* ngx-dialog .ngx-dialog-content: box-shadow: $shadow-3 */
-      box-shadow: var(--swim-dialog-box-shadow, var(--shadow-3));
-      background: var(--swim-dialog-bg, var(--grey-800));
+      border: var(--swim-dialog-border, none);
+      box-shadow: var(--swim-dialog-box-shadow, var(--shadow-dialog-panel));
+      background: var(--swim-dialog-bg, var(--grey-725));
       padding: 1.4rem;
       min-width: 250px;
       font-size: var(--font-size-m);
@@ -88,7 +89,9 @@ export const dialogStyles = [
     .swim-dialog__content--medium {
       padding: var(--spacing-0);
       width: calc(100vw - 120px);
-      background-color: transparent;
+      background: transparent;
+      border: none;
+      box-shadow: none;
     }
 
     .swim-dialog__content--large {
@@ -155,7 +158,7 @@ export const dialogStyles = [
       font-size: var(--font-size-3xl);
       font-weight: 400;
       margin: 0 0 1.4rem 0;
-      color: var(--swim-dialog-header-color, var(--grey-100));
+      color: var(--swim-dialog-header-color, var(--grey-050));
     }
 
     .swim-dialog__content--medium .swim-dialog__header,
@@ -195,6 +198,7 @@ export const dialogStyles = [
     :host(.swim-dialog--full-screen) .swim-dialog__content,
     .swim-dialog.swim-dialog--full-screen .swim-dialog__content {
       box-shadow: none;
+      border: none;
       box-sizing: border-box;
       width: 100%;
       min-height: 100%;
@@ -231,6 +235,14 @@ export const dialogStyles = [
       padding: 1.4rem;
       margin-top: 0;
       display: block;
+    }
+
+    /* Parity with swim-dialog.run-all-swim-dialog::part(content) from light DOM */
+    :host(.run-all-swim-dialog) .swim-dialog__content,
+    :host(.run-all-swim-dialog) .swim-dialog__content:focus-visible,
+    .swim-dialog.run-all-swim-dialog .swim-dialog__content,
+    .swim-dialog.run-all-swim-dialog .swim-dialog__content:focus-visible {
+      outline: none;
     }
   `
 ];

--- a/projects/swimlane/swim-ui/src/components/dialog/dialog.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/dialog.styles.ts
@@ -6,17 +6,14 @@ import { scrollbarStyles } from '../../styles/scrollbars';
  * Dialog component styles matching @swimlane/ngx-ui design system.
  * Uses CSS variables from base; BEM: swim-dialog, swim-dialog__content, etc.
  * Includes scrollbar styles so .swim-scroll on the body works inside shadow DOM.
+ *
+ * Optional theme overrides (set on a parent or this host; inherit into shadow):
+ * --swim-dialog-bg, --swim-dialog-header-color, --swim-dialog-body-color, --swim-dialog-box-shadow
  */
 export const dialogStyles = [
   baseStyles,
   scrollbarStyles,
   css`
-    :host {
-      --swim-dialog-bg: var(--grey-800);
-      --swim-dialog-header-color: var(--grey-100);
-      --swim-dialog-body-color: var(--grey-200);
-    }
-
     .swim-dialog {
       position: fixed;
       display: flex;
@@ -53,12 +50,13 @@ export const dialogStyles = [
       pointer-events: auto;
       position: relative;
       border-radius: var(--radius-8);
-      box-shadow: var(--shadow-3);
-      background: var(--swim-dialog-bg);
+      /* ngx-dialog .ngx-dialog-content: box-shadow: $shadow-3 */
+      box-shadow: var(--swim-dialog-box-shadow, var(--shadow-3));
+      background: var(--swim-dialog-bg, var(--grey-800));
       padding: 1.4rem;
       min-width: 250px;
       font-size: var(--font-size-m);
-      color: var(--swim-dialog-body-color);
+      color: var(--swim-dialog-body-color, var(--grey-200));
       animation-fill-mode: forwards;
       opacity: 0;
       transform: scale3d(1.2, 1.2, 1);
@@ -142,7 +140,7 @@ export const dialogStyles = [
       font-size: var(--font-size-3xl);
       font-weight: 400;
       margin: 0 0 1.4rem 0;
-      color: var(--swim-dialog-header-color);
+      color: var(--swim-dialog-header-color, var(--grey-100));
     }
 
     .swim-dialog__content--medium .swim-dialog__header,

--- a/projects/swimlane/swim-ui/src/components/dialog/index.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/index.ts
@@ -1,4 +1,7 @@
 export { SwimDialog } from './dialog.component';
 export { DialogFormat } from './dialog-format.enum';
 export { SwimLargeFormatDialogContent } from './large-format-dialog-content/large-format-dialog-content.component';
-export { SwimLargeFormatDialogFooter } from './large-format-dialog-footer/large-format-dialog-footer.component';
+export {
+  SwimLargeFormatDialogFooter,
+  type SwimLargeFormatDialogFooterAlign
+} from './large-format-dialog-footer/large-format-dialog-footer.component';

--- a/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.component.ts
@@ -13,7 +13,7 @@ import '../../icon/icon.component';
  * @slot - Body content
  * @slot footer - Footer content (e.g. buttons)
  *
- * @fires close-or-cancel - Fired when the header close/cancel button is clicked (detail: boolean – true if dirty)
+ * @fires close-or-cancel - Fired when the header close/cancel is clicked (detail: boolean dirty). Does not bubble.
  */
 const LARGE_FORMAT_DIALOG_CONTENT_TAG = 'swim-large-format-dialog-content';
 export class SwimLargeFormatDialogContent extends LitElement {
@@ -47,7 +47,7 @@ export class SwimLargeFormatDialogContent extends LitElement {
   private _hasFooterSlot = false;
 
   private _onCloseOrCancel(): void {
-    this.dispatchEvent(new CustomEvent('close-or-cancel', { detail: this.dirty, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('close-or-cancel', { detail: this.dirty, bubbles: false, composed: false }));
   }
 
   override firstUpdated(): void {

--- a/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.component.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, nothing } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { litBooleanAttrDefaultFalse } from '../../../utils/coerce';
 import { largeFormatDialogContentStyles } from './large-format-dialog-content.styles';
 import { scrollbarStyles } from '../../../styles/scrollbars';
@@ -8,6 +8,7 @@ import '../../icon/icon.component';
 /**
  * Content layout for Large or Medium format dialogs. Use inside swim-dialog when format="large" or format="medium".
  * Provides container, header (title + subtitle + close/cancel), scrollable body, and optional footer.
+ * When the parent `swim-dialog` uses `close-button="false"`, the header close/cancel is hidden (inherited `--swim-dialog-header-action-display`).
  *
  * @slot - Body content
  * @slot footer - Footer content (e.g. buttons)
@@ -42,8 +43,32 @@ export class SwimLargeFormatDialogContent extends LitElement {
   @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   dirty = false;
 
+  @state()
+  private _hasFooterSlot = false;
+
   private _onCloseOrCancel(): void {
     this.dispatchEvent(new CustomEvent('close-or-cancel', { detail: this.dirty, bubbles: true, composed: true }));
+  }
+
+  override firstUpdated(): void {
+    this._syncFooterSlotVisibility();
+  }
+
+  private _onFooterSlotChange = (): void => {
+    this._syncFooterSlotVisibility();
+  };
+
+  private _syncFooterSlotVisibility(): void {
+    const slot = this.renderRoot?.querySelector?.('slot[name="footer"]') as HTMLSlotElement | undefined;
+    if (!slot) return;
+    const nodes = slot.assignedNodes({ flatten: true });
+    const hasContent = nodes.some(
+      n =>
+        n.nodeType === Node.ELEMENT_NODE || (n.nodeType === Node.TEXT_NODE && (n.textContent?.trim() ?? '').length > 0)
+    );
+    if (this._hasFooterSlot !== hasContent) {
+      this._hasFooterSlot = hasContent;
+    }
   }
 
   render() {
@@ -51,6 +76,13 @@ export class SwimLargeFormatDialogContent extends LitElement {
       'format-dialog-container__header-title',
       'format-dialog-container__header-title--with-subtitle'
     ].join(' ');
+
+    const footerClasses = [
+      'format-dialog-container__footer',
+      this._hasFooterSlot ? '' : 'format-dialog-container__footer--hidden'
+    ]
+      .filter(Boolean)
+      .join(' ');
 
     return html`
       <main class="format-dialog-container">
@@ -74,8 +106,8 @@ export class SwimLargeFormatDialogContent extends LitElement {
         <section class="format-dialog-container__body swim-scroll">
           <slot></slot>
         </section>
-        <footer class="format-dialog-container__footer">
-          <slot name="footer"></slot>
+        <footer class="${footerClasses}">
+          <slot name="footer" @slotchange="${this._onFooterSlotChange}"></slot>
         </footer>
       </main>
     `;

--- a/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.component.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
+import { litBooleanAttrDefaultFalse } from '../../../utils/coerce';
 import { largeFormatDialogContentStyles } from './large-format-dialog-content.styles';
 import { scrollbarStyles } from '../../../styles/scrollbars';
 import '../../icon/icon.component';
@@ -38,7 +39,7 @@ export class SwimLargeFormatDialogContent extends LitElement {
   dialogDirtyActionTitle = 'Cancel';
 
   /** When true, shows cancel label and emits dirty flag on close */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   dirty = false;
 
   private _onCloseOrCancel(): void {

--- a/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.styles.ts
@@ -6,7 +6,7 @@ import { baseStyles } from '../../../styles/base';
  * Solid background, fixed header/footer heights, scrollable body.
  *
  * Optional overrides (set on a parent or this host; inherit into shadow):
- * --swim-format-dialog-bg, --swim-format-max-height, --swim-format-border-radius,
+ * --swim-format-dialog-bg, --swim-format-dialog-shadow, --swim-format-max-height, --swim-format-border-radius,
  * --swim-format-header-height, --swim-format-header-height-large, --swim-format-header-height-medium,
  * --swim-format-divider, --swim-format-header-padding-x, --swim-format-header-padding-end,
  * --swim-format-header-gap, --swim-format-header-title-stack-gap,
@@ -33,8 +33,8 @@ export const largeFormatDialogContentStyles = [
       flex-direction: column;
       height: 100%;
       max-height: var(--swim-format-max-height, 75vh);
-      background: var(--swim-format-dialog-bg, var(--grey-800));
-      box-shadow: 0 0 100px rgba(0, 0, 0, 0.25);
+      background: var(--swim-format-dialog-bg, var(--grey-725));
+      box-shadow: var(--swim-format-dialog-shadow, var(--shadow-dialog-panel));
       border-radius: var(--swim-format-border-radius, var(--radius-16, 16px));
       overflow: hidden;
     }

--- a/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-content/large-format-dialog-content.styles.ts
@@ -4,6 +4,18 @@ import { baseStyles } from '../../../styles/base';
 /**
  * Large/Medium format dialog content styles matching ngx-large-format-dialog-content.
  * Solid background, fixed header/footer heights, scrollable body.
+ *
+ * Optional overrides (set on a parent or this host; inherit into shadow):
+ * --swim-format-dialog-bg, --swim-format-max-height, --swim-format-border-radius,
+ * --swim-format-header-height, --swim-format-header-height-large, --swim-format-header-height-medium,
+ * --swim-format-divider, --swim-format-header-padding-x, --swim-format-header-padding-end,
+ * --swim-format-header-gap, --swim-format-header-title-stack-gap,
+ * --swim-format-header-close-gap, --swim-format-header-close-outline-width,
+ * --swim-format-body-padding, --swim-format-body-min-height, --swim-format-body-max-height,
+ * --swim-format-footer-height, --swim-format-footer-padding-y, --swim-format-footer-padding-x,
+ * --swim-format-footer-gap, --swim-format-title-size, --swim-format-title-line
+ * Inherited from parent swim-dialog when close-button is false:
+ * --swim-dialog-header-action-display (e.g. none)
  */
 export const largeFormatDialogContentStyles = [
   baseStyles,
@@ -14,12 +26,6 @@ export const largeFormatDialogContentStyles = [
       height: 100%;
       position: relative;
       overflow: hidden;
-      --swim-format-dialog-bg: var(--grey-800);
-      --swim-format-header-height-large: 90px;
-      --swim-format-header-height-medium: 60px;
-      --swim-format-footer-height: 4rem;
-      --swim-format-body-padding: 2rem;
-      --swim-format-border: 2px solid var(--grey-700);
     }
 
     .format-dialog-container {
@@ -27,42 +33,52 @@ export const largeFormatDialogContentStyles = [
       flex-direction: column;
       height: 100%;
       max-height: var(--swim-format-max-height, 75vh);
-      background: var(--swim-format-dialog-bg);
+      background: var(--swim-format-dialog-bg, var(--grey-800));
       box-shadow: 0 0 100px rgba(0, 0, 0, 0.25);
-      border-radius: var(--radius-16);
+      border-radius: var(--swim-format-border-radius, var(--radius-16, 16px));
       overflow: hidden;
     }
 
     :host([format='large']) .format-dialog-container {
-      --swim-format-max-height: calc(100vh - 7.25rem);
-      --swim-format-header-height: var(--swim-format-header-height-large);
+      max-height: var(--swim-format-max-height, calc(100vh - 7.25rem));
     }
 
     :host([format='medium']) .format-dialog-container {
-      --swim-format-max-height: 75vh;
-      --swim-format-header-height: var(--swim-format-header-height-medium);
-      --swim-format-body-max-height: calc(var(--swim-format-max-height) - var(--swim-format-header-height));
+      max-height: var(--swim-format-max-height, 75vh);
+      --swim-format-body-max-height-internal: calc(
+        var(--swim-format-max-height, 75vh) -
+          var(--swim-format-header-height, var(--swim-format-header-height-medium, 60px))
+      );
     }
 
     .format-dialog-container__header {
-      flex: 0 0 var(--swim-format-header-height, 90px);
-      height: var(--swim-format-header-height, 90px);
-      min-height: var(--swim-format-header-height, 90px);
-      border-bottom: var(--swim-format-border);
+      border-bottom: var(--swim-format-divider, var(--spacing-2, 2px) solid var(--grey-700));
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 0 var(--swim-format-body-padding);
-      padding-right: 2.5rem;
-      gap: 1.5rem;
+      padding: 0 var(--swim-format-header-padding-x, var(--spacing-32, 2rem));
+      padding-right: var(--swim-format-header-padding-end, var(--spacing-40, 2.5rem));
+      gap: var(--swim-format-header-gap, var(--spacing-24, 1.5rem));
       overflow: visible;
+    }
+
+    :host([format='large']) .format-dialog-container__header {
+      flex: 0 0 var(--swim-format-header-height, var(--swim-format-header-height-large, 90px));
+      height: var(--swim-format-header-height, var(--swim-format-header-height-large, 90px));
+      min-height: var(--swim-format-header-height, var(--swim-format-header-height-large, 90px));
+    }
+
+    :host([format='medium']) .format-dialog-container__header {
+      flex: 0 0 var(--swim-format-header-height, var(--swim-format-header-height-medium, 60px));
+      height: var(--swim-format-header-height, var(--swim-format-header-height-medium, 60px));
+      min-height: var(--swim-format-header-height, var(--swim-format-header-height-medium, 60px));
     }
 
     /* Match ngx-large-format-dialog-header-title__wrapper: flex 0 0 20%, height 100%, justify-content center */
     .format-dialog-container__header-title {
       display: flex;
       flex-direction: column;
-      gap: 2px;
+      gap: var(--swim-format-header-title-stack-gap, var(--spacing-2, 2px));
       flex: 0 0 20%;
       height: 100%;
       min-width: 0;
@@ -96,14 +112,14 @@ export const largeFormatDialogContentStyles = [
     }
 
     :host([format='medium']) .format-dialog-container__header-title h1 {
-      --swim-format-title-size: 1.375rem;
-      --swim-format-title-line: 1.625rem;
+      font-size: var(--swim-format-title-size, 1.375rem);
+      line-height: var(--swim-format-title-line, 1.625rem);
     }
 
     .format-dialog-container__header-action {
       flex: 0 0 auto;
       max-width: 50%;
-      display: flex;
+      display: var(--swim-dialog-header-action-display, flex);
       align-items: center;
       justify-content: flex-end;
     }
@@ -118,7 +134,7 @@ export const largeFormatDialogContentStyles = [
       cursor: pointer;
       display: inline-flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: var(--swim-format-header-close-gap, var(--spacing-8, 0.5rem));
     }
 
     .format-dialog-container__header-action__button swim-icon {
@@ -132,32 +148,50 @@ export const largeFormatDialogContentStyles = [
     }
 
     .format-dialog-container__header-action__button:focus-visible {
-      outline: 2px solid var(--blue-500);
-      outline-offset: 2px;
+      outline: var(--swim-format-header-close-outline-width, var(--spacing-2, 2px)) solid var(--blue-500);
+      outline-offset: var(--swim-format-header-close-outline-width, var(--spacing-2, 2px));
     }
 
     .format-dialog-container__body {
       flex: 1 1 auto;
-      min-height: 215px;
-      padding: 0 var(--swim-format-body-padding);
+      min-height: var(--swim-format-body-min-height, 215px);
+      padding: var(--swim-format-body-padding, var(--spacing-32, 2rem));
       color: var(--grey-200);
     }
 
     :host([format='medium']) .format-dialog-container__body {
-      max-height: var(--swim-format-body-max-height, auto);
+      max-height: var(--swim-format-body-max-height, var(--swim-format-body-max-height-internal, auto));
     }
 
     .format-dialog-container__footer {
-      flex: 0 0 var(--swim-format-footer-height);
-      height: var(--swim-format-footer-height);
-      min-height: var(--swim-format-footer-height);
-      border-top: var(--swim-format-border);
+      flex: 0 0 var(--swim-format-footer-height, calc(var(--spacing-48, 48px) + var(--spacing-16, 16px)));
+      height: var(--swim-format-footer-height, calc(var(--spacing-48, 48px) + var(--spacing-16, 16px)));
+      min-height: var(--swim-format-footer-height, calc(var(--spacing-48, 48px) + var(--spacing-16, 16px)));
+      border-top: var(--swim-format-divider, var(--spacing-2, 2px) solid var(--grey-700));
       display: flex;
       justify-content: space-between;
       align-items: center;
-      gap: var(--swim-format-footer-gap, 0.5rem);
-      padding: 0.75rem 2rem;
+      gap: var(--swim-format-footer-gap, var(--spacing-8, 0.5rem));
+      padding: var(--swim-format-footer-padding-y, var(--spacing-12, 0.75rem))
+        var(--swim-format-footer-padding-x, var(--spacing-32, 2rem));
       box-sizing: border-box;
+    }
+
+    .format-dialog-container__footer--hidden {
+      display: none;
+      flex: 0 0 0;
+      height: 0;
+      min-height: 0;
+      padding: 0;
+      border-top: none;
+      overflow: hidden;
+    }
+
+    /* Slotted footer host must span the row so inner justify-content (align) can take effect (ngx parity). */
+    .format-dialog-container__footer ::slotted(*) {
+      flex: 1 1 auto;
+      min-width: 0;
+      align-self: stretch;
     }
   `
 ];

--- a/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-footer/large-format-dialog-footer.component.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-footer/large-format-dialog-footer.component.ts
@@ -4,16 +4,29 @@ import { largeFormatDialogFooterStyles } from './large-format-dialog-footer.styl
 
 const LARGE_FORMAT_DIALOG_FOOTER_TAG = 'swim-large-format-dialog-footer';
 
+/** Horizontal alignment of slotted footer content (maps to flex `justify-content`). */
+export type SwimLargeFormatDialogFooterAlign =
+  | 'start'
+  | 'center'
+  | 'end'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly';
+
 /**
  * Footer for Large or Medium format dialogs. Use inside swim-large-format-dialog-content with slot="footer".
  *
  * @slot - Footer content (e.g. action buttons)
+ * @attr align - Horizontal alignment: start | center | end | space-between | space-around | space-evenly (default: center)
  */
 export class SwimLargeFormatDialogFooter extends LitElement {
   static styles = largeFormatDialogFooterStyles;
 
   @property({ type: String, reflect: true })
   format: 'large' | 'medium' = 'large';
+
+  @property({ type: String, reflect: true })
+  align: SwimLargeFormatDialogFooterAlign = 'center';
 
   render() {
     return html` <div class="format-dialog-footer"><slot></slot></div> `;

--- a/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-footer/large-format-dialog-footer.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-footer/large-format-dialog-footer.styles.ts
@@ -5,14 +5,16 @@ export const largeFormatDialogFooterStyles = [
   baseStyles,
   css`
     :host {
-      --swim-format-footer-gap: 0.5rem;
+      display: block;
+      box-sizing: border-box;
+      width: 100%;
     }
 
     .format-dialog-footer {
       display: flex;
       justify-content: center;
       align-items: center;
-      gap: var(--swim-format-footer-gap);
+      gap: var(--swim-format-footer-gap, var(--spacing-8, 0.5rem));
       width: 100%;
       height: 100%;
     }

--- a/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-footer/large-format-dialog-footer.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/dialog/large-format-dialog-footer/large-format-dialog-footer.styles.ts
@@ -16,5 +16,29 @@ export const largeFormatDialogFooterStyles = [
       width: 100%;
       height: 100%;
     }
+
+    :host([align='start']) .format-dialog-footer {
+      justify-content: flex-start;
+    }
+
+    :host([align='end']) .format-dialog-footer {
+      justify-content: flex-end;
+    }
+
+    :host([align='center']) .format-dialog-footer {
+      justify-content: center;
+    }
+
+    :host([align='space-between']) .format-dialog-footer {
+      justify-content: space-between;
+    }
+
+    :host([align='space-around']) .format-dialog-footer {
+      justify-content: space-around;
+    }
+
+    :host([align='space-evenly']) .format-dialog-footer {
+      justify-content: space-evenly;
+    }
   `
 ];

--- a/projects/swimlane/swim-ui/src/components/drawer/drawer.component.ts
+++ b/projects/swimlane/swim-ui/src/components/drawer/drawer.component.ts
@@ -150,7 +150,7 @@ export class SwimDrawer extends LitElement {
   }
 
   private _emitClose(): void {
-    this.dispatchEvent(new CustomEvent('close', { detail: true, bubbles: true }));
+    this.dispatchEvent(new CustomEvent('close', { detail: true, bubbles: false, composed: false }));
   }
 
   private _onBackdropClick(): void {

--- a/projects/swimlane/swim-ui/src/components/drawer/drawer.component.ts
+++ b/projects/swimlane/swim-ui/src/components/drawer/drawer.component.ts
@@ -2,7 +2,7 @@ import { LitElement, html, nothing } from 'lit';
 import { property, state, query } from 'lit/decorators.js';
 import { drawerStyles } from './drawer.styles';
 import { DrawerDirection } from './drawer-direction.enum';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 /**
  * SwimDrawer - Slide-in panel matching @swimlane/ngx-ui design system.
@@ -84,7 +84,7 @@ export class SwimDrawer extends LitElement {
   private _isRoot = true;
 
   /** Whether the drawer is visible/open */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get open(): boolean {
     return this._open;
   }

--- a/projects/swimlane/swim-ui/src/components/icon/icon.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/icon/icon.styles.ts
@@ -10,8 +10,13 @@ import { iconFontGlyphs } from './icon-font-glyphs';
  */
 export const iconStyles = css`
   :host {
-    display: inline-block;
-    vertical-align: baseline;
+    /* inline-flex keeps the host box tight to the glyph and centers the shadow icon in contexts
+       (e.g. swim-button) where inherited line-height would otherwise grow the line box asymmetrically */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    line-height: 1;
   }
 
   :host svg {
@@ -77,7 +82,7 @@ export const iconStyles = css`
   /* Font icon base (glyphs in icon-font-glyphs.ts); uses same font as ngx-ui ('ngx-icon'). */
   .swim-icon,
   .swim-icon__i.swim-icon {
-    display: inline-block;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 1em;
@@ -89,10 +94,14 @@ export const iconStyles = css`
     -moz-osx-font-smoothing: grayscale;
   }
 
-  /* Center the glyph regardless of font metrics (fixes vertical misalignment) */
+  /* Center the glyph in the em box; many ngx-icon glyphs sit high with display:block alone */
   .swim-icon::before,
   .swim-icon__i.swim-icon::before {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
     line-height: 1;
   }
 

--- a/projects/swimlane/swim-ui/src/components/input/input.component.ts
+++ b/projects/swimlane/swim-ui/src/components/input/input.component.ts
@@ -23,6 +23,9 @@ import { coerceBooleanProperty, litBooleanAttrDefaultFalse, litBooleanAttrDefaul
  * @fires focus - Fired when the input gains focus (does not bubble).
  * @fires blur - Fired when the input loses focus (does not bubble).
  *
+ * Imperative API: call `focus()` / `blur()` on the host element; they delegate to the inner
+ * native control (same as form validation focusing invalid fields).
+ *
  * @csspart input - The native input/textarea element
  * @csspart label - The label element
  */
@@ -267,7 +270,22 @@ export class SwimInput extends LitElement {
 
   /** Delegate focus to the internal input so form validation can focus invalid controls. */
   override focus(options?: FocusOptions): void {
-    this.inputElement?.focus(options);
+    const target = this.inputElement;
+    if (target) {
+      target.focus(options);
+      return;
+    }
+    void this.updateComplete.then(() => this.inputElement?.focus(options));
+  }
+
+  /** Delegate blur to the internal input. */
+  override blur(): void {
+    const target = this.inputElement;
+    if (target) {
+      target.blur();
+      return;
+    }
+    void this.updateComplete.then(() => this.inputElement?.blur());
   }
 
   updated(changedProperties: PropertyValues) {

--- a/projects/swimlane/swim-ui/src/components/input/input.component.ts
+++ b/projects/swimlane/swim-ui/src/components/input/input.component.ts
@@ -18,10 +18,10 @@ import { coerceBooleanProperty, litBooleanAttrDefaultFalse, litBooleanAttrDefaul
  * @slot suffix - Content to show after the input
  * @slot hint - Hint text below the input
  *
- * @fires change - Fired when the value changes
- * @fires input - Fired on input events
- * @fires focus - Fired when the input gains focus
- * @fires blur - Fired when the input loses focus
+ * @fires change - Fired when the value changes (does not bubble; listen on this element).
+ * @fires input - Fired on input events (does not bubble).
+ * @fires focus - Fired when the input gains focus (does not bubble).
+ * @fires blur - Fired when the input loses focus (does not bubble).
  *
  * @csspart input - The native input/textarea element
  * @csspart label - The label element
@@ -411,18 +411,18 @@ export class SwimInput extends LitElement {
       this.setAttribute('dirty', '');
     }
 
-    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('input', { bubbles: false, composed: false }));
   }
 
   private _handleChange(_e: Event) {
     this._validate();
-    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('change', { bubbles: false, composed: false }));
   }
 
   private _handleFocus(_e: FocusEvent) {
     this._focused = true;
     this.setAttribute('focused', '');
-    this.dispatchEvent(new FocusEvent('focus', { bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('focus', { bubbles: false, composed: false }));
   }
 
   private _handleBlur(_e: FocusEvent) {
@@ -435,7 +435,7 @@ export class SwimInput extends LitElement {
     }
 
     this._validate();
-    this.dispatchEvent(new FocusEvent('blur', { bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('blur', { bubbles: false, composed: false }));
   }
 
   private _togglePassword() {
@@ -492,7 +492,7 @@ export class SwimInput extends LitElement {
 
       const newValue = currentValue + 1;
       this.value = newValue.toString();
-      this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+      this.dispatchEvent(new Event('change', { bubbles: false, composed: false }));
     }
   }
 
@@ -505,7 +505,7 @@ export class SwimInput extends LitElement {
 
       const newValue = currentValue - 1;
       this.value = newValue.toString();
-      this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+      this.dispatchEvent(new Event('change', { bubbles: false, composed: false }));
     }
   }
 

--- a/projects/swimlane/swim-ui/src/components/input/input.component.ts
+++ b/projects/swimlane/swim-ui/src/components/input/input.component.ts
@@ -9,7 +9,7 @@ import { inputStyles } from './input.styles';
 import { InputTypes } from './input-types.enum';
 import { InputAppearance } from './input-appearance.enum';
 import { InputSize } from './input-size.enum';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse, litBooleanAttrDefaultTrue } from '../../utils/coerce';
 
 /**
  * SwimInput - An input component matching @swimlane/ngx-ui design system
@@ -91,7 +91,7 @@ export class SwimInput extends LitElement {
   /**
    * Whether the input is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -103,7 +103,7 @@ export class SwimInput extends LitElement {
   /**
    * Whether the input is readonly
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get readonly(): boolean {
     return this._readonly;
   }
@@ -115,7 +115,7 @@ export class SwimInput extends LitElement {
   /**
    * Whether the input is required
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get required(): boolean {
     return this._required;
   }
@@ -127,7 +127,7 @@ export class SwimInput extends LitElement {
   /**
    * Whether to autofocus
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, converter: litBooleanAttrDefaultFalse })
   get autofocus(): boolean {
     return this._autofocus;
   }
@@ -157,7 +157,7 @@ export class SwimInput extends LitElement {
   /**
    * Whether to show margin
    */
-  @property({ type: Boolean, reflect: true, attribute: 'marginless' })
+  @property({ type: Boolean, reflect: true, attribute: 'marginless', converter: litBooleanAttrDefaultFalse })
   get marginless(): boolean {
     return !this._withMargin;
   }
@@ -169,7 +169,7 @@ export class SwimInput extends LitElement {
   /**
    * Whether to show hint
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, converter: litBooleanAttrDefaultTrue })
   get withHint(): boolean {
     return this._withHint;
   }
@@ -181,7 +181,7 @@ export class SwimInput extends LitElement {
   /**
    * Enable password toggle
    */
-  @property({ type: Boolean, attribute: 'password-toggle-enabled' })
+  @property({ type: Boolean, attribute: 'password-toggle-enabled', converter: litBooleanAttrDefaultFalse })
   get passwordToggleEnabled(): boolean {
     return this._passwordToggleEnabled;
   }

--- a/projects/swimlane/swim-ui/src/components/list/list.component.ts
+++ b/projects/swimlane/swim-ui/src/components/list/list.component.ts
@@ -116,14 +116,14 @@ export class SwimList extends LitElement {
   private _emitScrollChanges(event: Event): void {
     const target = event.target as HTMLDivElement;
     const scrollY = target.scrollTop;
-    this.dispatchEvent(new CustomEvent('scroll', { detail: scrollY, bubbles: true }));
+    this.dispatchEvent(new CustomEvent('scroll', { detail: scrollY, bubbles: false, composed: false }));
     const pageSize = this.paginationConfig?.pageSize;
     if (pageSize) {
       const currentRow = Math.floor(scrollY / ROW_HEIGHT);
       const page = Math.floor(currentRow / pageSize) + 1;
       if (page !== this._page) {
         this._page = page;
-        this.dispatchEvent(new CustomEvent('page-change', { detail: page, bubbles: true }));
+        this.dispatchEvent(new CustomEvent('page-change', { detail: page, bubbles: false, composed: false }));
       }
     }
   }

--- a/projects/swimlane/swim-ui/src/components/navbar/navbar-item.component.ts
+++ b/projects/swimlane/swim-ui/src/components/navbar/navbar-item.component.ts
@@ -9,7 +9,7 @@ import { coerceNumberProperty } from '../../utils/coerce';
  *
  * @slot - Item content (e.g. icon, label)
  *
- * @fires active-change - Fired when this item becomes active (detail: number index)
+ * @fires active-change - Fired when this item becomes active (detail: number index). Does not bubble.
  */
 const NAVBAR_ITEM_TAG = 'swim-navbar-item';
 export class SwimNavbarItem extends LitElement {
@@ -99,8 +99,8 @@ export class SwimNavbarItem extends LitElement {
       this.dispatchEvent(
         new CustomEvent('active-change', {
           detail: this._index,
-          bubbles: true,
-          composed: true
+          bubbles: false,
+          composed: false
         })
       );
     }

--- a/projects/swimlane/swim-ui/src/components/navbar/navbar.component.ts
+++ b/projects/swimlane/swim-ui/src/components/navbar/navbar.component.ts
@@ -12,7 +12,7 @@ const BAR_SIZE = 40;
  *
  * @slot - Default slot for swim-navbar-item children
  *
- * @fires active-change - Fired when the active item changes (detail: number index)
+ * @fires active-change - Fired when the active item changes (detail: number index). Does not bubble.
  *
  * @csspart nav-items - Container for nav items
  * @csspart bar-track - Track for the active bar
@@ -52,8 +52,8 @@ export class SwimNavbar extends LitElement {
       this.dispatchEvent(
         new CustomEvent('active-change', {
           detail: this._active,
-          bubbles: true,
-          composed: true
+          bubbles: false,
+          composed: false
         })
       );
     }
@@ -140,8 +140,8 @@ export class SwimNavbar extends LitElement {
       this.dispatchEvent(
         new CustomEvent('active-change', {
           detail: this._active,
-          bubbles: true,
-          composed: true
+          bubbles: false,
+          composed: false
         })
       );
     }

--- a/projects/swimlane/swim-ui/src/components/navbar/navbar.component.ts
+++ b/projects/swimlane/swim-ui/src/components/navbar/navbar.component.ts
@@ -3,7 +3,7 @@ import { property, state, query } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { navbarStyles } from './navbar.styles';
 import { SwimNavbarItem } from './navbar-item.component';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 const BAR_SIZE = 40;
 
@@ -28,7 +28,7 @@ export class SwimNavbar extends LitElement {
   /**
    * Whether the active indicator bar is on top of the items (default: false = bottom).
    */
-  @property({ type: Boolean, reflect: true, attribute: 'bar-at-top' })
+  @property({ type: Boolean, reflect: true, attribute: 'bar-at-top', converter: litBooleanAttrDefaultFalse })
   get barAtTop(): boolean {
     return this._barAtTop;
   }

--- a/projects/swimlane/swim-ui/src/components/progress-spinner/progress-spinner.component.ts
+++ b/projects/swimlane/swim-ui/src/components/progress-spinner/progress-spinner.component.ts
@@ -4,7 +4,7 @@ import { progressSpinnerStyles } from './progress-spinner.styles';
 import { ProgressSpinnerMode } from './progress-spinner-mode.enum';
 import { SpinnerAppearance } from './spinner-appearance.enum';
 import type { SpinnerLabel } from './spinner-label.interface';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 const INDETERMINATE_VALUE = 50;
 const INDETERMINATE_TOTAL = 100;
@@ -85,7 +85,7 @@ export class SwimProgressSpinner extends LitElement {
   /**
    * Whether the operation failed (shows fail icon/color when complete).
    */
-  @property({ type: Boolean, reflect: true, attribute: 'is-failure' })
+  @property({ type: Boolean, reflect: true, attribute: 'is-failure', converter: litBooleanAttrDefaultFalse })
   get isFailure(): boolean {
     return this._isFailure;
   }

--- a/projects/swimlane/swim-ui/src/components/radio/radio-group.component.ts
+++ b/projects/swimlane/swim-ui/src/components/radio/radio-group.component.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { radioGroupStyles } from './radio.styles';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 import type { SwimRadio } from './radio.component';
 
 let nextId = 0;
@@ -37,7 +37,7 @@ export class SwimRadioGroup extends LitElement {
   @property({ type: String })
   id = `swim-radio-group-${++nextId}`;
 
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }

--- a/projects/swimlane/swim-ui/src/components/radio/radio-group.component.ts
+++ b/projects/swimlane/swim-ui/src/components/radio/radio-group.component.ts
@@ -161,8 +161,8 @@ export class SwimRadioGroup extends LitElement {
     this.dispatchEvent(
       new CustomEvent('change', {
         detail: this._value,
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }
@@ -179,7 +179,7 @@ export class SwimRadioGroup extends LitElement {
   };
 
   private _onGroupBlur = () => {
-    this.dispatchEvent(new FocusEvent('blur', { bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('blur', { bubbles: false, composed: false }));
   };
 
   private _focusFirst() {

--- a/projects/swimlane/swim-ui/src/components/radio/radio.component.ts
+++ b/projects/swimlane/swim-ui/src/components/radio/radio.component.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { radioStyles } from './radio.styles';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 let nextId = 0;
 
@@ -46,7 +46,7 @@ export class SwimRadio extends LitElement {
   }
   private _tabindex = 0;
 
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get checked(): boolean {
     return this._checked;
   }
@@ -60,7 +60,7 @@ export class SwimRadio extends LitElement {
   @property({ type: String })
   value = '';
 
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled || this.groupDisabled;
   }

--- a/projects/swimlane/swim-ui/src/components/radio/radio.component.ts
+++ b/projects/swimlane/swim-ui/src/components/radio/radio.component.ts
@@ -114,8 +114,8 @@ export class SwimRadio extends LitElement {
       this.dispatchEvent(
         new CustomEvent('change', {
           detail: this.value,
-          bubbles: true,
-          composed: true
+          bubbles: false,
+          composed: false
         })
       );
     }
@@ -126,18 +126,18 @@ export class SwimRadio extends LitElement {
     this.dispatchEvent(
       new CustomEvent('change', {
         detail: this.value,
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }
 
   private _onFocus(ev: FocusEvent) {
-    this.dispatchEvent(new FocusEvent('focus', { ...ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('focus', { ...ev, bubbles: false, composed: false }));
   }
 
   private _onBlur(ev: FocusEvent) {
-    this.dispatchEvent(new FocusEvent('blur', { ...ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('blur', { ...ev, bubbles: false, composed: false }));
   }
 
   render() {

--- a/projects/swimlane/swim-ui/src/components/radio/radio.component.ts
+++ b/projects/swimlane/swim-ui/src/components/radio/radio.component.ts
@@ -114,8 +114,9 @@ export class SwimRadio extends LitElement {
       this.dispatchEvent(
         new CustomEvent('change', {
           detail: this.value,
-          bubbles: false,
-          composed: false
+          // Must bubble so swim-radio-group (light-DOM parent) receives selection.
+          bubbles: true,
+          composed: true
         })
       );
     }
@@ -126,8 +127,8 @@ export class SwimRadio extends LitElement {
     this.dispatchEvent(
       new CustomEvent('change', {
         detail: this.value,
-        bubbles: false,
-        composed: false
+        bubbles: true,
+        composed: true
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/section/section.component.ts
+++ b/projects/swimlane/swim-ui/src/components/section/section.component.ts
@@ -15,7 +15,7 @@ let nextId = 0;
  * @slot header - Custom header content (replaces or supplements sectionTitle).
  * @slot - Default slot for section body content.
  *
- * @fires toggle - Fired when the section is expanded or collapsed (detail: boolean collapsed).
+ * @fires toggle - Fired when the section is expanded or collapsed (detail: boolean collapsed). Does not bubble.
  */
 const SECTION_TAG = 'swim-section';
 export class SwimSection extends LitElement {
@@ -159,8 +159,8 @@ export class SwimSection extends LitElement {
     this.dispatchEvent(
       new CustomEvent('toggle', {
         detail: nextCollapsed,
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/section/section.component.ts
+++ b/projects/swimlane/swim-ui/src/components/section/section.component.ts
@@ -3,19 +3,8 @@ import { property, state, query } from 'lit/decorators.js';
 import { sectionComponentStyles } from './section.styles';
 import { SectionAppearance } from './section-appearance.enum';
 import { TogglePosition } from './section-toggle-position.enum';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse, litBooleanAttrDefaultTrue } from '../../utils/coerce';
 import '../icon/icon.component';
-
-/** Converter so attribute "false" is respected (Lit's default Boolean ignores attribute value). */
-const booleanAttrConverter = {
-  fromAttribute: (value: string | null): boolean => value !== 'false' && value !== '',
-  toAttribute: (value: boolean): string => (value ? 'true' : 'false')
-};
-/** Same but default false when attribute is absent (for section-collapsed, header-toggle). */
-const booleanAttrConverterDefaultFalse = {
-  fromAttribute: (value: string | null): boolean => value !== null && value !== 'false',
-  toAttribute: (value: boolean): string => (value ? 'true' : 'false')
-};
 
 let nextId = 0;
 
@@ -46,7 +35,7 @@ export class SwimSection extends LitElement {
   @property({
     reflect: true,
     attribute: 'section-collapsed',
-    converter: booleanAttrConverterDefaultFalse
+    converter: litBooleanAttrDefaultFalse
   })
   get sectionCollapsed(): boolean {
     return this._sectionCollapsed;
@@ -63,7 +52,7 @@ export class SwimSection extends LitElement {
   @property({
     reflect: true,
     attribute: 'section-collapsible',
-    converter: booleanAttrConverter
+    converter: litBooleanAttrDefaultTrue
   })
   get sectionCollapsible(): boolean {
     return this._sectionCollapsible;
@@ -80,7 +69,7 @@ export class SwimSection extends LitElement {
   @property({
     reflect: true,
     attribute: 'header-toggle',
-    converter: booleanAttrConverterDefaultFalse
+    converter: litBooleanAttrDefaultFalse
   })
   get headerToggle(): boolean {
     return this._headerToggle;

--- a/projects/swimlane/swim-ui/src/components/select/select-filter.util.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select-filter.util.ts
@@ -39,11 +39,20 @@ export function optionMatchesFilter(
   keyword: string,
   options: { filterCaseSensitive: boolean }
 ): boolean {
-  if (!keyword.trim()) {
+  const trimmed = keyword.trim();
+  if (!trimmed) {
     return true;
   }
-  const q = options.filterCaseSensitive ? keyword : keyword;
-  const directFields = [option.name, option.title, option.label, option.description, option.value]
+  const q = options.filterCaseSensitive ? trimmed : trimmed.toLowerCase();
+  const directFields = [
+    option.name,
+    option.title,
+    option.label,
+    option.description,
+    option.value,
+    option.group,
+    option.category
+  ]
     .filter(v => v !== undefined && v !== null)
     .map(v => (typeof v === 'string' ? v : String(v)));
 

--- a/projects/swimlane/swim-ui/src/components/select/select-filter.util.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select-filter.util.ts
@@ -1,0 +1,66 @@
+import type { SelectOption } from './select-option.interface';
+
+const KNOWN_KEYS = new Set(['name', 'value', 'title', 'label', 'description', 'disabled', 'group', 'category']);
+
+function containsInString(value: string, keyword: string, caseSensitive: boolean): boolean {
+  if (!keyword) {
+    return true;
+  }
+  return caseSensitive ? value.includes(keyword) : value.toLowerCase().includes(keyword.toLowerCase());
+}
+
+function scanValue(value: unknown, keyword: string, caseSensitive: boolean, depth: number): boolean {
+  if (value === undefined || value === null || depth > 2) {
+    return false;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return containsInString(String(value), keyword, caseSensitive);
+  }
+  if (typeof value === 'string') {
+    return containsInString(value, keyword, caseSensitive);
+  }
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const keys = Object.getOwnPropertyNames(value as object);
+    for (const k of keys) {
+      if (scanValue((value as Record<string, unknown>)[k], keyword, caseSensitive, depth + 1)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Client-side filter: matches name, title, label, description, stringified value,
+ * and shallow nested fields on the option object (depth-capped).
+ */
+export function optionMatchesFilter(
+  option: SelectOption,
+  keyword: string,
+  options: { filterCaseSensitive: boolean }
+): boolean {
+  if (!keyword.trim()) {
+    return true;
+  }
+  const q = options.filterCaseSensitive ? keyword : keyword;
+  const directFields = [option.name, option.title, option.label, option.description, option.value]
+    .filter(v => v !== undefined && v !== null)
+    .map(v => (typeof v === 'string' ? v : String(v)));
+
+  for (const f of directFields) {
+    if (containsInString(f, q, options.filterCaseSensitive)) {
+      return true;
+    }
+  }
+
+  for (const key of Object.keys(option)) {
+    if (KNOWN_KEYS.has(key)) {
+      continue;
+    }
+    if (scanValue(option[key], q, options.filterCaseSensitive, 0)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/projects/swimlane/swim-ui/src/components/select/select-filter.util.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select-filter.util.ts
@@ -1,6 +1,6 @@
 import type { SelectOption } from './select-option.interface';
 
-const KNOWN_KEYS = new Set(['name', 'value', 'title', 'label', 'description', 'disabled', 'group', 'category']);
+const KNOWN_KEYS = new Set(['name', 'value', 'title', 'label', 'description', 'disabled', 'group']);
 
 function containsInString(value: string, keyword: string, caseSensitive: boolean): boolean {
   if (!keyword) {
@@ -31,7 +31,7 @@ function scanValue(value: unknown, keyword: string, caseSensitive: boolean, dept
 }
 
 /**
- * Client-side filter: matches name, title, label, description, stringified value,
+ * Client-side filter: matches name, title, label, description, group, stringified value,
  * and shallow nested fields on the option object (depth-capped).
  */
 export function optionMatchesFilter(
@@ -44,15 +44,7 @@ export function optionMatchesFilter(
     return true;
   }
   const q = options.filterCaseSensitive ? trimmed : trimmed.toLowerCase();
-  const directFields = [
-    option.name,
-    option.title,
-    option.label,
-    option.description,
-    option.value,
-    option.group,
-    option.category
-  ]
+  const directFields = [option.name, option.title, option.label, option.description, option.value, option.group]
     .filter(v => v !== undefined && v !== null)
     .map(v => (typeof v === 'string' ? v : String(v)));
 

--- a/projects/swimlane/swim-ui/src/components/select/select-option.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select-option.component.ts
@@ -36,9 +36,6 @@ export class SwimOption extends LitElement {
   @property({ type: String })
   group = '';
 
-  @property({ type: String })
-  category = '';
-
   @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;

--- a/projects/swimlane/swim-ui/src/components/select/select-option.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select-option.component.ts
@@ -11,7 +11,7 @@ const OPTION_TAG = 'swim-option';
  * ```html
  * <swim-select label="Attack Type">
  *   <swim-option name="breach" value="breach" label="Breach"></swim-option>
- *   <swim-option name="ddos" value="ddos" title="DDOS"></swim-option>
+ *   <swim-option name="ddos" value="ddos" title="DDOS" group="Network"></swim-option>
  * </swim-select>
  * ```
  */

--- a/projects/swimlane/swim-ui/src/components/select/select-option.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select-option.component.ts
@@ -1,6 +1,6 @@
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 const OPTION_TAG = 'swim-option';
 
@@ -10,8 +10,8 @@ const OPTION_TAG = 'swim-option';
  * Usage:
  * ```html
  * <swim-select label="Attack Type">
- *   <swim-option name="Breach" value="breach"></swim-option>
- *   <swim-option name="DDOS" value="ddos"></swim-option>
+ *   <swim-option name="breach" value="breach" label="Breach"></swim-option>
+ *   <swim-option name="ddos" value="ddos" title="DDOS"></swim-option>
  * </swim-select>
  * ```
  */
@@ -22,7 +22,24 @@ export class SwimOption extends LitElement {
   @property()
   value: any;
 
-  @property({ type: Boolean, reflect: true })
+  /** Display label when different from `name` */
+  @property({ type: String })
+  label = '';
+
+  /** Display title (alias of label for search / trigger) */
+  @property({ type: String })
+  title = '';
+
+  @property({ type: String })
+  description = '';
+
+  @property({ type: String })
+  group = '';
+
+  @property({ type: String })
+  category = '';
+
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -31,7 +48,7 @@ export class SwimOption extends LitElement {
   }
   private _disabled = false;
 
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get hidden(): boolean {
     return this._hidden;
   }

--- a/projects/swimlane/swim-ui/src/components/select/select-option.interface.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select-option.interface.ts
@@ -33,14 +33,9 @@ export interface SelectOption {
   disabled?: boolean;
 
   /**
-   * Group / section header (normalized with `category`)
+   * Group / section header when `grouped` is enabled on the select
    */
   group?: string;
-
-  /**
-   * Same as `group` — datasource may use either
-   */
-  category?: string;
 
   /**
    * Custom data

--- a/projects/swimlane/swim-ui/src/components/select/select-option.interface.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select-option.interface.ts
@@ -3,14 +3,29 @@
  */
 export interface SelectOption {
   /**
-   * Display name
+   * Stable identifier (often matches server `name`); shown when no title/label
    */
   name: string;
 
   /**
-   * Value
+   * Selected form / programmatic value (defaults to `name` when omitted)
    */
-  value: any;
+  value?: any;
+
+  /**
+   * Primary display string when different from `name` (e.g. AI-SOC: id in `name`, label in `title`)
+   */
+  title?: string;
+
+  /**
+   * Alias for `title` for display
+   */
+  label?: string;
+
+  /**
+   * Secondary line for search / list (not always shown in UI)
+   */
+  description?: string;
 
   /**
    * Whether the option is disabled
@@ -18,9 +33,14 @@ export interface SelectOption {
   disabled?: boolean;
 
   /**
-   * Group name for grouped options
+   * Group / section header (normalized with `category`)
    */
   group?: string;
+
+  /**
+   * Same as `group` — datasource may use either
+   */
+  category?: string;
 
   /**
    * Custom data

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -37,6 +37,10 @@ import './select-option.component';
  */
 const SELECT_TAG = 'swim-select';
 
+/** Top-layer popover avoids clipping inside transformed / overflow:hidden ancestors (e.g. dialogs). */
+const SELECT_POPOVER_TOP_LAYER =
+  typeof HTMLElement !== 'undefined' && typeof HTMLElement.prototype.showPopover === 'function';
+
 export class SwimSelect extends LitElement {
   static styles = [baseStyles, scrollbarStyles, selectStyles];
   static formAssociated = true;
@@ -108,6 +112,13 @@ export class SwimSelect extends LitElement {
 
   @property({ type: Number, attribute: 'filter-min-length' })
   filterMinLength = 2;
+
+  /**
+   * With the popover top layer, `start` anchors the panel to the combobox; `center` uses the
+   * full host width and horizontal bounds so the menu lines up with centered columns (e.g. dialogs).
+   */
+  @property({ type: String, attribute: 'dropdown-align' })
+  dropdownAlign: 'start' | 'center' = 'start';
 
   @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get loading(): boolean {
@@ -294,6 +305,7 @@ export class SwimSelect extends LitElement {
   /** Debounce id from `window.setTimeout` (DOM lib uses `number`). */
   private _filterDebounceTimer: number | undefined;
   private _clickOutsideListener?: (e: MouseEvent) => void;
+  private _dropdownScrollOrResizeListener?: () => void;
   private _childObserver?: MutationObserver;
 
   /**
@@ -320,6 +332,10 @@ export class SwimSelect extends LitElement {
   }
 
   disconnectedCallback() {
+    const dd = this.shadowRoot?.querySelector('.select-dropdown') as
+      | (HTMLElement & { hidePopover?: () => void })
+      | null;
+    this._teardownDropdownTopLayer(dd);
     super.disconnectedCallback();
     this._removeClickOutsideListener();
     this._childObserver?.disconnect();
@@ -383,6 +399,7 @@ export class SwimSelect extends LitElement {
       if (this._open) {
         this.setAttribute('open', '');
         this._addClickOutsideListener();
+        this.updateComplete.then(() => this._layoutOpenDropdownPanel());
         // Focus filter input if available
         setTimeout(() => {
           if (this.filterable && this.filterInput && !this.disabled) {
@@ -399,6 +416,14 @@ export class SwimSelect extends LitElement {
           this._filterDebounceTimer = undefined;
         }
       }
+    }
+
+    if (
+      this._open &&
+      (changedProperties.has('options') || changedProperties.has('loading')) &&
+      !changedProperties.has('_open')
+    ) {
+      this.updateComplete.then(() => this._layoutOpenDropdownPanel());
     }
   }
 
@@ -465,7 +490,13 @@ export class SwimSelect extends LitElement {
 
         ${this._open
           ? html`
-              <div class="select-dropdown swim-scroll" part="dropdown" role="listbox" id="${this.id}-listbox">
+              <div
+                class="select-dropdown swim-scroll"
+                part="dropdown"
+                role="listbox"
+                id="${this.id}-listbox"
+                popover="${SELECT_POPOVER_TOP_LAYER ? 'manual' : nothing}"
+              >
                 ${this.filterable
                   ? html`
                       <div
@@ -798,6 +829,10 @@ export class SwimSelect extends LitElement {
   }
 
   private _closeDropdown() {
+    const dd = this.shadowRoot?.querySelector('.select-dropdown') as
+      | (HTMLElement & { hidePopover?: () => void })
+      | null;
+    this._teardownDropdownTopLayer(dd);
     this._open = false;
     this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));
   }
@@ -902,7 +937,7 @@ export class SwimSelect extends LitElement {
 
   private _addClickOutsideListener() {
     this._clickOutsideListener = (e: MouseEvent) => {
-      if (!this.contains(e.target as Node)) {
+      if (!e.composedPath().includes(this)) {
         this._closeDropdown();
       }
     };
@@ -916,6 +951,97 @@ export class SwimSelect extends LitElement {
       document.removeEventListener('click', this._clickOutsideListener);
       this._clickOutsideListener = undefined;
     }
+  }
+
+  /** Manual popover + fixed geometry so the list escapes overflow/transform (e.g. medium dialog). */
+  private _layoutOpenDropdownPanel(): void {
+    if (!this._open || !SELECT_POPOVER_TOP_LAYER) return;
+    const dd = this.shadowRoot?.querySelector('.select-dropdown') as
+      | (HTMLElement & { showPopover?: () => void })
+      | null;
+    if (!dd || !this.selectInput || typeof dd.showPopover !== 'function') {
+      return;
+    }
+    this._applyDropdownPanelGeometry(dd, this.selectInput);
+    try {
+      dd.showPopover();
+    } catch {
+      /* already open or popover not available at runtime */
+    }
+    this._addDropdownScrollListener();
+  }
+
+  private _applyDropdownPanelGeometry(dd: HTMLElement, trigger: HTMLElement): void {
+    const tr = trigger.getBoundingClientRect();
+    const host = this.getBoundingClientRect();
+    const gap = 8;
+    const maxH = Math.min(300, Math.max(0, window.innerHeight - tr.bottom - gap - 8));
+    const useHost = this.dropdownAlign === 'center';
+    const panelW = useHost ? host.width : tr.width;
+    let leftPx = useHost ? host.left : tr.left;
+    if (useHost) {
+      const edge = 8;
+      leftPx = Math.min(Math.max(leftPx, edge), window.innerWidth - panelW - edge);
+    }
+    // UA `[popover]` uses `inset: 0; margin: auto` which centers the panel and fights our anchors.
+    dd.style.setProperty('inset', 'auto');
+    dd.style.setProperty('margin', '0');
+    dd.style.setProperty('height', 'auto');
+    dd.style.setProperty('position', 'fixed');
+    dd.style.setProperty('left', `${leftPx}px`);
+    dd.style.setProperty('top', `${tr.bottom + gap}px`);
+    dd.style.setProperty('width', `${panelW}px`);
+    dd.style.setProperty('max-height', `${maxH}px`);
+    dd.style.setProperty('z-index', '2147483646');
+    dd.style.setProperty('animation', 'none');
+    dd.style.setProperty('transform', 'none');
+  }
+
+  private _clearDropdownPanelGeometry(dd: HTMLElement): void {
+    [
+      'inset',
+      'margin',
+      'height',
+      'position',
+      'left',
+      'top',
+      'width',
+      'max-height',
+      'z-index',
+      'animation',
+      'transform'
+    ].forEach(p => dd.style.removeProperty(p));
+  }
+
+  private _teardownDropdownTopLayer(dd: (HTMLElement & { hidePopover?: () => void }) | null): void {
+    this._removeDropdownScrollListener();
+    if (!dd || !SELECT_POPOVER_TOP_LAYER) return;
+    try {
+      dd.hidePopover?.();
+    } catch {
+      /* not shown */
+    }
+    this._clearDropdownPanelGeometry(dd);
+  }
+
+  private _addDropdownScrollListener(): void {
+    if (!SELECT_POPOVER_TOP_LAYER || this._dropdownScrollOrResizeListener) return;
+    this._dropdownScrollOrResizeListener = () => {
+      if (!this._open) return;
+      const panel = this.shadowRoot?.querySelector('.select-dropdown') as HTMLElement | null;
+      if (panel && this.selectInput) {
+        this._applyDropdownPanelGeometry(panel, this.selectInput);
+      }
+    };
+    window.addEventListener('scroll', this._dropdownScrollOrResizeListener, true);
+    window.addEventListener('resize', this._dropdownScrollOrResizeListener);
+  }
+
+  private _removeDropdownScrollListener(): void {
+    if (!this._dropdownScrollOrResizeListener) return;
+    window.removeEventListener('scroll', this._dropdownScrollOrResizeListener, true);
+    window.removeEventListener('resize', this._dropdownScrollOrResizeListener);
+    this._dropdownScrollOrResizeListener = undefined;
   }
 
   // Form API

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -27,10 +27,10 @@ import './select-option.component';
  * @slot - swim-option children for declarative options
  * @slot hint - Custom hint content
  *
- * @fires change - Fired when selection changes
- * @fires dropdown-open - Fired when the options panel opens
- * @fires dropdown-close - Fired when the options panel closes
- * @fires filter-change - With `async-filter`: debounced `detail.query` for remote search (empty string below min length)
+ * @fires change - Fired when selection changes (does not bubble; listen on this element).
+ * @fires dropdown-open - Options panel opened (does not bubble).
+ * @fires dropdown-close - Options panel closed (does not bubble).
+ * @fires filter-change - With `async-filter`: debounced `detail.query` for remote search (does not bubble).
  *
  * @csspart select - The select input element
  * @csspart dropdown - The dropdown container
@@ -398,6 +398,17 @@ export class SwimSelect extends LitElement {
   updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
 
+    if (changedProperties.has('disabled')) {
+      if (this.disabled) {
+        this._focused = false;
+        this.removeAttribute('focused');
+        if (this._open) {
+          this._closeDropdown();
+        }
+      }
+      this._updateActiveState();
+    }
+
     if (changedProperties.has('value')) {
       this._updateActiveState();
       this._validate();
@@ -462,6 +473,7 @@ export class SwimSelect extends LitElement {
                 class="select-input"
                 part="select"
                 role="combobox"
+                aria-disabled="${this.disabled ? 'true' : nothing}"
                 aria-expanded="${this._open}"
                 aria-haspopup="listbox"
                 aria-controls="${this.id}-listbox"
@@ -489,6 +501,7 @@ export class SwimSelect extends LitElement {
                     type="button"
                     class="select-caret"
                     aria-label="Toggle dropdown"
+                    ?disabled="${this.disabled}"
                     @click="${this._handleToggle}"
                   >
                     <swim-icon font-icon="chevron-bold-down"></swim-icon>
@@ -701,6 +714,9 @@ export class SwimSelect extends LitElement {
   }
 
   private _handleFocus() {
+    if (this.disabled) {
+      return;
+    }
     this._focused = true;
     this.setAttribute('focused', '');
   }
@@ -718,6 +734,9 @@ export class SwimSelect extends LitElement {
   }
 
   private _handleKeyDown(e: KeyboardEvent) {
+    if (this.disabled) {
+      return;
+    }
     switch (e.key) {
       case 'Enter':
       case ' ':
@@ -753,8 +772,8 @@ export class SwimSelect extends LitElement {
     this.dispatchEvent(
       new CustomEvent('filter-change', {
         detail: { query },
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }
@@ -909,8 +928,8 @@ export class SwimSelect extends LitElement {
     this.dispatchEvent(
       new CustomEvent('change', {
         detail: { value: this.value },
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -7,7 +7,7 @@ import { selectStyles } from './select.styles';
 import { SelectOption } from './select-option.interface';
 import { InputAppearance } from '../input/input-appearance.enum';
 import { InputSize } from '../input/input-size.enum';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse, litBooleanAttrDefaultTrue } from '../../utils/coerce';
 import '../icon/icon.component';
 import './select-option.component';
 
@@ -28,11 +28,13 @@ import './select-option.component';
  * @fires change - Fired when selection changes
  * @fires open - Fired when dropdown opens
  * @fires close - Fired when dropdown closes
+ * @fires filter-change - With `async-filter`: debounced `detail.query` for remote search (empty string below min length)
  *
  * @csspart select - The select input element
  * @csspart dropdown - The dropdown container
  */
 const SELECT_TAG = 'swim-select';
+
 export class SwimSelect extends LitElement {
   static styles = [baseStyles, scrollbarStyles, selectStyles];
   static formAssociated = true;
@@ -76,6 +78,45 @@ export class SwimSelect extends LitElement {
   filterPlaceholder = 'Filter options...';
 
   /**
+   * When the filter matches nothing (sync) or async search returned no users
+   */
+  @property({ type: String, attribute: 'filter-empty-placeholder' })
+  filterEmptyPlaceholder = 'No matches';
+
+  /**
+   * Shown while `loading` is true during async search
+   */
+  @property({ type: String, attribute: 'filter-searching-placeholder' })
+  filterSearchingPlaceholder = 'Searching…';
+
+  /**
+   * Remote search: skip local filtering; parent updates `options` after `filter-change`
+   */
+  @property({ type: Boolean, attribute: 'async-filter', converter: litBooleanAttrDefaultFalse })
+  get asyncFilter(): boolean {
+    return this._asyncFilter;
+  }
+  set asyncFilter(value: boolean) {
+    this._asyncFilter = coerceBooleanProperty(value);
+  }
+  private _asyncFilter = false;
+
+  @property({ type: Number, attribute: 'filter-debounce-ms' })
+  filterDebounceMs = 500;
+
+  @property({ type: Number, attribute: 'filter-min-length' })
+  filterMinLength = 2;
+
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
+  get loading(): boolean {
+    return this._loading;
+  }
+  set loading(value: boolean) {
+    this._loading = coerceBooleanProperty(value);
+  }
+  private _loading = false;
+
+  /**
    * Select options
    */
   @property({ type: Array })
@@ -116,7 +157,7 @@ export class SwimSelect extends LitElement {
   /**
    * Whether the select is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -128,7 +169,7 @@ export class SwimSelect extends LitElement {
   /**
    * Whether the select is required
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get required(): boolean {
     return this._required;
   }
@@ -152,7 +193,7 @@ export class SwimSelect extends LitElement {
   /**
    * Whether to show margin
    */
-  @property({ type: Boolean, reflect: true, attribute: 'marginless' })
+  @property({ type: Boolean, reflect: true, attribute: 'marginless', converter: litBooleanAttrDefaultFalse })
   get marginless(): boolean {
     return !this._withMargin;
   }
@@ -164,7 +205,7 @@ export class SwimSelect extends LitElement {
   /**
    * Whether to show hint
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, converter: litBooleanAttrDefaultTrue })
   get withHint(): boolean {
     return this._withHint;
   }
@@ -176,7 +217,7 @@ export class SwimSelect extends LitElement {
   /**
    * Enable filtering
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, converter: litBooleanAttrDefaultTrue })
   get filterable(): boolean {
     return this._filterable;
   }
@@ -188,7 +229,7 @@ export class SwimSelect extends LitElement {
   /**
    * Allow multiple selection
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get multiple(): boolean {
     return this._multiple;
   }
@@ -200,7 +241,7 @@ export class SwimSelect extends LitElement {
   /**
    * Allow clearing selection
    */
-  @property({ type: Boolean, attribute: 'allow-clear' })
+  @property({ type: Boolean, attribute: 'allow-clear', converter: litBooleanAttrDefaultTrue })
   get allowClear(): boolean {
     return this._allowClear;
   }
@@ -236,6 +277,8 @@ export class SwimSelect extends LitElement {
   @state()
   private _focusedIndex = -1;
 
+  /** Debounce id from `window.setTimeout` (DOM lib uses `number`). */
+  private _filterDebounceTimer: number | undefined;
   private _clickOutsideListener?: (e: MouseEvent) => void;
   private _childObserver?: MutationObserver;
 
@@ -266,6 +309,10 @@ export class SwimSelect extends LitElement {
     super.disconnectedCallback();
     this._removeClickOutsideListener();
     this._childObserver?.disconnect();
+    if (this._filterDebounceTimer !== undefined) {
+      clearTimeout(this._filterDebounceTimer);
+      this._filterDebounceTimer = undefined;
+    }
   }
 
   /** Called by swim-option children when they connect/disconnect/update */
@@ -303,13 +350,24 @@ export class SwimSelect extends LitElement {
       this._validate();
     }
 
+    if (changedProperties.has('loading')) {
+      const wasLoading = changedProperties.get('loading');
+      if (wasLoading === true && !this.loading && this._open && this.filterable && !this.disabled) {
+        this.updateComplete.then(() => {
+          if (this.filterInput && document.activeElement !== this.filterInput) {
+            this.filterInput.focus({ preventScroll: true });
+          }
+        });
+      }
+    }
+
     if (changedProperties.has('_open')) {
       if (this._open) {
         this.setAttribute('open', '');
         this._addClickOutsideListener();
         // Focus filter input if available
         setTimeout(() => {
-          if (this.filterable && this.filterInput) {
+          if (this.filterable && this.filterInput && !this.disabled) {
             this.filterInput.focus();
           }
         }, 100);
@@ -318,6 +376,10 @@ export class SwimSelect extends LitElement {
         this._removeClickOutsideListener();
         this._filterQuery = '';
         this._focusedIndex = -1;
+        if (this._filterDebounceTimer !== undefined) {
+          clearTimeout(this._filterDebounceTimer);
+          this._filterDebounceTimer = undefined;
+        }
       }
     }
   }
@@ -326,6 +388,7 @@ export class SwimSelect extends LitElement {
     const hasValue = this._value.length > 0;
     const filteredOptions = this._getFilteredOptions();
     const showClear = this.allowClear && hasValue && !this.disabled;
+    const showList = filteredOptions.length > 0 && !this.loading;
 
     return html`
       <div class="select-wrap">
@@ -387,11 +450,16 @@ export class SwimSelect extends LitElement {
               <div class="select-dropdown swim-scroll" part="dropdown" role="listbox" id="${this.id}-listbox">
                 ${this.filterable
                   ? html`
-                      <div class="select-filter">
+                      <div
+                        class="select-filter ${this.loading ? 'select-filter--loading' : ''}"
+                        aria-busy="${this.loading}"
+                      >
                         <input
                           type="text"
                           class="select-filter-input"
                           placeholder="${this.filterPlaceholder}"
+                          ?disabled="${this.disabled}"
+                          ?readonly="${this.loading}"
                           .value="${this._filterQuery}"
                           @input="${this._handleFilterInput}"
                           @keydown="${this._handleFilterKeyDown}"
@@ -399,7 +467,7 @@ export class SwimSelect extends LitElement {
                       </div>
                     `
                   : nothing}
-                ${filteredOptions.length > 0
+                ${showList
                   ? html`
                       <ul class="select-options">
                         ${repeat(
@@ -409,7 +477,7 @@ export class SwimSelect extends LitElement {
                         )}
                       </ul>
                     `
-                  : html` <div class="select-empty">${this.emptyPlaceholder}</div> `}
+                  : html`<div class="select-empty">${this._emptyDropdownMessage()}</div>`}
               </div>
             `
           : nothing}
@@ -431,20 +499,45 @@ export class SwimSelect extends LitElement {
       `;
     } else {
       const option = this._allOptions.find(opt => this._getOptionValue(opt) === this._value[0]);
-      return html`${option?.name || this._value[0]}`;
+      const label = option ? this._getOptionLabel(option) : String(this._value[0]);
+      return html`${label}`;
     }
   }
 
+  private _getOptionLabel(option: SelectOption): string {
+    const t = option.title ?? option.label;
+    if (t !== undefined && t !== null && String(t).length > 0) {
+      return String(t);
+    }
+    return option.name;
+  }
+
+  private _emptyDropdownMessage(): string {
+    if (this.loading) {
+      return this.filterSearchingPlaceholder;
+    }
+    if (this.asyncFilter && this._filterQuery.trim().length < this.filterMinLength) {
+      return this.emptyPlaceholder;
+    }
+    if (this._allOptions.length === 0) {
+      return this.asyncFilter && this._filterQuery.trim().length > 0
+        ? this.filterEmptyPlaceholder
+        : this.emptyPlaceholder;
+    }
+    return this.filterEmptyPlaceholder;
+  }
+
   private _renderChip(option: SelectOption) {
+    const label = this._getOptionLabel(option);
     return html`
       <div class="select-chip">
-        <span class="select-chip-label">${option.name}</span>
+        <span class="select-chip-label">${label}</span>
         ${!this.disabled
           ? html`
               <button
                 type="button"
                 class="select-chip-remove"
-                aria-label="Remove ${option.name}"
+                aria-label="Remove ${label}"
                 @click="${(e: Event) => this._removeChip(e, option)}"
               >
                 <swim-icon font-icon="x"></swim-icon>
@@ -471,7 +564,7 @@ export class SwimSelect extends LitElement {
         @click="${() => this._handleOptionClick(option)}"
         @mouseenter="${() => (this._focusedIndex = index)}"
       >
-        ${option.name}
+        ${this._getOptionLabel(option)}
       </li>
     `;
   }
@@ -545,10 +638,36 @@ export class SwimSelect extends LitElement {
     }
   }
 
+  private _emitFilterChange(query: string) {
+    this.dispatchEvent(
+      new CustomEvent('filter-change', {
+        detail: { query },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
   private _handleFilterInput(e: Event) {
     const target = e.target as HTMLInputElement;
     this._filterQuery = target.value;
     this._focusedIndex = 0;
+
+    if (this.asyncFilter) {
+      if (this._filterDebounceTimer !== undefined) {
+        clearTimeout(this._filterDebounceTimer);
+        this._filterDebounceTimer = undefined;
+      }
+      const q = this._filterQuery.trim();
+      if (q.length < this.filterMinLength) {
+        this._emitFilterChange('');
+        return;
+      }
+      this._filterDebounceTimer = window.setTimeout(() => {
+        this._filterDebounceTimer = undefined;
+        this._emitFilterChange(q);
+      }, this.filterDebounceMs);
+    }
   }
 
   private _handleFilterKeyDown(e: KeyboardEvent) {
@@ -642,12 +761,19 @@ export class SwimSelect extends LitElement {
   }
 
   private _getFilteredOptions(): SelectOption[] {
-    if (!this._filterQuery) {
+    if (this.asyncFilter) {
+      return this._allOptions;
+    }
+    if (!this._filterQuery.trim()) {
       return this._allOptions;
     }
 
     const query = this._filterQuery.toLowerCase();
-    return this._allOptions.filter(option => option.name.toLowerCase().includes(query));
+    return this._allOptions.filter(option => {
+      const label = this._getOptionLabel(option).toLowerCase();
+      const desc = (option.description ?? '').toLowerCase();
+      return option.name.toLowerCase().includes(query) || label.includes(query) || desc.includes(query);
+    });
   }
 
   private _getOptionValue(option: SelectOption): any {

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -28,8 +28,8 @@ import './select-option.component';
  * @slot hint - Custom hint content
  *
  * @fires change - Fired when selection changes
- * @fires open - Fired when dropdown opens
- * @fires close - Fired when dropdown closes
+ * @fires dropdown-open - Fired when the options panel opens
+ * @fires dropdown-close - Fired when the options panel closes
  * @fires filter-change - With `async-filter`: debounced `detail.query` for remote search (empty string below min length)
  *
  * @csspart select - The select input element
@@ -216,7 +216,8 @@ export class SwimSelect extends LitElement {
   private _withMargin = true;
 
   /**
-   * Whether to show hint
+   * When true, the hint row is rendered only if `hint` is non-empty or a direct child uses `slot="hint"`.
+   * When false, the hint row is never rendered.
    */
   @property({ type: Boolean, converter: litBooleanAttrDefaultTrue })
   get withHint(): boolean {
@@ -284,6 +285,10 @@ export class SwimSelect extends LitElement {
   @state()
   private _slottedOptions: SelectOption[] = [];
 
+  /** Direct child assigned to `slot="hint"` (kept in sync via `_setupChildObserver`). */
+  @state()
+  private _hasSlottedHint = false;
+
   @state()
   private _open = false;
 
@@ -327,6 +332,7 @@ export class SwimSelect extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this._collectSlottedOptions();
+    this._syncSlottedHintPresence();
     this._setupChildObserver();
     this._updateActiveState();
   }
@@ -369,11 +375,24 @@ export class SwimSelect extends LitElement {
       });
   }
 
+  private _syncSlottedHintPresence() {
+    const next = Array.from(this.children).some(el => el.slot === 'hint');
+    if (next !== this._hasSlottedHint) {
+      this._hasSlottedHint = next;
+    }
+  }
+
   private _setupChildObserver() {
     this._childObserver = new MutationObserver(() => {
       this._collectSlottedOptions();
+      this._syncSlottedHintPresence();
     });
-    this._childObserver.observe(this, { childList: true, subtree: false });
+    this._childObserver.observe(this, {
+      childList: true,
+      subtree: false,
+      attributes: true,
+      attributeFilter: ['slot']
+    });
   }
 
   updated(changedProperties: PropertyValues) {
@@ -432,6 +451,7 @@ export class SwimSelect extends LitElement {
     const filteredOptions = this._getFilteredOptions();
     const showClear = this.allowClear && hasValue && !this.disabled;
     const showList = filteredOptions.length > 0 && !this.loading;
+    const showHint = this.withHint && (this.hint.trim() !== '' || this._hasSlottedHint);
 
     return html`
       <div class="select-wrap">
@@ -484,10 +504,13 @@ export class SwimSelect extends LitElement {
         <div class="select-underline">
           <div class="underline-fill"></div>
         </div>
-        <div class="select-hint ${!this.withHint ? 'hidden' : ''}">
-          <slot name="hint">${this.hint}</slot>
-        </div>
-
+        ${showHint
+          ? html`
+              <div class="select-hint">
+                <slot name="hint">${this.hint}</slot>
+              </div>
+            `
+          : nothing}
         ${this._open
           ? html`
               <div
@@ -825,7 +848,7 @@ export class SwimSelect extends LitElement {
     if (this.disabled) return;
     this._open = true;
     this._focusedIndex = 0;
-    this.dispatchEvent(new Event('open', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('dropdown-open', { bubbles: false, composed: false }));
   }
 
   private _closeDropdown() {
@@ -834,7 +857,7 @@ export class SwimSelect extends LitElement {
       | null;
     this._teardownDropdownTopLayer(dd);
     this._open = false;
-    this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('dropdown-close', { bubbles: false, composed: false }));
   }
 
   private _moveFocus(direction: number) {

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing, PropertyValues } from 'lit';
+import { LitElement, html, nothing, PropertyValues, TemplateResult } from 'lit';
 import { property, state, query } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { baseStyles } from '../../styles/base';
@@ -14,7 +14,9 @@ import './select-option.component';
 /**
  * SwimSelect - A select/dropdown component matching @swimlane/ngx-ui design system
  *
- * Options can be provided via the `options` property or declaratively with `<swim-option>` children:
+ * Options can be provided via the `options` property or declaratively with `<swim-option>` children.
+ * Set the `grouped` attribute to show section headers from each option’s `group` or `category`
+ * (`SelectOption` fields or `<swim-option>` attributes). Without `grouped`, those fields are ignored for layout.
  * ```html
  * <swim-select label="Attack Type">
  *   <swim-option name="Breach" value="breach"></swim-option>
@@ -227,6 +229,18 @@ export class SwimSelect extends LitElement {
   private _filterable = true;
 
   /**
+   * When true, show `group` / `category` as section headers in the dropdown (and indent options).
+   */
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
+  get grouped(): boolean {
+    return this._grouped;
+  }
+  set grouped(value: boolean) {
+    this._grouped = coerceBooleanProperty(value);
+  }
+  private _grouped = false;
+
+  /**
    * Allow multiple selection
    */
   @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
@@ -327,10 +341,14 @@ export class SwimSelect extends LitElement {
       .map(el => {
         const name = el.getAttribute('name') || '';
         const value = el.getAttribute('value');
+        const groupAttr = el.getAttribute('group');
+        const categoryAttr = el.getAttribute('category');
         return {
           name,
           value: value !== null ? value : name,
-          disabled: el.hasAttribute('disabled')
+          disabled: el.hasAttribute('disabled'),
+          ...(groupAttr != null && groupAttr.trim() !== '' ? { group: groupAttr.trim() } : {}),
+          ...(categoryAttr != null && categoryAttr.trim() !== '' ? { category: categoryAttr.trim() } : {})
         };
       });
   }
@@ -469,12 +487,18 @@ export class SwimSelect extends LitElement {
                   : nothing}
                 ${showList
                   ? html`
-                      <ul class="select-options">
-                        ${repeat(
-                          filteredOptions,
-                          option => this._getOptionValue(option),
-                          (option, index) => this._renderOption(option, index)
-                        )}
+                      <ul
+                        class="select-options ${this.grouped && this._listHasGroupHeadings(filteredOptions)
+                          ? 'select-options--grouped'
+                          : ''}"
+                      >
+                        ${this.grouped
+                          ? this._renderGroupedOptionRows(filteredOptions)
+                          : repeat(
+                              filteredOptions,
+                              option => this._getOptionValue(option),
+                              (option, index) => this._renderOption(option, index)
+                            )}
                       </ul>
                     `
                   : html`<div class="select-empty">${this._emptyDropdownMessage()}</div>`}
@@ -510,6 +534,39 @@ export class SwimSelect extends LitElement {
       return String(t);
     }
     return option.name;
+  }
+
+  /** Non-empty section title from `group` (preferred) or `category`. */
+  private _groupHeading(option: SelectOption): string {
+    const raw = option.group ?? option.category;
+    return raw != null && String(raw).trim() !== '' ? String(raw).trim() : '';
+  }
+
+  private _listHasGroupHeadings(options: SelectOption[]): boolean {
+    return options.some(o => this._groupHeading(o).length > 0);
+  }
+
+  private _renderGroupedOptionRows(filteredOptions: SelectOption[]): TemplateResult[] {
+    let previousHeading = '';
+    const rows: TemplateResult[] = [];
+    for (let index = 0; index < filteredOptions.length; index++) {
+      const option = filteredOptions[index];
+      const heading = this._groupHeading(option);
+      if (heading) {
+        if (heading !== previousHeading) {
+          rows.push(html`
+            <li class="select-option-group" role="presentation">
+              <span class="select-option-group-label">${heading}</span>
+            </li>
+          `);
+          previousHeading = heading;
+        }
+      } else {
+        previousHeading = '';
+      }
+      rows.push(this._renderOption(option, index));
+    }
+    return rows;
   }
 
   private _emptyDropdownMessage(): string {
@@ -772,7 +829,13 @@ export class SwimSelect extends LitElement {
     return this._allOptions.filter(option => {
       const label = this._getOptionLabel(option).toLowerCase();
       const desc = (option.description ?? '').toLowerCase();
-      return option.name.toLowerCase().includes(query) || label.includes(query) || desc.includes(query);
+      const group = this.grouped ? this._groupHeading(option).toLowerCase() : '';
+      return (
+        option.name.toLowerCase().includes(query) ||
+        label.includes(query) ||
+        desc.includes(query) ||
+        (group && group.includes(query))
+      );
     });
   }
 

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -16,8 +16,8 @@ import './select-option.component';
  * SwimSelect - A select/dropdown component matching @swimlane/ngx-ui design system
  *
  * Options can be provided via the `options` property or declaratively with `<swim-option>` children.
- * Set the `grouped` attribute to show section headers from each option’s `group` or `category`
- * (`SelectOption` fields or `<swim-option>` attributes). Without `grouped`, those fields are ignored for layout.
+ * Set the `grouped` attribute to show section headers from each option’s `group`
+ * (`SelectOption` field or `<swim-option group="...">`). Without `grouped`, `group` is ignored for layout.
  * ```html
  * <swim-select label="Attack Type">
  *   <swim-option name="Breach" value="breach"></swim-option>
@@ -242,7 +242,7 @@ export class SwimSelect extends LitElement {
   private _filterable = true;
 
   /**
-   * When true, show `group` / `category` as section headers in the dropdown (and indent options).
+   * When true, show `group` as section headers in the dropdown (and indent options).
    */
   @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get grouped(): boolean {
@@ -365,13 +365,11 @@ export class SwimSelect extends LitElement {
         const name = el.getAttribute('name') || '';
         const value = el.getAttribute('value');
         const groupAttr = el.getAttribute('group');
-        const categoryAttr = el.getAttribute('category');
         return {
           name,
           value: value !== null ? value : name,
           disabled: el.hasAttribute('disabled'),
-          ...(groupAttr != null && groupAttr.trim() !== '' ? { group: groupAttr.trim() } : {}),
-          ...(categoryAttr != null && categoryAttr.trim() !== '' ? { category: categoryAttr.trim() } : {})
+          ...(groupAttr != null && groupAttr.trim() !== '' ? { group: groupAttr.trim() } : {})
         };
       });
   }
@@ -604,9 +602,9 @@ export class SwimSelect extends LitElement {
     return option.name;
   }
 
-  /** Non-empty section title from `group` (preferred) or `category`. */
+  /** Non-empty section title from `group`. */
   private _groupHeading(option: SelectOption): string {
-    const raw = option.group ?? option.category;
+    const raw = option.group;
     return raw != null && String(raw).trim() !== '' ? String(raw).trim() : '';
   }
 

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -5,6 +5,7 @@ import { baseStyles } from '../../styles/base';
 import { scrollbarStyles } from '../../styles/scrollbars';
 import { selectStyles } from './select.styles';
 import { SelectOption } from './select-option.interface';
+import { optionMatchesFilter } from './select-filter.util';
 import { InputAppearance } from '../input/input-appearance.enum';
 import { InputSize } from '../input/input-size.enum';
 import { coerceBooleanProperty, litBooleanAttrDefaultFalse, litBooleanAttrDefaultTrue } from '../../utils/coerce';
@@ -902,18 +903,9 @@ export class SwimSelect extends LitElement {
       return this._allOptions;
     }
 
-    const query = this._filterQuery.toLowerCase();
-    return this._allOptions.filter(option => {
-      const label = this._getOptionLabel(option).toLowerCase();
-      const desc = (option.description ?? '').toLowerCase();
-      const group = this.grouped ? this._groupHeading(option).toLowerCase() : '';
-      return (
-        option.name.toLowerCase().includes(query) ||
-        label.includes(query) ||
-        desc.includes(query) ||
-        (group && group.includes(query))
-      );
-    });
+    return this._allOptions.filter(option =>
+      optionMatchesFilter(option, this._filterQuery, { filterCaseSensitive: false })
+    );
   }
 
   private _getOptionValue(option: SelectOption): any {

--- a/projects/swimlane/swim-ui/src/components/select/select.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.styles.ts
@@ -199,10 +199,6 @@ export const selectStyles = css`
     transition: color 0.2s ease-in-out;
   }
 
-  .select-hint.hidden {
-    display: none;
-  }
-
   /* Dropdown */
   .select-dropdown {
     position: absolute;

--- a/projects/swimlane/swim-ui/src/components/select/select.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.styles.ts
@@ -259,6 +259,20 @@ export const selectStyles = css`
     color: var(--grey-350);
   }
 
+  .select-filter-input:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+  }
+
+  .select-filter--loading .select-filter-input {
+    opacity: 0.85;
+    cursor: wait;
+  }
+
+  .select-filter--loading {
+    position: relative;
+  }
+
   .select-options {
     list-style: none;
     padding: 0;

--- a/projects/swimlane/swim-ui/src/components/select/select.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.styles.ts
@@ -279,6 +279,29 @@ export const selectStyles = css`
     margin: 0;
   }
 
+  .select-options--grouped .select-option {
+    padding-left: 25px;
+  }
+
+  .select-option-group {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    pointer-events: none;
+  }
+
+  .select-option-group-label {
+    display: block;
+    padding: 7px 15px;
+    font-size: var(--font-size-m);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--font-line-height-100);
+    color: var(--grey-300);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .select-option {
     padding: 7px 15px;
     font-size: var(--font-size-m);

--- a/projects/swimlane/swim-ui/src/components/select/select.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.styles.ts
@@ -33,21 +33,57 @@ export const selectStyles = css`
     font-size: var(--font-size-xl) !important;
   }
 
-  :host([focused]:not([invalid])) .select-label {
+  :host([focused]:not([invalid]):not([disabled])) .select-label {
     color: var(--blue-500) !important;
   }
 
-  :host([invalid][touched]) .select-underline {
+  :host([invalid][touched]:not([disabled])) .select-underline {
     background-color: var(--red-500) !important;
   }
 
-  :host([invalid][touched]) .underline-fill {
+  :host([invalid][touched]:not([disabled])) .underline-fill {
     background-color: var(--red-500) !important;
   }
 
-  :host([invalid][touched]) .select-label,
-  :host([invalid][touched]) .select-hint {
+  :host([invalid][touched]:not([disabled])) .select-label,
+  :host([invalid][touched]:not([disabled])) .select-hint {
     color: var(--red-500);
+  }
+
+  :host([disabled]) .select-input {
+    cursor: not-allowed;
+    color: var(--grey-400);
+    user-select: none;
+    pointer-events: none;
+  }
+
+  :host([disabled]) .select-label {
+    color: var(--grey-450);
+  }
+
+  :host([disabled]) .select-placeholder {
+    color: var(--grey-450);
+  }
+
+  :host([disabled]) .select-controls {
+    color: var(--grey-500);
+  }
+
+  :host([disabled]) .select-underline {
+    background-color: var(--grey-700);
+  }
+
+  :host([disabled]) .underline-fill {
+    width: 0 !important;
+  }
+
+  :host([disabled]) .select-hint {
+    color: var(--grey-450);
+  }
+
+  :host([disabled]) .select-chip {
+    background: var(--grey-650);
+    color: var(--grey-300);
   }
 
   .select-wrap {
@@ -96,11 +132,6 @@ export const selectStyles = css`
     outline: none;
   }
 
-  .select-input[disabled] {
-    cursor: not-allowed;
-    color: var(--grey-400);
-  }
-
   .select-value {
     flex: 1;
     padding: 3px 0;
@@ -146,7 +177,7 @@ export const selectStyles = css`
     margin-right: var(--spacing-8);
   }
 
-  :host([open]) .select-caret {
+  :host([open]:not([disabled])) .select-caret {
     transform: rotate(180deg);
   }
 
@@ -185,8 +216,8 @@ export const selectStyles = css`
     margin: 0 auto;
   }
 
-  :host([focused]) .underline-fill,
-  :host([open]) .underline-fill {
+  :host([focused]:not([disabled])) .underline-fill,
+  :host([open]:not([disabled])) .underline-fill {
     width: 100%;
   }
 

--- a/projects/swimlane/swim-ui/src/components/select/select.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.styles.ts
@@ -399,7 +399,7 @@ export const selectStyles = css`
   .select-chip-remove {
     background: none;
     border: none;
-    padding: 0;
+    padding: 4px 0 0 0;
     cursor: pointer;
     color: var(--grey-350);
     font-size: 0.5em;

--- a/projects/swimlane/swim-ui/src/components/slider/slider.component.ts
+++ b/projects/swimlane/swim-ui/src/components/slider/slider.component.ts
@@ -2,7 +2,7 @@ import { LitElement, html, PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { sliderStyles } from './slider.styles';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, coerceNumberProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 let nextId = 0;
 
@@ -79,7 +79,7 @@ export class SwimSlider extends LitElement {
   /**
    * Whether to show the filled portion of the track
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get filled(): boolean {
     return this._filled;
   }
@@ -91,7 +91,7 @@ export class SwimSlider extends LitElement {
   /**
    * Whether to allow multiple thumbs (range)
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get multiple(): boolean {
     return this._multiple;
   }
@@ -103,7 +103,7 @@ export class SwimSlider extends LitElement {
   /**
    * Whether the slider is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -115,7 +115,7 @@ export class SwimSlider extends LitElement {
   /**
    * Whether to show tick marks
    */
-  @property({ type: Boolean, attribute: 'show-ticks' })
+  @property({ type: Boolean, attribute: 'show-ticks', converter: litBooleanAttrDefaultFalse })
   get showTicks(): boolean {
     return this._showTicks;
   }

--- a/projects/swimlane/swim-ui/src/components/slider/slider.component.ts
+++ b/projects/swimlane/swim-ui/src/components/slider/slider.component.ts
@@ -267,8 +267,8 @@ export class SwimSlider extends LitElement {
     this.dispatchEvent(
       new CustomEvent<SliderChangeDetail>('change', {
         detail: { value: this.multiple ? value : Number(value), percent },
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/split/split-area.component.ts
+++ b/projects/swimlane/swim-ui/src/components/split/split-area.component.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
+import { litBooleanAttrDefaultFalse } from '../../utils/coerce';
 import { splitAreaBaseStyles } from './split-area.styles';
 import { basisToParts, partsToStyle } from './utils';
 import type { FlexParts } from './utils';
@@ -42,7 +43,7 @@ export class SwimSplitArea extends LitElement implements ISplitArea {
   maxBasis: string | undefined;
 
   /** When true, min-width/max-width are set from current basis (for edge cases). */
-  @property({ type: Boolean, attribute: 'should-adjust-max-min' })
+  @property({ type: Boolean, attribute: 'should-adjust-max-min', converter: litBooleanAttrDefaultFalse })
   shouldAdjustMaxMin = false;
 
   initialFlexParts: FlexParts = basisToParts('1', '1', DEFAULT_BASIS);

--- a/projects/swimlane/swim-ui/src/components/split/split-handle.component.ts
+++ b/projects/swimlane/swim-ui/src/components/split/split-handle.component.ts
@@ -11,10 +11,10 @@ const DEFAULT_BASIS = '0 0 15px';
  * SwimSplitHandle - Draggable divider between split areas. Used as a direct child of swim-split.
  * Direction is set by the parent swim-split.
  *
- * @fires drag - Fired during drag with movement (detail: MouseEvent)
- * @fires dragstart - Fired on mousedown when drag starts
- * @fires dragend - Fired on mouseup when drag ends
- * @fires dblclick - Fired on double-click (used by parent to snap to extremes)
+ * @fires drag - Fired during drag (detail: MouseEvent). Does not bubble.
+ * @fires dragstart - Fired on mousedown when drag starts. Does not bubble.
+ * @fires dragend - Fired on mouseup when drag ends. Does not bubble.
+ * @fires dblclick - Fired on double-click (parent snaps). Does not bubble.
  */
 const SPLIT_HANDLE_TAG = 'swim-split-handle';
 export class SwimSplitHandle extends LitElement {
@@ -65,21 +65,21 @@ export class SwimSplitHandle extends LitElement {
     ev.preventDefault();
     document.addEventListener('mouseup', this._boundMouseUp, true);
     document.addEventListener('mousemove', this._boundMouseMove, true);
-    this.dispatchEvent(new CustomEvent('dragstart', { detail: ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('dragstart', { detail: ev, bubbles: false, composed: false }));
   }
 
   private _onMouseMove(ev: MouseEvent): void {
-    this.dispatchEvent(new CustomEvent('drag', { detail: ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('drag', { detail: ev, bubbles: false, composed: false }));
   }
 
   private _onMouseUp(ev: MouseEvent): void {
     document.removeEventListener('mouseup', this._boundMouseUp, true);
     document.removeEventListener('mousemove', this._boundMouseMove, true);
-    this.dispatchEvent(new CustomEvent('dragend', { detail: ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('dragend', { detail: ev, bubbles: false, composed: false }));
   }
 
   private _onDblClick(ev: MouseEvent): void {
-    this.dispatchEvent(new CustomEvent('dblclick', { detail: ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('dblclick', { detail: ev, bubbles: false, composed: false }));
   }
 
   render() {

--- a/projects/swimlane/swim-ui/src/components/tabs/tab.component.ts
+++ b/projects/swimlane/swim-ui/src/components/tabs/tab.component.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { tabStyles } from './tab.styles.js';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 let nextId = 0;
 
@@ -58,7 +58,7 @@ export class SwimTab extends LitElement {
   /**
    * Whether this tab is currently active
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get active(): boolean {
     return this._active;
   }
@@ -76,7 +76,7 @@ export class SwimTab extends LitElement {
   /**
    * Whether this tab is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }

--- a/projects/swimlane/swim-ui/src/components/tabs/tab.component.ts
+++ b/projects/swimlane/swim-ui/src/components/tabs/tab.component.ts
@@ -11,6 +11,8 @@ let nextId = 0;
  *
  * @slot label - Custom label content (optional; if not used, the `label` property is shown in the tab list)
  * @slot - Tab panel content (shown when this tab is active)
+ *
+ * @fires swim-tab-active-change - Fired when `active` changes. Does not bubble.
  */
 const TAB_TAG = 'swim-tab';
 export class SwimTab extends LitElement {
@@ -68,7 +70,7 @@ export class SwimTab extends LitElement {
       const prev = this._active;
       this._active = next;
       this.requestUpdate('active', prev);
-      this.dispatchEvent(new CustomEvent('swim-tab-active-change', { bubbles: true, composed: true }));
+      this.dispatchEvent(new CustomEvent('swim-tab-active-change', { bubbles: false, composed: false }));
     }
   }
   private _active = false;

--- a/projects/swimlane/swim-ui/src/components/tabs/tabs.component.ts
+++ b/projects/swimlane/swim-ui/src/components/tabs/tabs.component.ts
@@ -11,8 +11,8 @@ import { coerceBooleanProperty, litBooleanAttrDefaultFalse } from '../../utils/c
  *
  * @slot - Default slot for swim-tab children (tab panels)
  *
- * @fires select-tab - Fired when the active tab changes (detail: { tab: SwimTab })
- * @fires select - Alias for select-tab (backwards compatibility)
+ * @fires select-tab - Fired when the active tab changes (detail: { tab: SwimTab }). Does not bubble.
+ * @fires select - Same detail as select-tab (legacy alias). Does not bubble.
  *
  * @csspart tablist - The tab list container (role=tablist)
  * @csspart tab-content - The container for tab panels
@@ -97,15 +97,15 @@ export class SwimTabs extends LitElement {
     this.dispatchEvent(
       new CustomEvent('select-tab', {
         detail: { tab },
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
     this.dispatchEvent(
       new CustomEvent('select', {
         detail: { tab },
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }

--- a/projects/swimlane/swim-ui/src/components/tabs/tabs.component.ts
+++ b/projects/swimlane/swim-ui/src/components/tabs/tabs.component.ts
@@ -4,7 +4,7 @@ import { baseStyles } from '../../styles/base';
 import { tabsStyles } from './tabs.styles';
 import { SwimTab } from './tab.component';
 import { TabsAppearance } from './tabs-appearance.enum';
-import { coerceBooleanProperty } from '../../utils/coerce';
+import { coerceBooleanProperty, litBooleanAttrDefaultFalse } from '../../utils/coerce';
 
 /**
  * SwimTabs - Tabs container matching @swimlane/ngx-ui design system
@@ -27,7 +27,7 @@ export class SwimTabs extends LitElement {
   /**
    * Layout direction: vertical shows tabs on the left
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get vertical(): boolean {
     return this._vertical;
   }

--- a/projects/swimlane/swim-ui/src/components/toggle/toggle.component.ts
+++ b/projects/swimlane/swim-ui/src/components/toggle/toggle.component.ts
@@ -177,18 +177,18 @@ export class SwimToggle extends LitElement {
           timeStamp: Date.now(),
           target: { checked: this._checked }
         },
-        bubbles: true,
-        composed: true
+        bubbles: false,
+        composed: false
       })
     );
   }
 
   private _onFocus(ev: FocusEvent) {
-    this.dispatchEvent(new FocusEvent('focus', { ...ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('focus', { ...ev, bubbles: false, composed: false }));
   }
 
   private _onBlur(ev: FocusEvent) {
-    this.dispatchEvent(new FocusEvent('blur', { ...ev, bubbles: true, composed: true }));
+    this.dispatchEvent(new FocusEvent('blur', { ...ev, bubbles: false, composed: false }));
   }
 
   private _onInputChange(ev: Event) {

--- a/projects/swimlane/swim-ui/src/components/toggle/toggle.component.ts
+++ b/projects/swimlane/swim-ui/src/components/toggle/toggle.component.ts
@@ -2,13 +2,12 @@ import { LitElement, html } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { baseStyles } from '../../styles/base';
 import { toggleStyles } from './toggle.styles';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
-
-/** Converter so show-icons="false" is respected (Lit's default Boolean ignores attribute value). */
-const booleanAttrConverter = {
-  fromAttribute: (value: string | null): boolean => value !== 'false' && value !== '',
-  toAttribute: (value: boolean): string => (value ? 'true' : 'false')
-};
+import {
+  coerceBooleanProperty,
+  coerceNumberProperty,
+  litBooleanAttrDefaultFalse,
+  litBooleanAttrDefaultTrue
+} from '../../utils/coerce';
 
 let nextId = 0;
 
@@ -57,7 +56,7 @@ export class SwimToggle extends LitElement {
   /**
    * Checked (on) state. Reflects as attribute for styling.
    */
-  @property({ type: Boolean, reflect: true, attribute: 'checked' })
+  @property({ type: Boolean, reflect: true, attribute: 'checked', converter: litBooleanAttrDefaultFalse })
   get checked(): boolean {
     return this._checked;
   }
@@ -72,7 +71,7 @@ export class SwimToggle extends LitElement {
   /**
    * Whether the toggle is disabled
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -84,7 +83,7 @@ export class SwimToggle extends LitElement {
   /**
    * Whether the toggle is required (for forms)
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get required(): boolean {
     return this._required;
   }
@@ -96,7 +95,7 @@ export class SwimToggle extends LitElement {
   /**
    * Whether to show check/x icons inside the track
    */
-  @property({ type: Boolean, attribute: 'show-icons', converter: booleanAttrConverter })
+  @property({ type: Boolean, attribute: 'show-icons', converter: litBooleanAttrDefaultTrue })
   get showIcons(): boolean {
     return this._showIcons;
   }

--- a/projects/swimlane/swim-ui/src/components/tooltip/tooltip.component.ts
+++ b/projects/swimlane/swim-ui/src/components/tooltip/tooltip.component.ts
@@ -213,7 +213,7 @@ export class SwimTooltip extends LitElement {
           this._addHideListeners();
         });
       });
-      this.dispatchEvent(new CustomEvent('show', { detail: true, bubbles: true }));
+      this.dispatchEvent(new CustomEvent('show', { detail: true, bubbles: false, composed: false }));
     };
     if (immediate) {
       run();
@@ -234,7 +234,7 @@ export class SwimTooltip extends LitElement {
       this._openFromClick = false;
       this._removeDocumentClick();
       this._removePanelHideListeners();
-      this.dispatchEvent(new CustomEvent('hide', { detail: true, bubbles: true }));
+      this.dispatchEvent(new CustomEvent('hide', { detail: true, bubbles: false, composed: false }));
     };
     if (immediate) {
       destroy();

--- a/projects/swimlane/swim-ui/src/components/tooltip/tooltip.component.ts
+++ b/projects/swimlane/swim-ui/src/components/tooltip/tooltip.component.ts
@@ -8,7 +8,12 @@ import { StyleType } from './style-type.enum';
 import { ShowType } from './show-type.enum';
 import { positionContent, positionCaret, determinePlacement } from './position';
 import type { Dimensions } from './position';
-import { coerceBooleanProperty, coerceNumberProperty } from '../../utils/coerce';
+import {
+  coerceBooleanProperty,
+  coerceNumberProperty,
+  litBooleanAttrDefaultFalse,
+  litBooleanAttrDefaultTrue
+} from '../../utils/coerce';
 
 /**
  * SwimTooltip – tooltip and popover wrapper matching @swimlane/ngx-ui.
@@ -61,10 +66,7 @@ export class SwimTooltip extends LitElement {
   @property({
     type: Boolean,
     attribute: 'show-caret',
-    converter: {
-      fromAttribute: (value: string | null) => value !== 'false',
-      toAttribute: (value: boolean) => (value ? '' : 'false')
-    }
+    converter: litBooleanAttrDefaultTrue
   })
   get showCaret(): boolean {
     return this._showCaret;
@@ -75,7 +77,7 @@ export class SwimTooltip extends LitElement {
   private _showCaret = true;
 
   /** Whether tooltip is disabled. */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, converter: litBooleanAttrDefaultFalse })
   get disabled(): boolean {
     return this._disabled;
   }
@@ -85,7 +87,7 @@ export class SwimTooltip extends LitElement {
   private _disabled = false;
 
   /** Close when clicking outside. */
-  @property({ type: Boolean, attribute: 'close-on-click-outside' })
+  @property({ type: Boolean, attribute: 'close-on-click-outside', converter: litBooleanAttrDefaultTrue })
   get closeOnClickOutside(): boolean {
     return this._closeOnClickOutside;
   }
@@ -95,7 +97,7 @@ export class SwimTooltip extends LitElement {
   private _closeOnClickOutside = true;
 
   /** Close when mouse leaves trigger (and panel if applicable). */
-  @property({ type: Boolean, attribute: 'close-on-mouse-leave' })
+  @property({ type: Boolean, attribute: 'close-on-mouse-leave', converter: litBooleanAttrDefaultTrue })
   get closeOnMouseLeave(): boolean {
     return this._closeOnMouseLeave;
   }

--- a/projects/swimlane/swim-ui/src/index.ts
+++ b/projects/swimlane/swim-ui/src/index.ts
@@ -16,6 +16,7 @@ export * from './components/calendar';
 export * from './components/card';
 export * from './components/checkbox';
 export * from './components/date-time';
+export * from './components/date-display';
 export * from './components/dialog';
 export * from './components/drawer';
 export * from './components/icon';

--- a/projects/swimlane/swim-ui/src/index.ts
+++ b/projects/swimlane/swim-ui/src/index.ts
@@ -1,6 +1,12 @@
 /**
  * @swimlane/swim-ui
  * Swim web component library matching Swimlane's ngx-ui design system
+ *
+ * **Custom events:** Dispatch with `bubbles: false` and `composed: false` by default so host-local
+ * listeners (`addEventListener` / Lit `@event` on the `swim-*` element) do not leak to ancestors or
+ * `document`. Event names stay conventional (e.g. `change`, `close`, `open`) because they do not bubble.
+ * If a future feature must use `bubbles: true`, prefer a non-generic, swim-specific event name to avoid
+ * collisions. See `.cursor/skills/use-swim-ui/SKILL.md` for the per-event table.
  */
 
 export * from './components/button';

--- a/projects/swimlane/swim-ui/src/styles/base.ts
+++ b/projects/swimlane/swim-ui/src/styles/base.ts
@@ -168,6 +168,13 @@ export const baseStyles = css`
     --shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12);
     --shadow-2: 0 1px 5px 0 rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12);
     --shadow-3: 0 1px 8px 0 rgba(0, 0, 0, 0.2), 0 3px 4px 0 rgba(0, 0, 0, 0.14), 0 3px 3px -2px rgba(0, 0, 0, 0.12);
+
+    /* Modal / large-format surface (ngx gradient-variables $bg-linear-3) */
+    --bg-linear-3: linear-gradient(180deg, #252a37 0%, #212631 100%);
+    /* Figma modal panel (filter: dy=2, stdDeviation=3.5, alpha 0.2) */
+    --shadow-dialog-panel: 0 2px 7px rgba(0, 0, 0, 0.2);
+    /* Diffuse halo (ngx large-format legacy); override with --shadow-dialog-panel for Figma parity */
+    --shadow-dialog-glow: 0 0 100px rgba(0, 0, 0, 0.25);
   }
 `;
 

--- a/projects/swimlane/swim-ui/src/styles/base.ts
+++ b/projects/swimlane/swim-ui/src/styles/base.ts
@@ -129,34 +129,44 @@ export const baseStyles = css`
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
 
-    /* Spacing */
-    --spacing-0: 0;
+    /* Spacing — aligned with ngx-ui layouts/_vars.scss */
+    --spacing-0: 0px;
     --spacing-2: 2px;
     --spacing-4: 4px;
+    --spacing-6: 6px;
     --spacing-8: 8px;
     --spacing-10: 10px;
     --spacing-12: 12px;
+    --spacing-14: 14px;
     --spacing-16: 16px;
+    --spacing-18: 18px;
     --spacing-20: 20px;
     --spacing-24: 24px;
-    --spacing-32: 32px;
+    --spacing-30: 30px;
+    --spacing-36: 36px;
+    --spacing-40: 40px;
+    --spacing-48: 48px;
 
-    /* Border Radius */
-    --radius-0: 0;
+    /* Border radius — aligned with ngx-ui layouts/_vars.scss */
+    --radius-0: 0px;
     --radius-2: 2px;
     --radius-4: 4px;
     --radius-6: 6px;
     --radius-8: 8px;
+    --radius-12: 12px;
     --radius-16: 16px;
+    --radius-24: 24px;
+    --radius-32: 32px;
     --radius-64: 64px;
+    --radius-1000: 1000px;
 
     /* Semantic colors */
     --color-error: var(--red-500);
     --color-success: #b0e53c;
 
-    /* Shadows */
-    --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.3);
-    --shadow-2: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+    /* Shadows — aligned with ngx-ui shadow-variables.scss (Material-style key/penumbra/ambient) */
+    --shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12);
+    --shadow-2: 0 1px 5px 0 rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12);
     --shadow-3: 0 1px 8px 0 rgba(0, 0, 0, 0.2), 0 3px 4px 0 rgba(0, 0, 0, 0.14), 0 3px 3px -2px rgba(0, 0, 0, 0.12);
   }
 `;

--- a/projects/swimlane/swim-ui/src/utils/coerce.ts
+++ b/projects/swimlane/swim-ui/src/utils/coerce.ts
@@ -25,10 +25,16 @@ export function coerceNumberProperty(value: any, fallbackValue: number | null = 
  */
 export const litBooleanAttrDefaultTrue = {
   fromAttribute: (value: string | null): boolean => value !== 'false',
-  toAttribute: (value: boolean): string => (value ? 'true' : 'false')
+  /** Omit attribute when true (default); set explicit `="false"` only when off. */
+  toAttribute: (value: boolean): string | null => (value ? null : 'false')
 };
 
 export const litBooleanAttrDefaultFalse = {
   fromAttribute: (value: string | null): boolean => value !== null && value !== 'false' && value !== '0',
-  toAttribute: (value: boolean): string => (value ? 'true' : 'false')
+  /**
+   * Use empty string when true so the boolean attribute is present; remove when false.
+   * Serializing false as `attr="false"` leaves the attribute in the DOM, so selectors like
+   * `[disabled]` / `[loading]` (common in resets and lazy-load styles) still match the host.
+   */
+  toAttribute: (value: boolean): string | null => (value ? '' : null)
 };

--- a/projects/swimlane/swim-ui/src/utils/coerce.ts
+++ b/projects/swimlane/swim-ui/src/utils/coerce.ts
@@ -18,3 +18,17 @@ export function coerceNumberProperty<D>(value: any, fallback: D): number | D;
 export function coerceNumberProperty(value: any, fallbackValue: number | null = null): number | null {
   return isNaN(parseFloat(value as any)) || isNaN(Number(value)) ? fallbackValue : Number(value);
 }
+
+/**
+ * Lit `type: Boolean` uses `fromAttribute: (v) => v != null`, so `prop="false"` becomes true.
+ * Use these converters on `@property({ type: Boolean, converter: … })` so string `"false"` is honored.
+ */
+export const litBooleanAttrDefaultTrue = {
+  fromAttribute: (value: string | null): boolean => value !== 'false',
+  toAttribute: (value: boolean): string => (value ? 'true' : 'false')
+};
+
+export const litBooleanAttrDefaultFalse = {
+  fromAttribute: (value: string | null): boolean => value !== null && value !== 'false' && value !== '0',
+  toAttribute: (value: boolean): string => (value ? 'true' : 'false')
+};

--- a/projects/swimlane/swim-ui/vite.lib.config.ts
+++ b/projects/swimlane/swim-ui/vite.lib.config.ts
@@ -10,6 +10,7 @@ const COMPONENT_NAMES = [
   'card',
   'checkbox',
   'date-time',
+  'date-display',
   'dialog',
   'drawer',
   'icon',


### PR DESCRIPTION
## Summary

This work improves **swim-ui** parity with ngx patterns, standardizes boolean attributes and custom-event contracts, enhances **dialog**, **select**, and **button**, aligns **large-format** dialog theming and footer layout, and expands the swim-ui **demo** and **Cursor swim-ui skill** docs.

### `swim-date-display` (new)

Adds **`swim-date-display`** — a read-only date/time element aligned with **ngx-time** / time-display from `@swimlane/ngx-ui`:

- **Inputs:** `datetime` (string or `Date`), optional `precision`, `timezone`, `default-input-time-zone`, `mode` (`timezone` | `human` | `local` | `custom`), `type` (`datetime` | `date` | `time`), `format`, `tooltip-format`, `clip-format`, and a `timezones` map (label → IANA id) for multi-zone views.
- **Display:** Uses shared `date-format` helpers (`formatDate`, `parseDate`, `resolveFormat`, etc.) so tokens and behavior stay consistent with `swim-date-time`.
- **Human mode:** Relative text via `Intl.RelativeTimeFormat` (e.g. minutes/hours/days ago).
- **Tooltip:** Optional multi-zone tooltip (`swim-tooltip`) with configurable placement, CSS class, and `tooltip-disabled`; underline when a zone panel applies (ngx `hasPopup` parity).
- **Clipboard:** Click or keyboard activation copies a zone-specific string (formats from `clip-format` / defaults); `default-copy-key` picks which zone row is the primary copy target. **`clickable`** supports an ngx-style **auto** mode (attribute omitted): enabled when the default copy key has clip text (e.g. multiple timezones).
- **Events:** Fires **`date-copied`** after copy with `detail: { key, clip, message }`. This event intentionally uses **`bubbles: true` / `composed: true`** so host apps can observe copy actions across shadow boundaries (unlike the repo-wide default of non-bubbling events elsewhere in this PR).
- **A11y / semantics:** Renders a semantic `<time>` with `datetime` where valid; invalid input shows `invalid-date-message`.
- **Shipping:** Exported from `package.json` / `src/index.ts` / Vite lib config; demo section **`demo/public/sections/date-display.html`** and nav wiring in `demo-init.ts` / `index.html`.

### Other highlights

- **Boolean attributes:** `litBooleanAttrDefaultTrue` / `litBooleanAttrDefaultFalse` in `coerce.ts` so values like `prop="false"` serialize and deserialize correctly; applied across many swim-ui components.
- **`swim-dialog`:** `close-on-blur` and `close-on-escape`, improved `close-button` behavior for large/medium headers, optional theming via CSS variables, enter animation for content (with `prefers-reduced-motion`), and focus management adjustments.
- **`swim-select`:** Panel events **`dropdown-open`** / **`dropdown-close`**; async filtering (`async-filter`, debounced **`filter-change`**), **grouped** options, optional popover top layer, **`dropdown-align`**, and related updates.
- **ngx `ngx-large-format-dialog-footer`:** **`align`** input and styles/tests where applicable in the branch.
- **Events (repo-wide):** Many custom events now default to **`bubbles: false` / `composed: false`** with updated docs and an event-propagation demo; see **Breaking / migration** below.

### Breaking / migration

- Consumers listening for **`open`** / **`close`** on **`swim-select`** must switch to **`dropdown-open`** / **`dropdown-close`**.
- Consumers that relied on **bubbling** custom events from swim-ui hosts may need to listen on the element directly or adjust delegation; **`date-copied`** on **`swim-date-display`** remains bubbling/composed by design.

### Risk / rollout

**High risk** in places: event propagation semantics changed for many components, and select dropdown events were renamed. Review consumers that use event delegation from document/window.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
