### PR TITLE
(release):52.0.0-alpha.2 | Start date and end date timming fix when selecting date manually

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 52.0.0-alpha.2 (2026-05-11)
+
 - Fix (`ngx-date-range-picker`): Fixed start and end times being wrong when manually selecting a date range. Clicking a start day now normalizes to `startOfDay()` (00:00:00) and clicking an end day normalizes to `endOfDay()` (23:59:59.999), matching the behaviour of the "Last week" and other presets. The fix is isolated to `onRangeSelect` so the calendar time inputs and AM/PM toggle are unaffected.
 
 ## 52.0.0-alpha.1 (2026-04-28)

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "52.0.0-alpha.1",
+  "version": "52.0.0-alpha.2",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary

Fix (`ngx-date-range-picker`): Fixed start and end times being wrong when manually selecting a date range. Clicking a start day now normalizes to `startOfDay()` (00:00:00) and clicking an end day normalizes to `endOfDay()` (23:59:59.999), matching the behaviour of the "Last week" and other presets. The fix is isolated to `onRangeSelect` so the calendar time inputs and AM/PM toggle are unaffected.


## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: bumps `@swimlane/ngx-ui` version and adds the `52.0.0-alpha.2` changelog entry; no runtime code changes in this diff.
> 
> **Overview**
> Prepares the `52.0.0-alpha.2` prerelease by bumping `projects/swimlane/ngx-ui/package.json` from `52.0.0-alpha.1` to `52.0.0-alpha.2`.
> 
> Updates `CHANGELOG.md` with a new `52.0.0-alpha.2` section describing the `ngx-date-range-picker` manual range-selection time normalization fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee88ea062fe82de930fb1cc0d10f78b89afa8945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->