### PR TITLE
(fix): prevent unwanted scroll when drawer opens

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-drawer`): Added `preventScroll: true` to the drawer's `focus()` call on init to prevent unwanted page scrolling when a drawer opens.
+
 ## 52.0.0-alpha.3 (2026-05-11)
 
 - Breaking: Removing angular 18 support

--- a/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.component.spec.ts
@@ -34,6 +34,14 @@ describe('DrawerComponent', () => {
     expect(component.closeOnOutsideClick).toEqual(true);
   });
 
+  describe('ngOnInit', () => {
+    it('should focus the element with preventScroll to avoid unwanted page scroll', () => {
+      const spy = vi.spyOn(component['elementRef'].nativeElement, 'focus');
+      component.ngOnInit();
+      expect(spy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+  });
+
   describe('cssClasses', () => {
     it('should get left drawer classes', () => {
       component.direction = DrawerDirection.Left;

--- a/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/drawer/drawer.component.ts
@@ -99,7 +99,7 @@ export class DrawerComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.position = this.isRoot ? DrawerPosition.fixed : DrawerPosition.absolute;
     this.setDimensions(this.size);
-    this.elementRef.nativeElement.focus();
+    this.elementRef.nativeElement.focus({ preventScroll: true });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
after edit screenshot of scroll DOD - 

<img width="941" height="344" alt="image" src="https://github.com/user-attachments/assets/1079fdf3-995c-4e21-9b12-745d8faf92ba" />


## Summary

When a drawer opens, `DrawerComponent.ngOnInit` calls `this.elementRef.nativeElement.focus()` to give the drawer keyboard focus. Without options, the browser scrolls the page to bring the element into view, causing a jarring scroll jump on every drawer open.

This fix passes `{ preventScroll: true }` to the `focus()` call so the drawer receives focus without triggering any scroll.

## Changes

- `drawer.component.ts`: pass `{ preventScroll: true }` to `nativeElement.focus()` in `ngOnInit`
- `drawer.component.spec.ts`: added unit test asserting `focus` is called with `{ preventScroll: true }`
- `CHANGELOG.md`: added entry under HEAD (unreleased)

## Checklist

- [x] *Added unit tests
- [x] *Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- ~~[ ] Updated the demo page~~
- ~~[ ] Included screenshots of visual changes~~

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change limited to the drawer’s initial `focus()` call, plus a unit test; low risk aside from any edge browser support for `preventScroll`.
> 
> **Overview**
> Prevents the page from jumping when `ngx-drawer` opens by changing `DrawerComponent.ngOnInit` to call `nativeElement.focus({ preventScroll: true })`.
> 
> Adds a focused unit test asserting the new `focus()` options, and documents the fix in `CHANGELOG.md` under **HEAD (unreleased)**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc70ee74b6c611e91938551663e4de1be4938c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->