### PR TITLE
(release): 52.0.0-alpha.4

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 52.0.0-alpha.4 (2026-05-18)
+
 - Fix (`ngx-drawer`): Added `preventScroll: true` to the drawer's `focus()` call on init to prevent unwanted page scrolling when a drawer opens.
 
 ## 52.0.0-alpha.3 (2026-05-11)

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "52.0.0-alpha.3",
+  "version": "52.0.0-alpha.4",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary

Added `preventScroll: true` to the drawer's `focus()` call on init to prevent unwanted page scrolling when a drawer opens.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates release metadata (`package.json` version and `CHANGELOG.md`) with no functional code changes in this PR.
> 
> **Overview**
> Bumps `@swimlane/ngx-ui` from `52.0.0-alpha.3` to `52.0.0-alpha.4` and adds the corresponding `CHANGELOG.md` entry documenting the `ngx-drawer` `focus()` initialization change (`preventScroll: true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61f18e251fc5dbba030a25ee0d1e02dd39b2476b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->