### PR TITLE
Feat: Allowing to render a template as placeholder in the ngx-select

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## HEAD (unreleased)
 
-## 52.0.0-alpha.5 (2026-06-01)
-
 - Feature (`ngx-select`): Added `placeholderTemplate` to allow render a template as placeholder.
 
 ## 52.0.0-alpha.4 (2026-05-18)

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD (unreleased)
 
+## 52.0.0-alpha.5 (2026-06-01)
+
+- Feature (`ngx-select`): Added `placeholderTemplate` to allow render a template as placeholder.
+
 ## 52.0.0-alpha.4 (2026-05-18)
 
 - Fix (`ngx-drawer`): Added `preventScroll: true` to the drawer's `focus()` call on init to prevent unwanted page scrolling when a drawer opens.

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -14,8 +14,14 @@
         <span [innerHTML]="requiredIndicator"></span>
       </label>
     }
-    @if (!selected?.length && placeholder) {
+    @if (!selected?.length) {
+      @if (placeholder) {
       <span class="ngx-select-placeholder" [innerHTML]="placeholder"> </span>
+      } @else if (placeholderTemplate) {
+        <div class="ngx-select-placeholder template">
+          <ng-container [ngTemplateOutlet]="placeholderTemplate"></ng-container>
+        </div>
+      }
     }
     @if (tagging || selectedOptions?.length) {
       <ul

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
@@ -30,6 +30,7 @@ import { CoerceBooleanProperty } from '../../utils/coerce/coerce-boolean';
 export class SelectInputComponent implements AfterViewInit, OnChanges {
   @Input() selectId: string;
   @Input() placeholder: string;
+  @Input() placeholderTemplate: TemplateRef<any>;
   @Input() identifier: string;
   @Input() options: SelectDropdownOption[];
   @Input() label: string;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
@@ -9,6 +9,7 @@
         [label]="label"
         [requiredIndicator]="requiredIndicatorView"
         [placeholder]="placeholder"
+        [placeholderTemplate]="placeholderTemplate"
         [multiple]="multiple"
         [identifier]="identifier"
         [tagging]="tagging"

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
@@ -337,6 +337,24 @@ describe('SelectComponent', () => {
     });
   });
 
+  describe('hasPlaceholder', () => {
+    it('should be true when placeholder has content', () => {
+      component.select.placeholder = 'Select an option';
+      expect(component.select.hasPlaceholder).toBeTruthy();
+    });
+
+    it('should be false when placeholder is empty', () => {
+      component.select.placeholder = '';
+      expect(component.select.hasPlaceholder).toBeFalsy();
+    });
+
+    it('should be true when placeholderTemplate is set', () => {
+      component.select.placeholder = '';
+      component.select.placeholderTemplate = {} as any;
+      expect(component.select.hasPlaceholder).toBeTruthy();
+    });
+  });
+
   describe('optionTemplates', () => {
     it('should get templates', () => {
       expect(component.select.optionTemplates.length).toBeGreaterThan(0);

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -254,7 +254,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   }
 
   get hasPlaceholder() {
-    return this.placeholder && this.placeholder.length > 0;
+    return (this.placeholder && this.placeholder.length > 0) || !!this.placeholderTemplate;
   }
 
   get value() {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -200,6 +200,8 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
    */
   @Input() groupByTemplate: TemplateRef<unknown>;
 
+  @Input() placeholderTemplate: TemplateRef<unknown>;
+
   @ContentChildren(SelectOptionDirective, { descendants: true })
   get optionTemplates() {
     return this._optionTemplates;

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -308,6 +308,35 @@
 <br />
 <br />
 
+<h4>Placeholder Template</h4>
+<ngx-select [placeholderTemplate]="placeholderTemplate">
+  <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="false"></ngx-select-option>
+</ngx-select>
+<ng-template #placeholderTemplate>
+  <div class="custom-placeholder">
+    <i class="ngx-icon ngx-warning-filled-sm "></i> Select an item
+  </div>
+</ng-template>
+<app-prism>
+  <![CDATA[<ngx-select [placeholderTemplate]="placeholderTemplate">
+  <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
+  <ngx-select-option [name]="'DDOS'" [value]="'ddos'" [disabled]="true"></ngx-select-option>
+  <ngx-select-option [name]="'Physical'" [value]="'pyhs'" [disabled]="false"></ngx-select-option>
+</ngx-select>
+<ng-template #placeholderTemplate>
+  <div class="custom-placeholder">
+    <i class="ngx-icon ngx-warning-filled-sm"></i> Select an item
+  </div>
+</ng-template>
+]]>
+</app-prism>
+
+<br />
+<br />
+<br />
+
 <h4>Disabled Options with Placeholder</h4>
 <ngx-select [placeholder]="'Select incident type...'">
   <ngx-select-option [name]="'Breach'" [value]="'breach'"></ngx-select-option>
@@ -1112,6 +1141,13 @@
             <code>emptyPlaceholder: string = 'No options available'</code>
           </th>
           <td>Placeholder to display when the component has no selectable options.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>placeholderTemplate: TemplateRef</code>
+          </th>
+          <td>Template to display as a placeholder when the component has no selectable options.</td>
         </tr>
         <tr>
           <th>

--- a/src/app/forms/selects-page/selects-page.component.scss
+++ b/src/app/forms/selects-page/selects-page.component.scss
@@ -1,0 +1,10 @@
+@use 'colors/colors' as colors;
+
+.custom-placeholder {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  .ngx-icon {
+    color: colors.$color-red-500;
+  }
+}

--- a/src/app/forms/selects-page/selects-page.component.ts
+++ b/src/app/forms/selects-page/selects-page.component.ts
@@ -15,6 +15,7 @@ export function forbiddenNameValidator(nameRe: RegExp): ValidatorFn {
 @Component({
   selector: 'app-selects-page',
   templateUrl: './selects-page.component.html',
+  styleUrls: ['./selects-page.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false
 })


### PR DESCRIPTION
## Summary

Allowing to render a template as placeholder in the ngx-select

<img width="971" height="373" alt="Screenshot 2026-06-01 at 3 01 51 PM" src="https://github.com/user-attachments/assets/aad8971b-6331-4fe1-8d9b-f505a4bb2106" />


## Checklist

- [X] \*Added unit tests
- [X] \*Added a code reviewer
- [X] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [X] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and display-only placeholder path; existing string placeholders unchanged.
> 
> **Overview**
> **`ngx-select`** gains an optional **`placeholderTemplate`** (`TemplateRef`) so the empty state can show custom markup (icons, layout) instead of only the string **`placeholder`**.
> 
> When nothing is selected, **`ngx-select-input`** still prefers **`placeholder`** if set; otherwise it renders **`placeholderTemplate`** via **`ngTemplateOutlet`**. **`hasPlaceholder`** and the host **`has-placeholder`** class now treat a bound template as having a placeholder. Unit tests cover **`hasPlaceholder`** with **`placeholderTemplate`**; the selects demo and CHANGELOG document the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7236442fc77bee2fe8f4046d97054846d1dde8fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->