### PR TITLE
(feat) Adds sort support in List component

### DIFF
--- a/cypress/e2e/components/list.cy.ts
+++ b/cypress/e2e/components/list.cy.ts
@@ -20,7 +20,7 @@ describe('List', () => {
     });
 
     it('displays the row number using the row index', () => {
-      cy.get('ngx-list').eq(2).as('CUT');
+      cy.get('ngx-list[data-cy="virtualized-pagination-list"]').as('CUT');
       cy.get('@CUT').find('ngx-list-column').first().should('contain.text', '1.');
     });
   });

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Feature (`ngx-list`): Added header sorting support with local and external sort modes. Sortable headers cycle `asc → desc → asc` on click. New inputs: `sortable`, `prop`, `type` (`'text' | 'date'`), and `comparator` on `ngx-list-header`; `externalSorting` and `sort: ListSortPropDir | null` on `ngx-list`. New output `onSort: EventEmitter<ListSortEvent>` on `ngx-list`. New exported types: `ListSortPropDir`, `ListSortDirection`, `ListSortEvent`, `ListSortComparator`, `ListHeader`, `ListHeaderSortType`. New sort utilities: `defaultListSortComparator`, `dateListSortComparator`, `getListSortComparator`.
+- Feature (`ngx-list`): Added header sorting support with local and external sort modes. Sortable headers cycle `asc → desc → asc` on click. New inputs: `sortable`, `prop`, `type` (`'text' | 'date'`), and `comparator` on `ngx-list-header`; `externalSorting` and `sort: ListSortPropDir | null` on `ngx-list`. New output `onSort: EventEmitter<ListSortEvent>` on `ngx-list`. New exported types: `ListSortPropDir`, `ListSortDirection`, `ListSortEvent`, `ListSortComparator`, `ListHeader`, `ListHeaderSortType`. New sort utilities: `defaultListSortComparator`, `parseListSortDate`.
 
 ## 52.0.0-alpha.5 (2026-06-03)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Feature (`ngx-list`): Added header sorting support with local and external sort modes. Sortable headers cycle `asc → desc → asc` on click. New inputs: `sortable`, `prop`, `type` (`'text' | 'date'`), and `comparator` on `ngx-list-header`; `externalSorting` and `sort: ListSortPropDir | null` on `ngx-list`. New output `onSort: EventEmitter<ListSortEvent>` on `ngx-list`. New exported types: `ListSortPropDir`, `ListSortDirection`, `ListSortEvent`, `ListSortComparator`, `ListHeader`, `ListHeaderSortType`. New sort utilities: `defaultListSortComparator`, `dateListSortComparator`, `getListSortComparator`.
+
 ## 52.0.0-alpha.5 (2026-06-03)
 
 - Feature (`ngx-select`): Added `placeholderTemplate` to allow render a template as placeholder.

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-header/list-header.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-header/list-header.component.html
@@ -2,6 +2,25 @@
 
 <ng-template #template>
   @if (header) {
-  <ng-container [ngTemplateOutlet]="header.headerTemplate"></ng-container>
+    @if (header.sortable) {
+      <button type="button" class="ngx-list-header__sort-button" (click)="onSortClick()">
+        <span class="ngx-list-header__label">
+          <ng-container [ngTemplateOutlet]="header.headerTemplate"></ng-container>
+        </span>
+        <span
+          class="ngx-list-header__sort-indicator"
+          [class.ngx-list-header__sort-indicator--asc]="sortDir === 'asc'"
+          [class.ngx-list-header__sort-indicator--desc]="sortDir === 'desc'"
+        >
+          @if (sortDir === 'asc') {
+            <i class="ngx-icon ngx-arrow-up" aria-hidden="true"></i>
+          } @else if (sortDir === 'desc') {
+            <i class="ngx-icon ngx-arrow-down" aria-hidden="true"></i>
+          }
+        </span>
+      </button>
+    } @else {
+      <ng-container [ngTemplateOutlet]="header.headerTemplate"></ng-container>
+    }
   }
 </ng-template>

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-header/list-header.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-header/list-header.component.html
@@ -1,26 +1,24 @@
 <ng-container [ngTemplateOutlet]="template"></ng-container>
 
 <ng-template #template>
-  @if (header) {
-    @if (header.sortable) {
-      <button type="button" class="ngx-list-header__sort-button" (click)="onSortClick()">
-        <span class="ngx-list-header__label">
-          <ng-container [ngTemplateOutlet]="header.headerTemplate"></ng-container>
-        </span>
-        <span
-          class="ngx-list-header__sort-indicator"
-          [class.ngx-list-header__sort-indicator--asc]="sortDir === 'asc'"
-          [class.ngx-list-header__sort-indicator--desc]="sortDir === 'desc'"
-        >
-          @if (sortDir === 'asc') {
-            <i class="ngx-icon ngx-arrow-up" aria-hidden="true"></i>
-          } @else if (sortDir === 'desc') {
-            <i class="ngx-icon ngx-arrow-down" aria-hidden="true"></i>
-          }
-        </span>
-      </button>
-    } @else {
+  @if (header) { @if (header.sortable) {
+  <button type="button" class="ngx-list-header__sort-button" (click)="onSortClick()">
+    <span class="ngx-list-header__label">
       <ng-container [ngTemplateOutlet]="header.headerTemplate"></ng-container>
-    }
-  }
+    </span>
+    <span
+      class="ngx-list-header__sort-indicator"
+      [class.ngx-list-header__sort-indicator--asc]="sortDir === 'asc'"
+      [class.ngx-list-header__sort-indicator--desc]="sortDir === 'desc'"
+    >
+      @if (sortDir === 'asc') {
+      <i class="ngx-icon ngx-arrow-up" aria-hidden="true"></i>
+      } @else if (sortDir === 'desc') {
+      <i class="ngx-icon ngx-arrow-down" aria-hidden="true"></i>
+      }
+    </span>
+  </button>
+  } @else {
+  <ng-container [ngTemplateOutlet]="header.headerTemplate"></ng-container>
+  } }
 </ng-template>

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-header/list-header.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-header/list-header.component.scss
@@ -3,4 +3,37 @@ ngx-list-header.ngx-list-header {
   font-size: 14px;
   font-weight: 700;
   line-height: 22px;
+
+  .ngx-list-header__sort-button {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    gap: var(--spacing-4);
+    line-height: inherit;
+    margin: 0;
+    padding: 0;
+    text-align: inherit;
+    width: 100%;
+  }
+
+  .ngx-list-header__label {
+    min-width: 0;
+  }
+
+  .ngx-list-header__sort-indicator {
+    display: inline-flex;
+    flex-shrink: 0;
+    min-width: var(--spacing-16);
+    opacity: 0;
+    transition: opacity 0.2s linear;
+
+    &--asc,
+    &--desc {
+      opacity: 1;
+    }
+  }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-header/list-header.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-header/list-header.component.ts
@@ -1,5 +1,8 @@
 import { Component, ContentChild, Input, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ListHeaderTemplateDirective } from './list-header-template.directive';
+import { ListSortComparator } from '../list-sort.utils';
+import { ListHeaderSortType } from '../models/list-header-sort-type.type';
+import { ListSortDirection } from '../models/list-sort-direction.type';
 
 @Component({
   selector: 'ngx-list-header',
@@ -14,8 +17,21 @@ import { ListHeaderTemplateDirective } from './list-header-template.directive';
 export class ListHeaderComponent {
   @ViewChild('template', { static: true }) template: TemplateRef<any>;
 
-  @Input() header: any;
+  @Input() header: ListHeaderComponent;
+  @Input() sortable = false;
+  @Input() prop?: string;
+  @Input() type?: ListHeaderSortType;
+  @Input() comparator?: ListSortComparator;
+  @Input() sortDir?: ListSortDirection;
+  @Input() onHeaderSort?: (sourceHeader: ListHeaderComponent) => void;
 
   @ContentChild(ListHeaderTemplateDirective, { read: TemplateRef, static: true })
   headerTemplate: TemplateRef<ListHeaderTemplateDirective>;
+
+  onSortClick(): void {
+    const sourceHeader = this.header ?? this;
+    if (sourceHeader.sortable) {
+      this.onHeaderSort?.(sourceHeader);
+    }
+  }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.spec.ts
@@ -1,0 +1,58 @@
+import { ListHeaderComponent } from './list-header/list-header.component';
+import { getNextListSort, sortListRows } from './list-sort.utils';
+
+describe('list-sort.utils', () => {
+  const createHeader = (prop: string): ListHeaderComponent => {
+    const header = new ListHeaderComponent();
+    header.prop = prop;
+    header.sortable = true;
+    return header;
+  };
+
+  it('should cycle sort state none -> asc -> desc -> asc', () => {
+    const header = createHeader('name');
+    let sort = getNextListSort(null, header);
+    expect(sort).toEqual({ prop: 'name', dir: 'asc' });
+
+    sort = getNextListSort(sort, header);
+    expect(sort).toEqual({ prop: 'name', dir: 'desc' });
+
+    sort = getNextListSort(sort, header);
+    expect(sort).toEqual({ prop: 'name', dir: 'asc' });
+  });
+
+  it('should replace active sort when a different column is selected', () => {
+    const nameHeader = createHeader('name');
+    const valueHeader = createHeader('value');
+
+    const sort = getNextListSort({ prop: 'name', dir: 'asc' }, valueHeader);
+    expect(sort).toEqual({ prop: 'value', dir: 'asc' });
+    expect(nameHeader.prop).toBe('name');
+  });
+
+  it('should sort date strings chronologically when type is date', () => {
+    const header = createHeader('date');
+    header.type = 'date';
+    const rows = [{ date: '1/10/2025' }, { date: '1/2/2025' }, { date: '1/6/2025' }];
+
+    const sorted = sortListRows(rows, { prop: 'date', dir: 'asc' }, [header]);
+    expect(sorted.map(row => row.date)).toEqual(['1/2/2025', '1/6/2025', '1/10/2025']);
+  });
+
+  it('should sort date strings chronologically when prop is date', () => {
+    const header = createHeader('date');
+    const rows = [{ date: '1/10/2025' }, { date: '1/2/2025' }, { date: '1/6/2025' }];
+
+    const sorted = sortListRows(rows, { prop: 'date', dir: 'asc' }, [header]);
+    expect(sorted.map(row => row.date)).toEqual(['1/2/2025', '1/6/2025', '1/10/2025']);
+  });
+
+  it('should sort rows using a column comparator when provided', () => {
+    const header = createHeader('value');
+    header.comparator = (a, b) => Number(a) - Number(b);
+    const rows = [{ value: 3 }, { value: 1 }, { value: 2 }];
+
+    const sorted = sortListRows(rows, { prop: 'value', dir: 'asc' }, [header]);
+    expect(sorted.map(row => row.value)).toEqual([1, 2, 3]);
+  });
+});

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.spec.ts
@@ -1,58 +1,139 @@
 import { ListHeaderComponent } from './list-header/list-header.component';
-import { getNextListSort, sortListRows } from './list-sort.utils';
+import { defaultListSortComparator, getNextListSort, parseListSortDate, sortListRows } from './list-sort.utils';
 
 describe('list-sort.utils', () => {
-  const createHeader = (prop: string): ListHeaderComponent => {
-    const header = new ListHeaderComponent();
-    header.prop = prop;
-    header.sortable = true;
-    return header;
+  const header = (prop: string, overrides: Partial<ListHeaderComponent> = {}): ListHeaderComponent => {
+    const h = new ListHeaderComponent();
+    h.sortable = true;
+    h.prop = prop;
+    Object.assign(h, overrides);
+    return h;
   };
 
-  it('should cycle sort state none -> asc -> desc -> asc', () => {
-    const header = createHeader('name');
-    let sort = getNextListSort(null, header);
-    expect(sort).toEqual({ prop: 'name', dir: 'asc' });
+  describe('getNextListSort', () => {
+    it('should return asc on first click', () => {
+      expect(getNextListSort(null, header('name'))).toEqual({ prop: 'name', dir: 'asc' });
+    });
 
-    sort = getNextListSort(sort, header);
-    expect(sort).toEqual({ prop: 'name', dir: 'desc' });
+    it('should cycle asc -> desc -> asc', () => {
+      const h = header('name');
+      let sort = getNextListSort(null, h);
+      expect(sort).toEqual({ prop: 'name', dir: 'asc' });
 
-    sort = getNextListSort(sort, header);
-    expect(sort).toEqual({ prop: 'name', dir: 'asc' });
+      sort = getNextListSort(sort, h);
+      expect(sort).toEqual({ prop: 'name', dir: 'desc' });
+
+      sort = getNextListSort(sort, h);
+      expect(sort).toEqual({ prop: 'name', dir: 'asc' });
+    });
+
+    it('should reset to asc when switching to a different column', () => {
+      const sort = getNextListSort({ prop: 'name', dir: 'asc' }, header('value'));
+      expect(sort).toEqual({ prop: 'value', dir: 'asc' });
+    });
+
+    it('should return current sort unchanged when header has no prop', () => {
+      const current = { prop: 'name', dir: 'asc' as const };
+      expect(getNextListSort(current, header(''))).toBe(current);
+    });
   });
 
-  it('should replace active sort when a different column is selected', () => {
-    const nameHeader = createHeader('name');
-    const valueHeader = createHeader('value');
+  describe('sortListRows', () => {
+    it('should return a copy of rows unchanged when sort is null', () => {
+      const rows = [{ name: 'B' }, { name: 'A' }];
+      const result = sortListRows(rows, null, []);
+      expect(result).toEqual(rows);
+      expect(result).not.toBe(rows);
+    });
 
-    const sort = getNextListSort({ prop: 'name', dir: 'asc' }, valueHeader);
-    expect(sort).toEqual({ prop: 'value', dir: 'asc' });
-    expect(nameHeader.prop).toBe('name');
+    it('should sort strings ascending', () => {
+      const rows = [{ name: 'Charlie' }, { name: 'Alice' }, { name: 'Bob' }];
+      const sorted = sortListRows(rows, { prop: 'name', dir: 'asc' }, [header('name')]);
+      expect(sorted.map(r => r.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+    });
+
+    it('should sort strings descending', () => {
+      const rows = [{ name: 'Charlie' }, { name: 'Alice' }, { name: 'Bob' }];
+      const sorted = sortListRows(rows, { prop: 'name', dir: 'desc' }, [header('name')]);
+      expect(sorted.map(r => r.name)).toEqual(['Charlie', 'Bob', 'Alice']);
+    });
+
+    it('should sort date strings chronologically when type is date', () => {
+      const rows = [{ date: '1/10/2025' }, { date: '1/2/2025' }, { date: '1/6/2025' }];
+      const sorted = sortListRows(rows, { prop: 'date', dir: 'asc' }, [header('date', { type: 'date' })]);
+      expect(sorted.map(r => r.date)).toEqual(['1/2/2025', '1/6/2025', '1/10/2025']);
+    });
+
+    it('should sort date strings chronologically when prop is "date"', () => {
+      const rows = [{ date: '1/10/2025' }, { date: '1/2/2025' }, { date: '1/6/2025' }];
+      const sorted = sortListRows(rows, { prop: 'date', dir: 'asc' }, [header('date')]);
+      expect(sorted.map(r => r.date)).toEqual(['1/2/2025', '1/6/2025', '1/10/2025']);
+    });
+
+    it('should sort date strings in descending order', () => {
+      const rows = [{ date: '1/2/2025' }, { date: '1/10/2025' }, { date: '1/6/2025' }];
+      const sorted = sortListRows(rows, { prop: 'date', dir: 'desc' }, [header('date', { type: 'date' })]);
+      expect(sorted.map(r => r.date)).toEqual(['1/10/2025', '1/6/2025', '1/2/2025']);
+    });
+
+    it('should use a custom column comparator when provided', () => {
+      const rows = [{ value: 3 }, { value: 1 }, { value: 2 }];
+      const h = header('value', { comparator: (a, b) => Number(a) - Number(b) });
+      const sorted = sortListRows(rows, { prop: 'value', dir: 'asc' }, [h]);
+      expect(sorted.map(r => r.value)).toEqual([1, 2, 3]);
+    });
+
+    it('should not mutate the original rows array', () => {
+      const rows = [{ name: 'B' }, { name: 'A' }];
+      sortListRows(rows, { prop: 'name', dir: 'asc' }, [header('name')]);
+      expect(rows.map(r => r.name)).toEqual(['B', 'A']);
+    });
   });
 
-  it('should sort date strings chronologically when type is date', () => {
-    const header = createHeader('date');
-    header.type = 'date';
-    const rows = [{ date: '1/10/2025' }, { date: '1/2/2025' }, { date: '1/6/2025' }];
+  describe('parseListSortDate', () => {
+    it('should return null for null or undefined', () => {
+      expect(parseListSortDate(null)).toBeNull();
+      expect(parseListSortDate(undefined)).toBeNull();
+    });
 
-    const sorted = sortListRows(rows, { prop: 'date', dir: 'asc' }, [header]);
-    expect(sorted.map(row => row.date)).toEqual(['1/2/2025', '1/6/2025', '1/10/2025']);
+    it('should return timestamp for a Date object', () => {
+      const d = new Date('2025-01-06');
+      expect(parseListSortDate(d)).toBe(d.getTime());
+    });
+
+    it('should return the value unchanged for a number', () => {
+      expect(parseListSortDate(1234567890)).toBe(1234567890);
+    });
+
+    it('should parse a valid date string to a timestamp', () => {
+      expect(parseListSortDate('1/6/2025')).toBe(Date.parse('1/6/2025'));
+    });
+
+    it('should return null for an unparseable string', () => {
+      expect(parseListSortDate('not-a-date')).toBeNull();
+    });
   });
 
-  it('should sort date strings chronologically when prop is date', () => {
-    const header = createHeader('date');
-    const rows = [{ date: '1/10/2025' }, { date: '1/2/2025' }, { date: '1/6/2025' }];
+  describe('defaultListSortComparator', () => {
+    it('should sort null values last', () => {
+      expect(defaultListSortComparator(null, 'a')).toBeLessThan(0);
+      expect(defaultListSortComparator('a', null)).toBeGreaterThan(0);
+      expect(defaultListSortComparator(null, null)).toBe(0);
+    });
 
-    const sorted = sortListRows(rows, { prop: 'date', dir: 'asc' }, [header]);
-    expect(sorted.map(row => row.date)).toEqual(['1/2/2025', '1/6/2025', '1/10/2025']);
-  });
+    it('should compare numbers numerically', () => {
+      expect(defaultListSortComparator(1, 2)).toBeLessThan(0);
+      expect(defaultListSortComparator(2, 1)).toBeGreaterThan(0);
+      expect(defaultListSortComparator(1, 1)).toBe(0);
+    });
 
-  it('should sort rows using a column comparator when provided', () => {
-    const header = createHeader('value');
-    header.comparator = (a, b) => Number(a) - Number(b);
-    const rows = [{ value: 3 }, { value: 1 }, { value: 2 }];
+    it('should compare strings case-insensitively', () => {
+      expect(defaultListSortComparator('a', 'B')).toBeLessThan(0);
+      expect(defaultListSortComparator('B', 'a')).toBeGreaterThan(0);
+    });
 
-    const sorted = sortListRows(rows, { prop: 'value', dir: 'asc' }, [header]);
-    expect(sorted.map(row => row.value)).toEqual([1, 2, 3]);
+    it('should sort numeric strings in natural order', () => {
+      expect(defaultListSortComparator('item-2', 'item-10')).toBeLessThan(0);
+    });
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.ts
@@ -48,10 +48,7 @@ export function parseListSortDate(value: unknown): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
-export function dateListSortComparator(a: unknown, b: unknown): number {
-  const timeA = parseListSortDate(a);
-  const timeB = parseListSortDate(b);
-
+function compareParsedDates(timeA: number | null, timeB: number | null): number {
   if (timeA == null && timeB == null) {
     return 0;
   }
@@ -71,16 +68,6 @@ export function getListHeaderSortType(header: Pick<ListHeaderComponent, 'prop' |
   }
 
   return header.prop === 'date' ? 'date' : 'text';
-}
-
-export function getListSortComparator(
-  header: Pick<ListHeaderComponent, 'prop' | 'type' | 'comparator'>
-): ListSortComparator {
-  if (header.comparator) {
-    return header.comparator;
-  }
-
-  return getListHeaderSortType(header) === 'date' ? dateListSortComparator : defaultListSortComparator;
 }
 
 export function getNextListSort(
@@ -109,17 +96,22 @@ export function sortListRows(
   }
 
   const header = Array.from(headers).find(item => item?.prop === sort.prop);
-  const comparator = header ? getListSortComparator(header) : defaultListSortComparator;
-  const isDateSort = !header?.comparator && getListHeaderSortType(header ?? { prop: sort.prop }) === 'date';
+  const isDateSort = !header.comparator && getListHeaderSortType(header ?? { prop: sort.prop }) === 'date';
+  const comparator = header.comparator ? header.comparator : defaultListSortComparator;
 
-  const parsedDates = isDateSort
-    ? new Map(rows.map(row => [row, parseListSortDate(row[sort.prop])]))
-    : null;
+  const parsedDates = isDateSort ? new Map(rows.map(row => [row, parseListSortDate(row[sort.prop])])) : null;
 
   return [...rows].sort((rowA, rowB) => {
-    const valueA = parsedDates ? parsedDates.get(rowA) : rowA[sort.prop];
-    const valueB = parsedDates ? parsedDates.get(rowB) : rowB[sort.prop];
-    const result = comparator(valueA, valueB, rowA, rowB);
+    let result: number;
+    if (parsedDates) {
+      const valueA = parsedDates.get(rowA);
+      const valueB = parsedDates.get(rowB);
+      result = compareParsedDates(valueA, valueB);
+    } else {
+      const valueA = rowA[sort.prop];
+      const valueB = rowB[sort.prop];
+      result = comparator(valueA, valueB, rowA, rowB);
+    }
     return sort.dir === 'desc' ? -result : result;
   });
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.ts
@@ -1,0 +1,126 @@
+import { ListHeaderComponent } from './list-header/list-header.component';
+import { ListHeaderSortType } from './models/list-header-sort-type.type';
+import { ListSortPropDir } from './models/list-sort-prop-dir';
+import { ListSortDirection } from './models/list-sort-direction.type';
+
+export type ListSortComparator = (
+  a: unknown,
+  b: unknown,
+  rowA?: Record<string, unknown>,
+  rowB?: Record<string, unknown>
+) => number;
+
+export function defaultListSortComparator(a: unknown, b: unknown): number {
+  if (a == null && b == null) {
+    return 0;
+  }
+  if (a == null) {
+    return -1;
+  }
+  if (b == null) {
+    return 1;
+  }
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+  if (typeof a === 'string' && typeof b === 'string') {
+    return a.localeCompare(b);
+  }
+  return String(a).localeCompare(String(b));
+}
+
+export function parseListSortDate(value: unknown): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function dateListSortComparator(a: unknown, b: unknown): number {
+  const timeA = parseListSortDate(a);
+  const timeB = parseListSortDate(b);
+
+  if (timeA == null && timeB == null) {
+    return 0;
+  }
+  if (timeA == null) {
+    return -1;
+  }
+  if (timeB == null) {
+    return 1;
+  }
+
+  return timeA - timeB;
+}
+
+export function getListHeaderSortType(header: Pick<ListHeaderComponent, 'prop' | 'type'>): ListHeaderSortType {
+  if (header.type) {
+    return header.type;
+  }
+
+  return header.prop === 'date' ? 'date' : 'text';
+}
+
+export function getListSortComparator(
+  header: Pick<ListHeaderComponent, 'prop' | 'type' | 'comparator'>
+): ListSortComparator {
+  if (header.comparator) {
+    return header.comparator;
+  }
+
+  return getListHeaderSortType(header) === 'date' ? dateListSortComparator : defaultListSortComparator;
+}
+
+export function getNextListSort(
+  currentSort: ListSortPropDir | null,
+  header: ListHeaderComponent
+): ListSortPropDir | null {
+  const prop = header.prop;
+  if (!prop) {
+    return currentSort;
+  }
+
+  if (!currentSort || currentSort.prop !== prop) {
+    return { prop, dir: 'asc' };
+  }
+
+  return { prop, dir: currentSort.dir === 'asc' ? 'desc' : 'asc' };
+}
+
+export function sortListRows(
+  rows: Array<Record<string, unknown>>,
+  sort: ListSortPropDir | null,
+  headers: Iterable<ListHeaderComponent>
+): Array<Record<string, unknown>> {
+  if (!sort?.prop) {
+    return [...rows];
+  }
+
+  const header = Array.from(headers).find(item => item?.prop === sort.prop);
+  const comparator = header ? getListSortComparator(header) : defaultListSortComparator;
+
+  return [...rows].sort((rowA, rowB) => {
+    const valueA = rowA[sort.prop];
+    const valueB = rowB[sort.prop];
+    const result = comparator(valueA, valueB, rowA, rowB);
+    return sort.dir === 'desc' ? -result : result;
+  });
+}
+
+export function getListSortDirection(sort: ListSortPropDir | null, prop?: string): ListSortDirection | undefined {
+  if (!prop || !sort || sort.prop !== prop) {
+    return undefined;
+  }
+
+  return sort.dir;
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.ts
@@ -10,6 +10,8 @@ export type ListSortComparator = (
   rowB?: Record<string, unknown>
 ) => number;
 
+const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
+
 export function defaultListSortComparator(a: unknown, b: unknown): number {
   if (a == null && b == null) {
     return 0;
@@ -24,9 +26,9 @@ export function defaultListSortComparator(a: unknown, b: unknown): number {
     return a - b;
   }
   if (typeof a === 'string' && typeof b === 'string') {
-    return a.localeCompare(b);
+    return collator.compare(a, b);
   }
-  return String(a).localeCompare(String(b));
+  return collator.compare(String(a), String(b));
 }
 
 export function parseListSortDate(value: unknown): number | null {
@@ -108,10 +110,15 @@ export function sortListRows(
 
   const header = Array.from(headers).find(item => item?.prop === sort.prop);
   const comparator = header ? getListSortComparator(header) : defaultListSortComparator;
+  const isDateSort = !header?.comparator && getListHeaderSortType(header ?? { prop: sort.prop }) === 'date';
+
+  const parsedDates = isDateSort
+    ? new Map(rows.map(row => [row, parseListSortDate(row[sort.prop])]))
+    : null;
 
   return [...rows].sort((rowA, rowB) => {
-    const valueA = rowA[sort.prop];
-    const valueB = rowB[sort.prop];
+    const valueA = parsedDates ? parsedDates.get(rowA) : rowA[sort.prop];
+    const valueB = parsedDates ? parsedDates.get(rowB) : rowB[sort.prop];
     const result = comparator(valueA, valueB, rowA, rowB);
     return sort.dir === 'desc' ? -result : result;
   });

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list.component.html
@@ -4,13 +4,18 @@
   [class.ngx-list__headers-container__scrollable]="hasScrollbar"
 >
   @for (header of headers; track header) {
-  <ng-container *ngComponentOutlet="headerComponent; inputs: { header: header }"></ng-container>
+  <ng-container
+    *ngComponentOutlet="
+      headerComponent;
+      inputs: { header: header, sortDir: getSortDirection(header), onHeaderSort: onHeaderSort }
+    "
+  ></ng-container>
   }
 </div>
 <hr />
 @if (virtualScroll) {
 <cdk-virtual-scroll-viewport #virtualScrollViewport [style.height.px]="height" [itemSize]="rowHeight">
-  <div *cdkVirtualFor="let data of dataSource; index as i">
+  <div *cdkVirtualFor="let data of displayDataSource; track: data; index as i">
     <ng-container
       *ngComponentOutlet="
         rowComponent;
@@ -21,7 +26,7 @@
 </cdk-virtual-scroll-viewport>
 } @else {
 <div #listRowsContainer [style.height.px]="height" class="ngx-list__rows-container">
-  @for (data of dataSource; track data; let idx = $index) {
+  @for (data of displayDataSource; track data; let idx = $index) {
   <ng-container
     *ngComponentOutlet="
       rowComponent;

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list.component.spec.ts
@@ -1,6 +1,7 @@
 import type { Mock } from 'vitest';
 import { fakeAsync, tick } from '@angular/core/testing';
 import { ListComponent } from './list.component';
+import { ListHeaderComponent } from './list-header/list-header.component';
 import { of } from 'rxjs';
 
 describe('ListComponent', () => {
@@ -23,10 +24,20 @@ describe('ListComponent', () => {
     return el;
   };
 
+  const createSortableHeader = (prop: string, sortable = true): ListHeaderComponent => {
+    const header = new ListHeaderComponent();
+    header.sortable = sortable;
+    header.prop = prop;
+    return header;
+  };
+
   beforeEach(() => {
     component = new ListComponent();
     component.columnLayout = null as any;
-    component.headers = { length: 1 } as any;
+    component.headers = {
+      length: 1,
+      toArray: () => [createSortableHeader('name')]
+    } as any;
     component.listRowsContainer = {
       nativeElement: createListRowsNativeElement()
     } as any;
@@ -35,6 +46,11 @@ describe('ListComponent', () => {
     component.virtualScrollViewport = {
       elementScrolled: () => of(mockScrollEvent)
     } as any;
+    component.dataSource = [
+      { name: 'Charlie', value: 3 },
+      { name: 'Alice', value: 1 },
+      { name: 'Bob', value: 2 }
+    ];
   });
 
   it('should create', () => {
@@ -168,6 +184,111 @@ describe('ListComponent', () => {
       component.initScrollListener();
 
       expect(emitScrollChangesSpy).toHaveBeenCalledWith(mockScrollEvent);
+    });
+  });
+
+  describe('sorting', () => {
+    beforeEach(() => {
+      component.headers = {
+        length: 1,
+        toArray: () => [createSortableHeader('name')]
+      } as any;
+      component.ngAfterContentInit();
+    });
+
+    it('should emit onSort with expected payload when a sortable header is clicked', () => {
+      const header = createSortableHeader('name');
+      const onSortSpy = vi.spyOn(component.onSort, 'emit');
+
+      component.onHeaderSort(header);
+
+      expect(onSortSpy).toHaveBeenCalledWith({
+        sort: { prop: 'name', dir: 'asc' }
+      });
+    });
+
+    it('should sort rows ascending then descending then ascending again in local mode', () => {
+      const header = createSortableHeader('name');
+
+      component.onHeaderSort(header);
+      expect(component.displayDataSource.map(row => row.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+
+      component.onHeaderSort(header);
+      expect(component.displayDataSource.map(row => row.name)).toEqual(['Charlie', 'Bob', 'Alice']);
+
+      component.onHeaderSort(header);
+      expect(component.displayDataSource.map(row => row.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+    });
+
+    it('should not reorder rows in external sorting mode', () => {
+      component.externalSorting = true;
+      const header = createSortableHeader('name');
+
+      component.onHeaderSort(header);
+
+      expect(component.displayDataSource.map(row => row.name)).toEqual(['Charlie', 'Alice', 'Bob']);
+    });
+
+    it('should respect pre-seeded sort input', () => {
+      component.sort = { prop: 'name', dir: 'asc' };
+      component.ngOnChanges({
+        sort: {
+          currentValue: component.sort,
+          previousValue: null,
+          firstChange: false,
+          isFirstChange: () => false
+        },
+        dataSource: {
+          currentValue: component.dataSource,
+          previousValue: [],
+          firstChange: false,
+          isFirstChange: () => false
+        }
+      });
+
+      expect(component.displayDataSource.map(row => row.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+      expect(component.getSortDirection(createSortableHeader('name'))).toBe('asc');
+    });
+
+    it('should recompute sorted rows when dataSource changes in local mode', () => {
+      const header = createSortableHeader('name');
+      component.onHeaderSort(header);
+
+      component.dataSource = [
+        { name: 'Zoe', value: 1 },
+        { name: 'Amy', value: 2 }
+      ];
+      component.ngOnChanges({
+        dataSource: {
+          currentValue: component.dataSource,
+          previousValue: [],
+          firstChange: false,
+          isFirstChange: () => false
+        }
+      });
+
+      expect(component.displayDataSource.map(row => row.name)).toEqual(['Amy', 'Zoe']);
+    });
+
+    it('should reset scroll position after local sort', () => {
+      const scrollToSpy = vi.spyOn(component.listRowsContainer.nativeElement, 'scrollTo');
+      const header = createSortableHeader('name');
+
+      component.onHeaderSort(header);
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 0 });
+      expect(component.page).toBe(1);
+    });
+
+    it('should reset scroll position after external sort', () => {
+      const scrollToSpy = vi.spyOn(component.listRowsContainer.nativeElement, 'scrollTo');
+      component.externalSorting = true;
+      const header = createSortableHeader('name');
+
+      component.onHeaderSort(header);
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 0 });
+      expect(component.page).toBe(1);
     });
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list.component.ts
@@ -7,9 +7,11 @@ import {
   ElementRef,
   EventEmitter,
   Input,
+  OnChanges,
   OnDestroy,
   Output,
   QueryList,
+  SimpleChanges,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
@@ -19,6 +21,11 @@ import { ListRowComponent } from './list-row/list-row.component';
 import { ListColumnComponent } from './list-column/list-column.component';
 import { ListHeaderComponent } from './list-header/list-header.component';
 import { ListPaginationConfig } from './models/list-pagination-config';
+import { ListSortEvent } from './models/list-sort-event';
+import { ListSortPropDir } from './models/list-sort-prop-dir';
+import { ListSortDirection } from './models/list-sort-direction.type';
+import { getListSortDirection, getNextListSort, sortListRows } from './list-sort.utils';
+
 @Component({
   selector: 'ngx-list',
   templateUrl: './list.component.html',
@@ -29,9 +36,11 @@ import { ListPaginationConfig } from './models/list-pagination-config';
     class: 'ngx-list'
   }
 })
-export class ListComponent implements AfterContentInit, AfterViewInit, OnDestroy {
+export class ListComponent implements AfterContentInit, AfterViewInit, OnChanges, OnDestroy {
   @Input() columnLayout: Partial<CSSStyleDeclaration>;
   @Input() dataSource: Array<Record<string, unknown>> = [];
+  @Input() externalSorting = false;
+  @Input() sort: ListSortPropDir | null = null;
   @Input() height: number;
   @Input() paginationConfig: ListPaginationConfig;
   @Input() virtualScroll = false;
@@ -39,6 +48,7 @@ export class ListComponent implements AfterContentInit, AfterViewInit, OnDestroy
 
   @Output() onPageChange = new EventEmitter<number>();
   @Output() onScroll = new EventEmitter<number>();
+  @Output() onSort = new EventEmitter<ListSortEvent>();
 
   @ContentChild(ListRowComponent) row: ListRowComponent;
 
@@ -55,12 +65,26 @@ export class ListComponent implements AfterContentInit, AfterViewInit, OnDestroy
     display: 'grid',
     gap: '1rem'
   };
+  displayDataSource: Array<Record<string, unknown>> = [];
   hasScrollbar = false;
   page = 1;
 
+  private _sort: ListSortPropDir | null = null;
   private destroy$ = new Subject<void>();
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['sort']) {
+      this._sort = this.sort ? { ...this.sort } : null;
+    }
+
+    if (changes['dataSource'] || changes['sort']) {
+      this.updateDisplayDataSource();
+    }
+  }
+
   ngAfterContentInit(): void {
+    this._sort = this.sort ? { ...this.sort } : null;
+    this.updateDisplayDataSource();
     this.generateLayout();
   }
 
@@ -92,6 +116,35 @@ export class ListComponent implements AfterContentInit, AfterViewInit, OnDestroy
     this.destroy$.next();
     this.destroy$.complete();
   }
+
+  getSortDirection(header: ListHeaderComponent): ListSortDirection | undefined {
+    return getListSortDirection(this._sort, header.prop);
+  }
+
+  /**
+   * @function onHeaderSort
+   *
+   * @description
+   * Handles sortable header clicks by updating sort state, emitting `onSort`, and applying local sorting when enabled.
+   *
+   * @param {ListHeaderComponent} header - the clicked header
+   */
+  onHeaderSort = (header: ListHeaderComponent): void => {
+    if (!header.sortable || !header.prop) {
+      return;
+    }
+
+    this._sort = getNextListSort(this._sort, header);
+    this.onSort.emit({
+      sort: this._sort ? { ...this._sort } : null
+    });
+
+    if (!this.externalSorting) {
+      this.updateDisplayDataSource();
+    }
+
+    this.resetScrollAfterSort();
+  };
 
   /**
    * @function emitScrollChanges
@@ -153,6 +206,34 @@ export class ListComponent implements AfterContentInit, AfterViewInit, OnDestroy
       fromEvent(this.listRowsContainer.nativeElement, 'scroll')
         .pipe(takeUntil(this.destroy$))
         .subscribe(event => this.emitScrollChanges(event));
+    }
+  }
+
+  private updateDisplayDataSource(): void {
+    const rows = this.dataSource ?? [];
+
+    if (this.externalSorting || !this._sort) {
+      this.displayDataSource = [...rows];
+      return;
+    }
+
+    this.displayDataSource = sortListRows(rows, this._sort, this.getHeaderList());
+  }
+
+  private getHeaderList(): ListHeaderComponent[] {
+    return this.headers?.toArray?.() ?? [];
+  }
+
+  private resetScrollAfterSort(): void {
+    this.page = 1;
+
+    if (this.virtualScroll && this.virtualScrollViewport) {
+      this.virtualScrollViewport.scrollToIndex(0);
+      return;
+    }
+
+    if (this.listRowsContainer?.nativeElement) {
+      this.listRowsContainer.nativeElement.scrollTo({ top: 0 });
     }
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/list/models/list-header-sort-type.type.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/models/list-header-sort-type.type.ts
@@ -1,0 +1,1 @@
+export type ListHeaderSortType = 'text' | 'date';

--- a/projects/swimlane/ngx-ui/src/lib/components/list/models/list-sort-direction.type.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/models/list-sort-direction.type.ts
@@ -1,0 +1,1 @@
+export type ListSortDirection = 'asc' | 'desc';

--- a/projects/swimlane/ngx-ui/src/lib/components/list/models/list-sort-event.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/models/list-sort-event.ts
@@ -1,0 +1,5 @@
+import { ListSortPropDir } from './list-sort-prop-dir';
+
+export interface ListSortEvent {
+  sort: ListSortPropDir | null;
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/list/models/list-sort-prop-dir.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/models/list-sort-prop-dir.ts
@@ -1,0 +1,6 @@
+import { ListSortDirection } from './list-sort-direction.type';
+
+export interface ListSortPropDir {
+  prop: string;
+  dir: ListSortDirection;
+}

--- a/projects/swimlane/ngx-ui/src/public_api.ts
+++ b/projects/swimlane/ngx-ui/src/public_api.ts
@@ -172,6 +172,15 @@ export * from './lib/components/list/list.module';
 export * from './lib/components/list/list.component';
 export * from './lib/components/list/models/list-row-status.enum';
 export * from './lib/components/list/models/list-pagination-config';
+export * from './lib/components/list/models/list-sort-direction.type';
+export * from './lib/components/list/models/list-sort-prop-dir';
+export * from './lib/components/list/models/list-sort-event';
+export * from './lib/components/list/models/list-header-sort-type.type';
+export {
+  dateListSortComparator,
+  defaultListSortComparator,
+  getListSortComparator
+} from './lib/components/list/list-sort.utils';
 export * from './lib/components/list/list-header/list-header.component';
 export * from './lib/components/list/list-header/list-header-template.directive';
 export * from './lib/components/list/list-row/list-row.component';

--- a/projects/swimlane/ngx-ui/src/public_api.ts
+++ b/projects/swimlane/ngx-ui/src/public_api.ts
@@ -176,11 +176,7 @@ export * from './lib/components/list/models/list-sort-direction.type';
 export * from './lib/components/list/models/list-sort-prop-dir';
 export * from './lib/components/list/models/list-sort-event';
 export * from './lib/components/list/models/list-header-sort-type.type';
-export {
-  dateListSortComparator,
-  defaultListSortComparator,
-  getListSortComparator
-} from './lib/components/list/list-sort.utils';
+export { defaultListSortComparator, parseListSortDate } from './lib/components/list/list-sort.utils';
 export * from './lib/components/list/list-header/list-header.component';
 export * from './lib/components/list/list-header/list-header-template.directive';
 export * from './lib/components/list/list-row/list-row.component';

--- a/src/app/components/list-page/list-page.component.html
+++ b/src/app/components/list-page/list-page.component.html
@@ -447,7 +447,7 @@
         <ngx-tab label="TypeScript">
           <!-- prettier-ignore -->
           <app-prism language="js">
-<![CDATA[import { getListSortComparator, ListRowStatus, ListSortEvent, ListSortPropDir } from '@swimlane/ngx-ui';
+<![CDATA[import { defaultListSortComparator, parseListSortDate, ListRowStatus, ListSortEvent, ListSortPropDir } from '@swimlane/ngx-ui';
 
   @Component({
     selector: 'app',
@@ -469,13 +469,13 @@
       }
 
       const { prop, dir } = event.sort;
-      const comparator = getListSortComparator({
-        prop,
-        type: prop === 'date' ? 'date' : 'text'
-      });
+      const isDate = prop === 'date';
+      const parsed = isDate ? new Map(this.data.map(row => [row, parseListSortDate(row[prop])])) : null;
 
       this.externalSortData = [...this.data].sort((rowA, rowB) => {
-        const result = comparator(rowA[prop], rowB[prop], rowA, rowB);
+        const a = parsed ? parsed.get(rowA) : rowA[prop];
+        const b = parsed ? parsed.get(rowB) : rowB[prop];
+        const result = defaultListSortComparator(a, b);
         return dir === 'desc' ? -result : result;
       });
     }

--- a/src/app/components/list-page/list-page.component.html
+++ b/src/app/components/list-page/list-page.component.html
@@ -486,6 +486,7 @@
     </ngx-section>
     <ngx-section class="shadow" sectionTitle="Virtualized Scroll-Based Pagination">
       <ngx-list
+        data-cy="virtualized-pagination-list"
         [columnLayout]="paginationColumnLayout"
         [dataSource]="largeData"
         [height]="400"

--- a/src/app/components/list-page/list-page.component.html
+++ b/src/app/components/list-page/list-page.component.html
@@ -1243,8 +1243,8 @@
             <code>sort: ListSortPropDir | null = null</code>
           </th>
           <td>
-            Active sort state with column <code>prop</code> and direction (<code>asc</code> or <code>desc</code>). Set to
-            <code>null</code> when unsorted. Used to reflect header state and reapply sorting when
+            Active sort state with column <code>prop</code> and direction (<code>asc</code> or <code>desc</code>). Set
+            to <code>null</code> when unsorted. Used to reflect header state and reapply sorting when
             <code>dataSource</code> changes.
           </td>
         </tr>

--- a/src/app/components/list-page/list-page.component.html
+++ b/src/app/components/list-page/list-page.component.html
@@ -252,6 +252,238 @@
         </ngx-tab>
       </ngx-tabs>
     </ngx-section>
+    <ngx-section class="shadow" sectionTitle="Local Header Sorting">
+      <ngx-list [dataSource]="data">
+        <ngx-list-header [sortable]="true" prop="type">
+          <ng-template ngx-list-header-template>Attack Type</ng-template>
+        </ngx-list-header>
+        <ngx-list-header [sortable]="true" prop="date" type="date">
+          <ng-template ngx-list-header-template>Date of Attack</ng-template>
+        </ngx-list-header>
+        <ngx-list-header [sortable]="true" prop="origin">
+          <ng-template ngx-list-header-template>Origin of Attack</ng-template>
+        </ngx-list-header>
+
+        <ngx-list-column>
+          <ng-template ngx-list-column-template let-row="row">{{ row.type }}</ng-template>
+        </ngx-list-column>
+        <ngx-list-column>
+          <ng-template ngx-list-column-template let-row="row">{{ row.date }}</ng-template>
+        </ngx-list-column>
+        <ngx-list-column>
+          <ng-template ngx-list-column-template let-row="row">{{ row.origin }}</ng-template>
+        </ngx-list-column>
+
+        <ngx-list-row [status]="rowStatus"></ngx-list-row>
+      </ngx-list>
+
+      <br />
+      <br />
+
+      <ngx-tabs>
+        <ngx-tab label="Markup">
+          <!-- prettier-ignore -->
+          <app-prism ngNonBindable>
+  <![CDATA[
+  <ngx-list [dataSource]="data">
+    <ngx-list-header [sortable]="true" prop="type">
+      <ng-template ngx-list-header-template>Attack Type</ng-template>
+    </ngx-list-header>
+    <ngx-list-header [sortable]="true" prop="date" type="date">
+      <ng-template ngx-list-header-template>Date of Attack</ng-template>
+    </ngx-list-header>
+    <ngx-list-header [sortable]="true" prop="origin">
+      <ng-template ngx-list-header-template>Origin of Attack</ng-template>
+    </ngx-list-header>
+
+    <ngx-list-column>
+      <ng-template ngx-list-column-template let-row="row">{{ row.type }}</ng-template>
+    </ngx-list-column>
+    <ngx-list-column>
+      <ng-template ngx-list-column-template let-row="row">{{ row.date }}</ng-template>
+    </ngx-list-column>
+    <ngx-list-column>
+      <ng-template ngx-list-column-template let-row="row">{{ row.origin }}</ng-template>
+    </ngx-list-column>
+
+    <ngx-list-row [status]="rowStatus"></ngx-list-row>
+  </ngx-list>
+  ]]>
+          </app-prism>
+        </ngx-tab>
+        <ngx-tab label="TypeScript">
+          <!-- prettier-ignore -->
+          <app-prism language="js">
+<![CDATA[import { ListRowStatus } from '@swimlane/ngx-ui';
+
+  @Component({
+    selector: 'app',
+    templateUrl: './app.template.html'
+  })
+  export class AppComponent {
+    data: Array<Record<string, unknown>> = [
+      {
+        type: 'Malware',
+        date: '1/1/2025',
+        origin: 'China'
+      },
+      {
+        type: 'DDOS',
+        date: '1/5/2025',
+        origin: 'China'
+      },
+      {
+        type: 'DDOS',
+        date: '1/5/2025',
+        origin: 'Russia'
+      },
+      {
+        type: 'XSS',
+        date: '1/6/2025',
+        origin: 'North Korea'
+      },
+      {
+        type: 'DDOS',
+        date: '1/6/2025',
+        origin: 'North Korea'
+      },
+      {
+        type: 'Ransomware',
+        date: '1/8/2025',
+        origin: 'China'
+      },
+      {
+        type: 'DDOS',
+        date: '1/9/2025',
+        origin: 'China'
+      },
+      {
+        type: 'SQL injection',
+        date: '1/10/2025',
+        origin: 'North Korea'
+      },
+      {
+        type: 'Malware',
+        date: '1/11/2025',
+        origin: 'Russia'
+      }
+    ];
+
+    rowStatus = ListRowStatus.Error;
+  }]]>
+          </app-prism>
+        </ngx-tab>
+      </ngx-tabs>
+    </ngx-section>
+    <ngx-section class="shadow" sectionTitle="External Header Sorting">
+      <ngx-list
+        [dataSource]="externalSortData"
+        [externalSorting]="true"
+        [sort]="externalSort"
+        (onSort)="onExternalSort($event)"
+      >
+        <ngx-list-header [sortable]="true" prop="type">
+          <ng-template ngx-list-header-template>Attack Type</ng-template>
+        </ngx-list-header>
+        <ngx-list-header [sortable]="true" prop="date" type="date">
+          <ng-template ngx-list-header-template>Date of Attack</ng-template>
+        </ngx-list-header>
+        <ngx-list-header [sortable]="true" prop="origin">
+          <ng-template ngx-list-header-template>Origin of Attack</ng-template>
+        </ngx-list-header>
+
+        <ngx-list-column>
+          <ng-template ngx-list-column-template let-row="row">{{ row.type }}</ng-template>
+        </ngx-list-column>
+        <ngx-list-column>
+          <ng-template ngx-list-column-template let-row="row">{{ row.date }}</ng-template>
+        </ngx-list-column>
+        <ngx-list-column>
+          <ng-template ngx-list-column-template let-row="row">{{ row.origin }}</ng-template>
+        </ngx-list-column>
+
+        <ngx-list-row [status]="rowStatus"></ngx-list-row>
+      </ngx-list>
+
+      <br />
+      <br />
+
+      <ngx-tabs>
+        <ngx-tab label="Markup">
+          <!-- prettier-ignore -->
+          <app-prism ngNonBindable>
+  <![CDATA[
+  <ngx-list
+    [dataSource]="externalSortData"
+    [externalSorting]="true"
+    [sort]="externalSort"
+    (onSort)="onExternalSort($event)"
+  >
+    <ngx-list-header [sortable]="true" prop="type">
+      <ng-template ngx-list-header-template>Attack Type</ng-template>
+    </ngx-list-header>
+    <ngx-list-header [sortable]="true" prop="date" type="date">
+      <ng-template ngx-list-header-template>Date of Attack</ng-template>
+    </ngx-list-header>
+    <ngx-list-header [sortable]="true" prop="origin">
+      <ng-template ngx-list-header-template>Origin of Attack</ng-template>
+    </ngx-list-header>
+
+    <ngx-list-column>
+      <ng-template ngx-list-column-template let-row="row">{{ row.type }}</ng-template>
+    </ngx-list-column>
+    <ngx-list-column>
+      <ng-template ngx-list-column-template let-row="row">{{ row.date }}</ng-template>
+    </ngx-list-column>
+    <ngx-list-column>
+      <ng-template ngx-list-column-template let-row="row">{{ row.origin }}</ng-template>
+    </ngx-list-column>
+
+    <ngx-list-row [status]="rowStatus"></ngx-list-row>
+  </ngx-list>
+  ]]>
+          </app-prism>
+        </ngx-tab>
+        <ngx-tab label="TypeScript">
+          <!-- prettier-ignore -->
+          <app-prism language="js">
+<![CDATA[import { getListSortComparator, ListRowStatus, ListSortEvent, ListSortPropDir } from '@swimlane/ngx-ui';
+
+  @Component({
+    selector: 'app',
+    templateUrl: './app.template.html'
+  })
+  export class AppComponent {
+    data: Array<Record<string, unknown>> = [/* ... */];
+
+    externalSortData: Array<Record<string, unknown>> = [...this.data];
+    externalSort: ListSortPropDir | null = null;
+    rowStatus = ListRowStatus.Error;
+
+    onExternalSort(event: ListSortEvent): void {
+      this.externalSort = event.sort ? { ...event.sort } : null;
+
+      if (!event.sort) {
+        this.externalSortData = [...this.data];
+        return;
+      }
+
+      const { prop, dir } = event.sort;
+      const comparator = getListSortComparator({
+        prop,
+        type: prop === 'date' ? 'date' : 'text'
+      });
+
+      this.externalSortData = [...this.data].sort((rowA, rowB) => {
+        const result = comparator(rowA[prop], rowB[prop], rowA, rowB);
+        return dir === 'desc' ? -result : result;
+      });
+    }
+  }]]>
+          </app-prism>
+        </ngx-tab>
+      </ngx-tabs>
+    </ngx-section>
     <ngx-section class="shadow" sectionTitle="Virtualized Scroll-Based Pagination">
       <ngx-list
         [columnLayout]="paginationColumnLayout"
@@ -998,6 +1230,27 @@
         <tr>
           <th>
             <code class="component-type">&#64;Input()</code>
+            <code>externalSorting: boolean = false</code>
+          </th>
+          <td>
+            When <code>true</code>, the list emits sort intent via <code>onSort</code> and expects the parent to update
+            <code>dataSource</code>. When <code>false</code>, the list sorts rows internally.
+          </td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>sort: ListSortPropDir | null = null</code>
+          </th>
+          <td>
+            Active sort state with column <code>prop</code> and direction (<code>asc</code> or <code>desc</code>). Set to
+            <code>null</code> when unsorted. Used to reflect header state and reapply sorting when
+            <code>dataSource</code> changes.
+          </td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
             <code>height: number</code>
           </th>
           <td>
@@ -1061,12 +1314,64 @@
             scroll container. This output is provided for implementing a custom pagination solution.
           </td>
         </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Output()</code>
+            <code>onSort: EventEmitter&lt;ListSortEvent&gt;</code>
+          </th>
+          <td>
+            Event emitted when a sortable header is clicked. The payload includes the next <code>sort</code> state.
+          </td>
+        </tr>
       </tbody>
     </table>
     <hr />
 
     <h3 class="style-header" id="ngx-list-header-inputs">ngx-list-header Inputs</h3>
-    <h4>No component inputs to display.</h4>
+    <table class="table documentation-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>sortable: boolean = false</code>
+          </th>
+          <td>Whether the header can be clicked to sort the list.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>prop?: string</code>
+          </th>
+          <td>The row property name used for sorting when this header is active.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>type?: 'text' | 'date'</code>
+          </th>
+          <td>
+            Sort value type for local sorting. When omitted, <code>prop="date"</code> defaults to date sorting. Use
+            <code>type="date"</code> for date strings such as <code>M/D/YYYY</code>.
+          </td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>comparator?: (a, b, rowA?, rowB?) =&gt; number</code>
+          </th>
+          <td>
+            Optional comparator for local sorting. Used by <code>ngx-list</code> when <code>externalSorting</code> is
+            <code>false</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
     <hr />
     <h3 class="style-header" id="ngx-list-header-outputs">ngx-list-header Outputs</h3>
     <h4>No component outputs to display.</h4>

--- a/src/app/components/list-page/list-page.component.ts
+++ b/src/app/components/list-page/list-page.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ListRowStatus } from '@swimlane/ngx-ui';
+import { getListSortComparator, ListRowStatus, ListSortEvent, ListSortPropDir } from '@swimlane/ngx-ui';
 
 @Component({
   selector: 'app-list-page',
@@ -153,6 +153,29 @@ export class ListPageComponent {
   };
 
   rowStatus: ListRowStatus = ListRowStatus.Error;
+
+  externalSortData: Array<Record<string, unknown>> = [...this.data];
+  externalSort: ListSortPropDir | null = null;
+
+  onExternalSort(event: ListSortEvent): void {
+    this.externalSort = event.sort ? { ...event.sort } : null;
+
+    if (!event.sort) {
+      this.externalSortData = [...this.data];
+      return;
+    }
+
+    const { prop, dir } = event.sort;
+    const comparator = getListSortComparator({
+      prop,
+      type: prop === 'date' ? 'date' : 'text'
+    });
+
+    this.externalSortData = [...this.data].sort((rowA, rowB) => {
+      const result = comparator(rowA[prop], rowB[prop], rowA, rowB);
+      return dir === 'desc' ? -result : result;
+    });
+  }
 
   onPageChangeVirtualScroll(event: number) {
     console.log('VIRTUALIZED EXAMPLE PAGE NUMBER: ', event);

--- a/src/app/components/list-page/list-page.component.ts
+++ b/src/app/components/list-page/list-page.component.ts
@@ -1,5 +1,11 @@
 import { Component } from '@angular/core';
-import { getListSortComparator, ListRowStatus, ListSortEvent, ListSortPropDir } from '@swimlane/ngx-ui';
+import {
+  defaultListSortComparator,
+  parseListSortDate,
+  ListRowStatus,
+  ListSortEvent,
+  ListSortPropDir
+} from '@swimlane/ngx-ui';
 
 @Component({
   selector: 'app-list-page',
@@ -166,13 +172,13 @@ export class ListPageComponent {
     }
 
     const { prop, dir } = event.sort;
-    const comparator = getListSortComparator({
-      prop,
-      type: prop === 'date' ? 'date' : 'text'
-    });
+    const isDate = prop === 'date';
+    const parsed = isDate ? new Map(this.data.map(row => [row, parseListSortDate(row[prop])])) : null;
 
     this.externalSortData = [...this.data].sort((rowA, rowB) => {
-      const result = comparator(rowA[prop], rowB[prop], rowA, rowB);
+      const a = parsed ? parsed.get(rowA) : rowA[prop];
+      const b = parsed ? parsed.get(rowB) : rowB[prop];
+      const result = defaultListSortComparator(a, b);
       return dir === 'desc' ? -result : result;
     });
   }


### PR DESCRIPTION
## Summary

- Added header sorting support with local and external sort modes in `ngx-list`. 
- Sortable headers cycle `asc → desc → asc` on click. 
- New inputs: 
     - `sortable`, `prop`, `type` (`'text' | 'date'`), and `comparator` on `ngx-list-header`
     -`externalSorting` and `sort: ListSortPropDir | null` on `ngx-list`. 
- New output 
    - `onSort: EventEmitter<ListSortEvent>` on `ngx-list`. 
- New exported types: 
    - `ListSortPropDir`, `ListSortDirection`, `ListSortEvent`, `ListSortComparator`, `ListHeader`, `ListHeaderSortType`. New sort utilities: `defaultListSortComparator`, `dateListSortComparator`, `getListSortComparator`.


https://github.com/user-attachments/assets/a9031c6a-cd03-4035-9750-a0baa45188f8



## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [x] Included screenshots of visual changes

_\*required_
