### PR TITLE
(release): 52.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@open-wc/semantic-dom-diff": "0.19.7",
     "@schematics/angular": "^21.2.7",
     "@swimlane/eslint-config": "^2.0.0",
-    "@swimlane/prettier-config-swimlane": "4.0.0-alpha.0",
+    "@swimlane/prettier-config-swimlane": "4.0.0",
     "@types/codemirror": "5.60.5",
     "@types/faker": "^4.1.11",
     "@types/moment-timezone": "^0.5.13",

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## HEAD (unreleased)
 
+## 52.0.0
+
+- Enhancement (`ngx-list`): Added header sorting support with local and external sort modes. Sortable headers cycle `asc → desc → asc` on click. New inputs: `sortable`, `prop`, `type` (`'text' | 'date'`), and `comparator` on `ngx-list-header`; `externalSorting` and `sort: ListSortPropDir | null` on `ngx-list`. New output `onSort: EventEmitter<ListSortEvent>` on `ngx-list`. New exported types: `ListSortPropDir`, `ListSortDirection`, `ListSortEvent`, `ListSortComparator`, `ListHeader`, `ListHeaderSortType`. New sort utilities: `defaultListSortComparator`, `parseListSortDate`.
+- Enhancement (`ngx-select`): Added `placeholderTemplate` to allow render a template as placeholder.
+- Enhancement: Added support for Angular 21.2
+- Enhancement: Migrating from control directives to control flow
+- Enhancement: Adding vitest globals
+- Fix (`ngx-drawer`): Added `preventScroll: true` to the drawer's `focus()` call on init to prevent unwanted page scrolling when a drawer opens.
+- Fix (`ngx-date-range-picker`): Fixed start and end times being wrong when manually selecting a date range. Clicking a start day now normalizes to `startOfDay()` (00:00:00) and clicking an end day normalizes to `endOfDay()` (23:59:59.999), matching the behaviour of the "Last week" and other presets. The fix is isolated to `onRangeSelect` so the calendar time inputs and AM/PM toggle are unaffected.
+- Fix: Warnings related to trackBy in for
+- Chore: Migrating karma to vitest
+- Breaking: Removing angular 18 support
+
 ## 52.0.0-alpha.6 (2026-06-17)
 
 - Feature (`ngx-list`): Added header sorting support with local and external sort modes. Sortable headers cycle `asc → desc → asc` on click. New inputs: `sortable`, `prop`, `type` (`'text' | 'date'`), and `comparator` on `ngx-list-header`; `externalSorting` and `sort: ListSortPropDir | null` on `ngx-list`. New output `onSort: EventEmitter<ListSortEvent>` on `ngx-list`. New exported types: `ListSortPropDir`, `ListSortDirection`, `ListSortEvent`, `ListSortComparator`, `ListHeader`, `ListHeaderSortType`. New sort utilities: `defaultListSortComparator`, `parseListSortDate`.

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "52.0.0-alpha.6",
+  "version": "52.0.0",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5154,12 +5154,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swimlane/prettier-config-swimlane@npm:4.0.0-alpha.0":
-  version: 4.0.0-alpha.0
-  resolution: "@swimlane/prettier-config-swimlane@npm:4.0.0-alpha.0"
+"@swimlane/prettier-config-swimlane@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@swimlane/prettier-config-swimlane@npm:4.0.0"
   peerDependencies:
     prettier: 3.3.3
-  checksum: 10c0/f552c95628010d6f1aaa8dbd094136b22fe1f643085c8e5b7b64443c741fb5287cecdcb426f0d7c47db57a7b562d4c698357532fb45c6b402b91088050a86f3d
+  checksum: 10c0/e0a99fd4f71e1c4bc6cf9e3e5aa9ad0c82004f1b2e0ff3eeabf64b380faf230fb47db8c7858c09b50c3d90741b8e289ab92a7b97234115e468243b565bc5ab41
   languageName: node
   linkType: hard
 
@@ -14834,7 +14834,7 @@ __metadata:
     "@open-wc/semantic-dom-diff": "npm:0.19.7"
     "@schematics/angular": "npm:^21.2.7"
     "@swimlane/eslint-config": "npm:^2.0.0"
-    "@swimlane/prettier-config-swimlane": "npm:4.0.0-alpha.0"
+    "@swimlane/prettier-config-swimlane": "npm:4.0.0"
     "@types/codemirror": "npm:5.60.5"
     "@types/faker": "npm:^4.1.11"
     "@types/json-schema": "npm:7.0.11"


### PR DESCRIPTION

## 52.0.0

- Enhancement (`ngx-list`): Added header sorting support with local and external sort modes. Sortable headers cycle `asc → desc → asc` on click. New inputs: `sortable`, `prop`, `type` (`'text' | 'date'`), and `comparator` on `ngx-list-header`; `externalSorting` and `sort: ListSortPropDir | null` on `ngx-list`. New output `onSort: EventEmitter<ListSortEvent>` on `ngx-list`. New exported types: `ListSortPropDir`, `ListSortDirection`, `ListSortEvent`, `ListSortComparator`, `ListHeader`, `ListHeaderSortType`. New sort utilities: `defaultListSortComparator`, `parseListSortDate`.
- Enhancement (`ngx-select`): Added `placeholderTemplate` to allow render a template as placeholder.
- Enhancement: Added support for Angular 21.2
- Enhancement: Migrating from control directives to control flow
- Enhancement: Adding vitest globals
- Fix (`ngx-drawer`): Added `preventScroll: true` to the drawer's `focus()` call on init to prevent unwanted page scrolling when a drawer opens.
- Fix (`ngx-date-range-picker`): Fixed start and end times being wrong when manually selecting a date range. Clicking a start day now normalizes to `startOfDay()` (00:00:00) and clicking an end day normalizes to `endOfDay()` (23:59:59.999), matching the behaviour of the "Last week" and other presets. The fix is isolated to `onRangeSelect` so the calendar time inputs and AM/PM toggle are unaffected.
- Fix: Warnings related to trackBy in for
- Chore: Migrating karma to vitest
- Breaking: Removing angular 18 support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes plus a dev dependency pin; publish risk is the usual major semver/breaking Angular 18 removal already documented in the changelog.
> 
> **Overview**
> This PR **cuts the stable 52.0.0 release** for `@swimlane/ngx-ui` by moving the package version from `52.0.0-alpha.6` to **`52.0.0`** and adding a consolidated **`## 52.0.0`** section at the top of `CHANGELOG.md` (HEAD left empty for the next unreleased work). The notes roll up prior alpha work: list header sorting, `ngx-select` placeholder templates, Angular 21.2 / control-flow migration, Vitest, drawer and date-range-picker fixes, and **dropping Angular 18** support.
> 
> Separately, dev formatting is aligned with stable Prettier config by bumping **`@swimlane/prettier-config-swimlane`** from `4.0.0-alpha.0` to **`4.0.0`** in the root `package.json` and `yarn.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e2cc5cf8f063160437841a6d62b8e276377ffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->