### PR TITLE
Date Ranger Picker Highlight Fix

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fixing Date Picker to Highlight correct Date range for strings
+
 ## 52.0.0
 
 - Enhancement (`ngx-list`): Added header sorting support with local and external sort modes. Sortable headers cycle `asc → desc → asc` on click. New inputs: `sortable`, `prop`, `type` (`'text' | 'date'`), and `comparator` on `ngx-list-header`; `externalSorting` and `sort: ListSortPropDir | null` on `ngx-list`. New output `onSort: EventEmitter<ListSortEvent>` on `ngx-list`. New exported types: `ListSortPropDir`, `ListSortDirection`, `ListSortEvent`, `ListSortComparator`, `ListHeader`, `ListHeaderSortType`. New sort utilities: `defaultListSortComparator`, `parseListSortDate`.

--- a/projects/swimlane/ngx-ui/src/lib/components/date-range-calendar/date-range-picker.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/date-range-calendar/date-range-picker.component.ts
@@ -150,7 +150,7 @@ export class DateRangePickerComponent implements OnInit, OnChanges {
           : this.selectedRange.start;
       const endDate =
         typeof this.selectedRange.end === 'string'
-          ? DateUtils.parseExpression(this.selectedRange.end)
+          ? DateUtils.parseExpression(this.selectedRange.end, 'end')
           : this.selectedRange.end;
       this.lastConfirmedRange = {
         startDate,
@@ -164,6 +164,7 @@ export class DateRangePickerComponent implements OnInit, OnChanges {
       this.form.endDate = endDate;
       this.rangeModel = { startDate, endDate };
       this.setTooltipDate(startDate, endDate);
+      this.updateSelectedPresetByValue();
     }
   }
 
@@ -207,7 +208,7 @@ export class DateRangePickerComponent implements OnInit, OnChanges {
 
   onCustomInputChange() {
     const start = this.parseFn(this.form.startRaw);
-    const end = this.parseFn(this.form.endRaw);
+    const end = this.parseFn(this.form.endRaw, 'end');
 
     if (!start || !end || !isValid(start) || !isValid(end)) {
       this.validationError = `Invalid date expression`;


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/e7ca31f4-fcfd-48f9-81c5-1cd1bdc73f8e



Added end while parsing date string to highlight correct date

## Checklist

- ~~[ ] \*Added unit tests~~
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- ~~[ ] Updated the demo page~~
- [x] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parsing and init behavior in the date range picker UI component; no auth, data, or API changes.
> 
> **Overview**
> Fixes **`ngx-date-range-picker`** when `selectedRange` or custom inputs use relative **string** expressions for the end bound: end values are now parsed with **`parseExpression(..., 'end')`** (same as manual custom input parsing), so end-of-day / end-of-period semantics apply and the calendar highlights the intended last day.
> 
> On load from **`selectedRange`**, the component also calls **`updateSelectedPresetByValue()`** so the matching preset label and highlight stay in sync with the parsed range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 782c955b0fe0389c541d8bc7b3e6d7d67a932b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->