### PR TITLE
Adds default sort to documentation

### DIFF
--- a/src/app/components/list-page/list-page.component.html
+++ b/src/app/components/list-page/list-page.component.html
@@ -253,7 +253,7 @@
       </ngx-tabs>
     </ngx-section>
     <ngx-section class="shadow" sectionTitle="Local Header Sorting">
-      <ngx-list [dataSource]="data">
+      <ngx-list [dataSource]="data" [sort]="{ prop: 'date', dir: 'desc' }">
         <ngx-list-header [sortable]="true" prop="type">
           <ng-template ngx-list-header-template>Attack Type</ng-template>
         </ngx-list-header>

--- a/src/app/components/list-page/list-page.component.ts
+++ b/src/app/components/list-page/list-page.component.ts
@@ -161,7 +161,10 @@ export class ListPageComponent {
   rowStatus: ListRowStatus = ListRowStatus.Error;
 
   externalSortData: Array<Record<string, unknown>> = [...this.data];
-  externalSort: ListSortPropDir | null = null;
+  externalSort: ListSortPropDir | null = {
+    prop: 'date',
+    dir: 'desc'
+  };
 
   onExternalSort(event: ListSortEvent): void {
     this.externalSort = event.sort ? { ...event.sort } : null;


### PR DESCRIPTION
## Summary

- Currently the sorting on documentation works when someone clicks on the header
- This PR just adds the default sort on a column, so that we can see the arrow buttons

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
