### PR TITLE
feat: add directive to project dropdowns through cdk portal

### DIFF
--- a/cypress/e2e/components/json-editor.cy.ts
+++ b/cypress/e2e/components/json-editor.cy.ts
@@ -1,3 +1,8 @@
+// JSON Editor dropdowns use `ngxDropdownPortal`, so while open their menus are
+// moved into the CDK overlay container and are no longer inside the editor DOM.
+// On close the menu is restored to its original parent, hidden.
+const openDropdownMenu = () => cy.get('.cdk-overlay-container ngx-dropdown-menu');
+
 describe('Json Editor', () => {
   before(() => {
     cy.visit('/json-editor');
@@ -65,10 +70,11 @@ describe('Json Editor', () => {
               cy.get('ngx-dropdown').as('addPropDropdown').scrollIntoView();
               cy.get('@addPropDropdown').should('be.visible');
               cy.get('@addPropDropdown').find('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
-              cy.get('@addPropDropdown').find('ngx-dropdown-menu').should('exist');
             });
         });
       });
+
+      openDropdownMenu().should('exist');
     });
 
     describe('Array', () => {
@@ -76,17 +82,14 @@ describe('Json Editor', () => {
         cy.get('ngx-section').eq(1).find('ngx-json-editor-flat').as('jsonEditorFlat');
       });
       it('Should allow to add a property of type array', () => {
-        cy.get('@jsonEditorFlat').within(() => {
-          cy.get('ngx-dropdown-menu')
-            .last()
-            .should('exist')
-            .within(() => {
-              cy.contains('li', 'Array').click();
-            });
-        });
-        cy.get('@jsonEditorFlat').within(() => {
-          cy.get('ngx-dropdown-menu').last().should('not.be.visible');
-        });
+        openDropdownMenu()
+          .last()
+          .should('exist')
+          .within(() => {
+            cy.contains('li', 'Array').click();
+          });
+
+        openDropdownMenu().should('not.exist');
         cy.get('ngx-json-array-node-flat').should('exist');
       });
 
@@ -101,13 +104,15 @@ describe('Json Editor', () => {
               .within(() => {
                 cy.get('ngx-dropdown-toggle').should('contain.text', 'Add an item').click();
               });
-            cy.get('ngx-dropdown-menu')
-              .last()
-              .should('be.visible')
-              .within(() => {
-                cy.contains('li', 'String').click();
-              });
           });
+
+        openDropdownMenu()
+          .last()
+          .should('be.visible')
+          .within(() => {
+            cy.contains('li', 'String').click();
+          });
+
         cy.get('ngx-json-array-node-flat')
           .should('exist')
           .last()
@@ -124,13 +129,14 @@ describe('Json Editor', () => {
             .within(() => {
               cy.get('ngx-dropdown-toggle').should('be.visible').click();
             });
-          cy.get('ngx-dropdown-menu')
-            .should('be.visible')
-            .first()
-            .within(() => {
-              cy.contains('button', 'Delete').click({ force: true });
-            });
         });
+
+        openDropdownMenu()
+          .should('be.visible')
+          .first()
+          .within(() => {
+            cy.contains('button', 'Delete').click({ force: true });
+          });
 
         cy.get('ngx-json-array-node-flat').within(() => {
           cy.get('.node').should('have.length', 0);
@@ -144,40 +150,46 @@ describe('Json Editor', () => {
             .within(() => {
               cy.get('ngx-dropdown-toggle').should('contain.text', 'Add an item').click();
             });
-          cy.get('ngx-dropdown-menu')
-            .should('be.visible')
-            .last()
-            .within(() => {
-              cy.contains('li', 'Object').click();
-            });
-          cy.get('ngx-json-object-node-flat').scrollIntoView();
-
-          cy.get('ngx-json-object-node-flat')
-            .should('exist')
-            .within(() => {
-              cy.get('.add-button')
-                .should('be.visible')
-                .last()
-                .within(() => {
-                  cy.get('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
-                });
-
-              cy.get('ngx-dropdown-menu')
-                .should('be.visible')
-                .within(() => {
-                  cy.contains('li', 'String').click();
-                });
-
-              cy.get('ngx-json-editor-node-info').scrollIntoView();
-
-              cy.get('ngx-json-editor-node-info').find('ngx-input').should('be.visible').ngxFill('name');
-
-              cy.get('.node-input ngx-input')
-                .should('exist')
-                .should('have.attr', 'type', 'textarea')
-                .ngxFill('Swimlane User');
-            });
         });
+
+        openDropdownMenu()
+          .should('be.visible')
+          .last()
+          .within(() => {
+            cy.contains('li', 'Object').click();
+          });
+
+        cy.get('ngx-json-array-node-flat').find('ngx-json-object-node-flat').scrollIntoView();
+        cy.get('ngx-json-array-node-flat')
+          .find('ngx-json-object-node-flat')
+          .should('exist')
+          .within(() => {
+            cy.get('.add-button')
+              .should('be.visible')
+              .last()
+              .within(() => {
+                cy.get('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
+              });
+          });
+
+        openDropdownMenu()
+          .should('be.visible')
+          .within(() => {
+            cy.contains('li', 'String').click();
+          });
+
+        cy.get('ngx-json-array-node-flat')
+          .find('ngx-json-object-node-flat')
+          .within(() => {
+            cy.get('ngx-json-editor-node-info').scrollIntoView();
+
+            cy.get('ngx-json-editor-node-info').find('ngx-input').should('be.visible').ngxFill('name');
+
+            cy.get('.node-input ngx-input')
+              .should('exist')
+              .should('have.attr', 'type', 'textarea')
+              .ngxFill('Swimlane User');
+          });
       });
 
       it('should allow adding another object with same props as array item', () => {
@@ -188,42 +200,48 @@ describe('Json Editor', () => {
             .should('be.visible')
             .within(() => {
               cy.get('ngx-dropdown-toggle').should('contain.text', 'Add an item').click();
-              cy.get('ngx-dropdown-menu').scrollIntoView();
-
-              cy.get('ngx-dropdown-menu')
-                .should('be.visible')
-                .last()
-                .within(() => {
-                  cy.contains('li', 'Object').click();
-                });
-            });
-
-          cy.get('ngx-json-object-node-flat').eq(1).scrollIntoView();
-          cy.get('ngx-json-object-node-flat')
-            .eq(1)
-            .should('exist')
-            .within(() => {
-              cy.get('.add-button')
-                .should('be.visible')
-                .within(() => {
-                  cy.get('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
-                  cy.get('ngx-dropdown-menu')
-                    .should('be.visible')
-                    .within(() => {
-                      cy.contains('li', 'String').click();
-                    });
-                });
-
-              cy.get('ngx-json-editor-node-info').scrollIntoView();
-
-              cy.get('ngx-json-editor-node-info').find('ngx-input').should('be.visible').ngxFill('name');
-
-              cy.get('.node-input ngx-input')
-                .should('exist')
-                .should('have.attr', 'type', 'textarea')
-                .ngxFill('Swimlane Admin');
             });
         });
+
+        openDropdownMenu()
+          .should('be.visible')
+          .last()
+          .within(() => {
+            cy.contains('li', 'Object').click();
+          });
+
+        cy.get('ngx-json-array-node-flat').find('ngx-json-object-node-flat').eq(1).scrollIntoView();
+        cy.get('ngx-json-array-node-flat')
+          .find('ngx-json-object-node-flat')
+          .eq(1)
+          .should('exist')
+          .within(() => {
+            cy.get('.add-button')
+              .should('be.visible')
+              .within(() => {
+                cy.get('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
+              });
+          });
+
+        openDropdownMenu()
+          .should('be.visible')
+          .within(() => {
+            cy.contains('li', 'String').click();
+          });
+
+        cy.get('ngx-json-array-node-flat')
+          .find('ngx-json-object-node-flat')
+          .eq(1)
+          .within(() => {
+            cy.get('ngx-json-editor-node-info').scrollIntoView();
+
+            cy.get('ngx-json-editor-node-info').find('ngx-input').should('be.visible').ngxFill('name');
+
+            cy.get('.node-input ngx-input')
+              .should('exist')
+              .should('have.attr', 'type', 'textarea')
+              .ngxFill('Swimlane Admin');
+          });
       });
     });
 
@@ -276,8 +294,7 @@ describe('Json Editor', () => {
           describe('String prop', () => {
             it('Adding', () => {
               cy.get('@addPropDropdown').find('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
-              cy.get('@addPropDropdown')
-                .find('ngx-dropdown-menu')
+              openDropdownMenu()
                 .should('exist')
                 .within(() => {
                   cy.contains('li', 'String').click();
@@ -345,8 +362,7 @@ describe('Json Editor', () => {
           describe('Array prop', () => {
             it('Adding', () => {
               cy.get('@addPropDropdown').find('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
-              cy.get('@addPropDropdown')
-                .find('ngx-dropdown-menu')
+              openDropdownMenu()
                 .should('exist')
                 .within(() => {
                   cy.contains('li', 'Array').click();
@@ -389,8 +405,7 @@ describe('Json Editor', () => {
               it('Modifying', () => {
                 cy.get('@section3').find('ngx-json-array-node-flat .add-button ngx-dropdown').as('arrayPropDdl');
                 cy.get('@arrayPropDdl').find('ngx-dropdown-toggle').click();
-                cy.get('@arrayPropDdl')
-                  .find('ngx-dropdown-menu')
+                openDropdownMenu()
                   .should('exist')
                   .within(() => {
                     cy.contains('li', 'Number').click();
@@ -435,8 +450,7 @@ describe('Json Editor', () => {
             cy.get('@section3').find('ngx-json-editor-flat div.node').eq(2).as('arrayNode');
             cy.get('@arrayNode').find('.node-options ngx-dropdown').as('nodeOptions');
             cy.get('@nodeOptions').find('ngx-dropdown-toggle').click();
-            cy.get('@nodeOptions')
-              .find('ngx-dropdown-menu')
+            openDropdownMenu()
               .should('exist')
               .within(() => {
                 cy.contains('button', 'Remove').click();
@@ -495,11 +509,15 @@ describe('Json Editor', () => {
               cy.get('ngx-dropdown').as('addPropDropdown').scrollIntoView();
               cy.get('@addPropDropdown').should('be.visible');
               cy.get('@addPropDropdown').find('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
-              cy.get('@addPropDropdown').find('ngx-dropdown-menu').should('exist');
-              cy.contains('li', 'Object').click();
             });
         });
       });
+
+      openDropdownMenu()
+        .should('exist')
+        .within(() => {
+          cy.contains('li', 'Object').click();
+        });
     });
 
     it('should allow modifying the property title', () => {
@@ -527,11 +545,15 @@ describe('Json Editor', () => {
               cy.get('ngx-dropdown').as('addPropDropdown').scrollIntoView();
               cy.get('@addPropDropdown').should('be.visible');
               cy.get('@addPropDropdown').find('ngx-dropdown-toggle').should('contain.text', 'Add a property').click();
-              cy.get('@addPropDropdown').find('ngx-dropdown-menu').should('exist');
-              cy.contains('li', 'String').click();
             });
         });
       });
+
+      openDropdownMenu()
+        .should('exist')
+        .within(() => {
+          cy.contains('li', 'String').click();
+        });
     });
 
     it('should allow modifying the nested property title', () => {
@@ -556,8 +578,16 @@ describe('Json Editor', () => {
           .should('be.visible')
           .within(() => {
             cy.get('ngx-dropdown-toggle').should('be.visible').click();
-            cy.contains('button', 'Remove').click();
           });
+      });
+
+      openDropdownMenu()
+        .should('exist')
+        .within(() => {
+          cy.contains('button', 'Remove').click();
+        });
+
+      cy.get('@schemaBuilderMode').within(() => {
         cy.get('ngx-json-editor-flat').as('jsonEditorFlat');
         cy.get('@jsonEditorFlat').within(() => {
           cy.get('.info-name>span').last().should('not.contain.text', 'str_1');

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Feature (`ngx-dropdown`): Added opt-in `ngxDropdownPortal` directive to render dropdown menus via Angular CDK Overlay, avoiding clipping inside overflow containers. Supports `portalOffsetX`, `portalOffsetY`, `portalPanelClass`, and `portalFollowScroll` (default `true`). Global portal styles are included in the library CSS bundle. 
+- Feature: Applied `ngxDropdownPortal` to JSON Editor type-picker dropdowns.
+
 ## 52.1.0 (2026-06-19)
 
 - Fixing Date Picker to Highlight correct Date range for strings

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Feature (`ngx-dropdown`): Added opt-in `ngxDropdownPortal` directive to render dropdown menus via Angular CDK Overlay, avoiding clipping inside overflow containers. Supports `portalOffsetX`, `portalOffsetY`, `portalPanelClass`, and `portalFollowScroll` (default `true`). Global portal styles are included in the library CSS bundle. 
+- Feature (`ngx-dropdown`): Added opt-in `ngxDropdownPortal` directive to render dropdown menus via Angular CDK Overlay, avoiding clipping inside overflow containers. Supports `portalOffsetX`, `portalOffsetY`, `portalPanelClass`, and `portalFollowScroll` (default `true`). Closes when the trigger scrolls fully out of view. Global portal styles are included in the library CSS bundle.
 - Feature: Applied `ngxDropdownPortal` to JSON Editor type-picker dropdowns.
 
 ## 52.1.0 (2026-06-19)

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-portal.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-portal.directive.ts
@@ -75,10 +75,7 @@ export class DropdownPortalDirective implements DoCheck, OnDestroy {
 
     this.overlayRef.updatePositionStrategy(this.createPositionStrategy(menu));
     this.overlayRef.attach(new DomPortal(menu));
-
-    if (this.portalFollowScroll) {
-      this.bindScrollListeners();
-    }
+    this.bindScrollListeners();
   }
 
   private detach(): void {
@@ -135,12 +132,54 @@ export class DropdownPortalDirective implements DoCheck, OnDestroy {
     this.unbindScrollListeners();
 
     this.ngZone.runOutsideAngular(() => {
+      const onScroll = () => this.onScroll();
+
       for (const parent of this.getScrollParents(this.elementRef.nativeElement)) {
-        const cleanup = this.renderer.listen(parent, 'scroll', () => {
-          this.overlayRef?.updatePosition();
-        });
-        this.scrollListenerCleanups.push(cleanup);
+        this.scrollListenerCleanups.push(this.renderer.listen(parent, 'scroll', onScroll));
       }
+
+      // Viewport / document scrolling (bubble phase only reaches window/document).
+      this.scrollListenerCleanups.push(this.renderer.listen('window', 'scroll', onScroll));
+    });
+  }
+
+  private onScroll(): void {
+    if (!this.overlayRef?.hasAttached()) {
+      return;
+    }
+
+    if (this.isOriginFullyHidden()) {
+      this.ngZone.run(() => this.dropdown.close());
+      return;
+    }
+
+    if (this.portalFollowScroll) {
+      this.overlayRef.updatePosition();
+    }
+  }
+
+  /**
+   * True when the trigger is completely outside the viewport or any scrollable
+   * ancestor (above/below/left/right of the fold).
+   */
+  private isOriginFullyHidden(): boolean {
+    const origin = this.elementRef.nativeElement.getBoundingClientRect();
+    const boundsList: Array<Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left'>> = [
+      {
+        top: 0,
+        left: 0,
+        bottom: window.innerHeight,
+        right: window.innerWidth
+      },
+      ...this.getScrollParents(this.elementRef.nativeElement).map(parent => parent.getBoundingClientRect())
+    ];
+
+    return boundsList.some(bounds => {
+      const outsideAbove = origin.bottom < bounds.top;
+      const outsideBelow = origin.top > bounds.bottom;
+      const outsideLeft = origin.right < bounds.left;
+      const outsideRight = origin.left > bounds.right;
+      return outsideAbove || outsideBelow || outsideLeft || outsideRight;
     });
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-portal.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-portal.directive.ts
@@ -1,0 +1,208 @@
+import { ConnectedPosition, Overlay, OverlayRef, ScrollStrategy } from '@angular/cdk/overlay';
+import { DomPortal } from '@angular/cdk/portal';
+import { Directive, DoCheck, ElementRef, Input, NgZone, OnDestroy, Renderer2 } from '@angular/core';
+import { Subscription } from 'rxjs';
+
+import { CoerceBooleanProperty } from '../../utils/coerce/coerce-boolean';
+import { DropdownComponent } from './dropdown.component';
+
+@Directive({
+  exportAs: 'ngxDropdownPortal',
+  selector: 'ngx-dropdown[ngxDropdownPortal]',
+  standalone: false
+})
+export class DropdownPortalDirective implements DoCheck, OnDestroy {
+  @Input() portalOffsetX = 0;
+  @Input() portalOffsetY = 0;
+  @Input() portalPanelClass?: string | string[];
+
+  /**
+   * When true (default), the portaled menu tracks its trigger as scrollable
+   * ancestors move. Set to false to leave the menu fixed in the viewport.
+   */
+  @Input() @CoerceBooleanProperty() portalFollowScroll = true;
+
+  private overlayRef: OverlayRef | null = null;
+  private detachmentsSub: Subscription | null = null;
+  private scrollListenerCleanups: Array<() => void> = [];
+  private wasOpen = false;
+  private closingFromDetach = false;
+
+  constructor(
+    private readonly dropdown: DropdownComponent,
+    private readonly elementRef: ElementRef<HTMLElement>,
+    private readonly overlay: Overlay,
+    private readonly renderer: Renderer2,
+    private readonly ngZone: NgZone
+  ) {}
+
+  ngDoCheck(): void {
+    const isOpen = this.dropdown.open;
+
+    if (isOpen && !this.wasOpen) {
+      this.attach();
+    } else if (!isOpen && this.wasOpen) {
+      this.detach();
+    }
+
+    this.wasOpen = isOpen;
+  }
+
+  ngOnDestroy(): void {
+    this.disposeOverlay();
+  }
+
+  private attach(): void {
+    const menu = this.dropdown.dropdownMenu?.element;
+    if (!menu || this.overlayRef?.hasAttached()) {
+      return;
+    }
+
+    if (!this.overlayRef) {
+      this.overlayRef = this.createOverlay(menu);
+      this.detachmentsSub = this.overlayRef.detachments().subscribe(() => {
+        this.unbindScrollListeners();
+        if (this.dropdown.open) {
+          this.closingFromDetach = true;
+          this.dropdown.close();
+          this.closingFromDetach = false;
+        }
+        this.wasOpen = false;
+      });
+    } else {
+      this.overlayRef.updateScrollStrategy(this.createScrollStrategy());
+    }
+
+    this.overlayRef.updatePositionStrategy(this.createPositionStrategy(menu));
+    this.overlayRef.attach(new DomPortal(menu));
+
+    if (this.portalFollowScroll) {
+      this.bindScrollListeners();
+    }
+  }
+
+  private detach(): void {
+    this.unbindScrollListeners();
+
+    if (this.closingFromDetach) {
+      return;
+    }
+
+    if (this.overlayRef?.hasAttached()) {
+      this.overlayRef.detach();
+    }
+  }
+
+  private disposeOverlay(): void {
+    this.unbindScrollListeners();
+    this.detachmentsSub?.unsubscribe();
+    this.detachmentsSub = null;
+
+    if (this.overlayRef) {
+      this.overlayRef.dispose();
+      this.overlayRef = null;
+    }
+  }
+
+  private createOverlay(menu: HTMLElement): OverlayRef {
+    return this.overlay.create({
+      positionStrategy: this.createPositionStrategy(menu),
+      scrollStrategy: this.createScrollStrategy(),
+      panelClass: this.getPanelClasses()
+    });
+  }
+
+  private createScrollStrategy(): ScrollStrategy {
+    if (!this.portalFollowScroll) {
+      return this.overlay.scrollStrategies.noop();
+    }
+
+    // Window / cdkScrollable scrolls. Nested overflow ancestors are handled by
+    // bindScrollListeners — CDK's ScrollDispatcher does not capture those.
+    return this.overlay.scrollStrategies.reposition({ autoClose: false });
+  }
+
+  private createPositionStrategy(menu: HTMLElement) {
+    return this.overlay
+      .position()
+      .flexibleConnectedTo(this.elementRef.nativeElement)
+      .withPush(true)
+      .withFlexibleDimensions(false)
+      .withPositions(this.getPositions(menu));
+  }
+
+  private bindScrollListeners(): void {
+    this.unbindScrollListeners();
+
+    this.ngZone.runOutsideAngular(() => {
+      for (const parent of this.getScrollParents(this.elementRef.nativeElement)) {
+        const cleanup = this.renderer.listen(parent, 'scroll', () => {
+          this.overlayRef?.updatePosition();
+        });
+        this.scrollListenerCleanups.push(cleanup);
+      }
+    });
+  }
+
+  private unbindScrollListeners(): void {
+    for (const cleanup of this.scrollListenerCleanups) {
+      cleanup();
+    }
+    this.scrollListenerCleanups = [];
+  }
+
+  private getScrollParents(element: HTMLElement): HTMLElement[] {
+    const parents: HTMLElement[] = [];
+    let parent = element.parentElement;
+
+    while (parent) {
+      const style = getComputedStyle(parent);
+      const overflow = `${style.overflow}${style.overflowY}${style.overflowX}`;
+
+      if (/(auto|scroll|overlay)/.test(overflow)) {
+        parents.push(parent);
+      }
+
+      parent = parent.parentElement;
+    }
+
+    return parents;
+  }
+
+  private getPositions(menu: HTMLElement): ConnectedPosition[] {
+    const alignEnd = menu.classList.contains('align-right');
+    const originX = alignEnd ? 'end' : 'start';
+    const overlayX = alignEnd ? 'end' : 'start';
+    const offsetX = this.portalOffsetX;
+    const offsetY = this.portalOffsetY;
+
+    return [
+      {
+        originX,
+        originY: 'bottom',
+        overlayX,
+        overlayY: 'top',
+        offsetX,
+        offsetY
+      },
+      {
+        originX,
+        originY: 'top',
+        overlayX,
+        overlayY: 'bottom',
+        offsetX,
+        offsetY
+      }
+    ];
+  }
+
+  private getPanelClasses(): string[] {
+    const classes = ['ngx-dropdown', 'open', 'adjusted', 'ngx-dropdown-portal-panel'];
+
+    if (!this.portalPanelClass) {
+      return classes;
+    }
+
+    return classes.concat(Array.isArray(this.portalPanelClass) ? this.portalPanelClass : [this.portalPanelClass]);
+  }
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.module.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown.module.ts
@@ -1,14 +1,16 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { OverlayModule } from '@angular/cdk/overlay';
 
 import { DropdownComponent } from './dropdown.component';
 import { DropdownToggleDirective } from './dropdown-toggle.directive';
 import { DropdownMenuDirective } from './dropdown-menu.directive';
+import { DropdownPortalDirective } from './dropdown-portal.directive';
 import { InViewportModule } from 'ng-in-viewport';
 
 @NgModule({
-  declarations: [DropdownComponent, DropdownToggleDirective, DropdownMenuDirective],
-  exports: [DropdownComponent, DropdownToggleDirective, DropdownMenuDirective],
-  imports: [CommonModule, InViewportModule]
+  declarations: [DropdownComponent, DropdownToggleDirective, DropdownMenuDirective, DropdownPortalDirective],
+  exports: [DropdownComponent, DropdownToggleDirective, DropdownMenuDirective, DropdownPortalDirective],
+  imports: [CommonModule, OverlayModule, InViewportModule]
 })
 export class DropdownModule {}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-dropdown-panel.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-dropdown-panel.scss
@@ -1,0 +1,5 @@
+@use './json-editor.extensions';
+
+.ngx-json-editor-dropdown-panel .ngx-dropdown-menu {
+  @extend %ngx-dropdown-menu;
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-flat.component.ts
@@ -26,7 +26,7 @@ import type { QueryList } from '@angular/core';
 @Component({
   selector: 'ngx-json-editor-flat',
   templateUrl: './json-editor-flat.component.html',
-  styleUrls: ['./json-editor-flat.component.scss'],
+  styleUrls: ['./json-editor-flat.component.scss', '../json-editor-dropdown-panel.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   standalone: false

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/array-node-flat/array-node-flat.component.html
@@ -1,123 +1,100 @@
 @if (model.length !== undefined) {
-  <div class="array-node-flat" [hidden]="!expanded">
-    @for (value of model; track arrayTrackBy($index); let i = $index) {
-      <div
-        class="array-node-content"
-        [class.no-margin]="schemaBuilderMode"
-        >
-        <ngx-json-editor-node-flat
-          [model]="value"
-          (modelChange)="updateArrayItem(i, $event)"
-          [schema]="schemaBuilderMode ? schemaRef.items : schemas[i]"
-          [path]="path + '[' + i + ']'"
-          [errors]="errors"
-          [typeCheckOverrides]="typeCheckOverrides"
-          [level]="level"
-          [hideRoot]="hideRoot"
-          [formats]="formats"
-          [schemaRef]="schemaRef?.items || null"
-          [schemaBuilderMode]="schemaBuilderMode"
-          [arrayItem]="schemaBuilderMode"
+<div class="array-node-flat" [hidden]="!expanded">
+  @for (value of model; track arrayTrackBy($index); let i = $index) {
+  <div class="array-node-content" [class.no-margin]="schemaBuilderMode">
+    <ngx-json-editor-node-flat
+      [model]="value"
+      (modelChange)="updateArrayItem(i, $event)"
+      [schema]="schemaBuilderMode ? schemaRef.items : schemas[i]"
+      [path]="path + '[' + i + ']'"
+      [errors]="errors"
+      [typeCheckOverrides]="typeCheckOverrides"
+      [level]="level"
+      [hideRoot]="hideRoot"
+      [formats]="formats"
+      [schemaRef]="schemaRef?.items || null"
+      [schemaBuilderMode]="schemaBuilderMode"
+      [arrayItem]="schemaBuilderMode"
       [arrayName]="
         (schema.title ? schema.title : schema.propertyName !== undefined ? schema.propertyName : 'Array ' + level) +
         '[' +
         (schemaBuilderMode ? '' : i) +
         ']'
       "
-          [indentationArray]="indentationArray"
-          [showKnownProperties]="showKnownProperties"
-          [isDuplicated]="isDuplicated"
-          [passwordToggleEnabled]="passwordToggleEnabled"
-          [inputControlTemplate]="inputControlTemplate"
-          (schemaUpdate)="schemaUpdate.emit(schemaRef)"
-          >
-          <div class="node-options" node-options>
-            @if (schemaBuilderMode) {
-              <button
-                type="button"
-                class="node-options-btn"
-                (click)="onPropertyConfig(schemaRef.items, i)"
-                >
-                <i class="ngx-icon ngx-cog"></i>
-              </button>
-            }
-            <ngx-dropdown>
-              <ngx-dropdown-toggle>
-                <button type="button" class="node-options-btn">
-                  <i class="ngx-icon ngx-dots-vert-round"></i>
-                </button>
-              </ngx-dropdown-toggle>
-              <ngx-dropdown-menu class="ngx-dropdown-menu align-right">
-                <ul class="vertical-list">
-                  <li><button type="button" (click)="deleteArrayItem(i)">Delete</button></li>
-                  @if (schemas[i]?.$meta?.type) {
-                    @for (type of schemas[i]?.$meta?.type; track type) {
-                      <li>
-                        <button type="button" (click)="changeItemType(i, type)" [disabled]="schemas[i].currentType === type">
-                          Change type to {{ dataTypeMap[type].name }}
-                        </button>
-                      </li>
-                    }
-                  }
-                </ul>
-              </ngx-dropdown-menu>
-            </ngx-dropdown>
-          </div>
-        </ngx-json-editor-node-flat>
-      </div>
-    }
-    @if (!schemaBuilderMode || !model.length) {
-      <div
-        class="add-button"
-        [class.background]="hideRoot ? level > -1 : level"
-        >
-        @for (separator of indentationArray; track separator) {
-          <span class="json-editor--vertical-separator"></span>
+      [indentationArray]="indentationArray"
+      [showKnownProperties]="showKnownProperties"
+      [isDuplicated]="isDuplicated"
+      [passwordToggleEnabled]="passwordToggleEnabled"
+      [inputControlTemplate]="inputControlTemplate"
+      (schemaUpdate)="schemaUpdate.emit(schemaRef)"
+    >
+      <div class="node-options" node-options>
+        @if (schemaBuilderMode) {
+        <button type="button" class="node-options-btn" (click)="onPropertyConfig(schemaRef.items, i)">
+          <i class="ngx-icon ngx-cog"></i>
+        </button>
         }
-        <div
-          class="indented-content"
-          [style.marginLeft]="hideRoot && level === 0 ? '15px' : '0'"
-          [style.backgroundColor]="level === 0 ? '' : 'rgba(49,56,71,0.5)'"
-          >
-          <ngx-dropdown>
-            <ngx-dropdown-toggle>
-              <button [disabled]="isDuplicated" type="button">
-                <i class="ngx-icon ngx-tree-expand"></i>
-                <span>Add an item</span>
-              </button>
-            </ngx-dropdown-toggle>
-            <ngx-dropdown-menu class="ngx-dropdown-menu">
-              <ul class="vertical-list">
-                @if (!schema || !schema.items || !schema.items.type) {
-                  @for (dataType of dataTypes; track dataType) {
-                    <li (click)="addArrayItem(dataType)">
-                      <button type="button">{{ dataType.name }}</button>
-                    </li>
-                  }
-                }
-                @if (schema?.items?.type) {
-                  @if (!_array.isArray(schema.items.type)) {
-                    <li>
-                      <button type="button" (click)="addArrayItem()">Add</button>
-                    </li>
-                  }
-                  @if (_array.isArray(schema.items.type)) {
-                    @for (type of schema.items.type; track type) {
-                      <li>
-                        <button type="button" (click)="addArrayItem(dataTypeMap[type])">
-                          Add {{ dataTypeMap[type].name }}
-                        </button>
-                      </li>
-                    }
-                  }
-                }
-              </ul>
-            </ngx-dropdown-menu>
-          </ngx-dropdown>
-        </div>
+        <ngx-dropdown ngxDropdownPortal portalPanelClass="ngx-json-editor-dropdown-panel">
+          <ngx-dropdown-toggle>
+            <button type="button" class="node-options-btn">
+              <i class="ngx-icon ngx-dots-vert-round"></i>
+            </button>
+          </ngx-dropdown-toggle>
+          <ngx-dropdown-menu class="ngx-dropdown-menu align-right">
+            <ul class="vertical-list">
+              <li><button type="button" (click)="deleteArrayItem(i)">Delete</button></li>
+              @if (schemas[i]?.$meta?.type) { @for (type of schemas[i]?.$meta?.type; track type) {
+              <li>
+                <button type="button" (click)="changeItemType(i, type)" [disabled]="schemas[i].currentType === type">
+                  Change type to {{ dataTypeMap[type].name }}
+                </button>
+              </li>
+              } }
+            </ul>
+          </ngx-dropdown-menu>
+        </ngx-dropdown>
       </div>
-    }
+    </ngx-json-editor-node-flat>
   </div>
+  } @if (!schemaBuilderMode || !model.length) {
+  <div class="add-button" [class.background]="hideRoot ? level > -1 : level">
+    @for (separator of indentationArray; track separator) {
+    <span class="json-editor--vertical-separator"></span>
+    }
+    <div
+      class="indented-content"
+      [style.marginLeft]="hideRoot && level === 0 ? '15px' : '0'"
+      [style.backgroundColor]="level === 0 ? '' : 'rgba(49,56,71,0.5)'"
+    >
+      <ngx-dropdown ngxDropdownPortal portalPanelClass="ngx-json-editor-dropdown-panel">
+        <ngx-dropdown-toggle>
+          <button [disabled]="isDuplicated" type="button">
+            <i class="ngx-icon ngx-tree-expand"></i>
+            <span>Add an item</span>
+          </button>
+        </ngx-dropdown-toggle>
+        <ngx-dropdown-menu class="ngx-dropdown-menu">
+          <ul class="vertical-list">
+            @if (!schema || !schema.items || !schema.items.type) { @for (dataType of dataTypes; track dataType) {
+            <li (click)="addArrayItem(dataType)">
+              <button type="button">{{ dataType.name }}</button>
+            </li>
+            } } @if (schema?.items?.type) { @if (!_array.isArray(schema.items.type)) {
+            <li>
+              <button type="button" (click)="addArrayItem()">Add</button>
+            </li>
+            } @if (_array.isArray(schema.items.type)) { @for (type of schema.items.type; track type) {
+            <li>
+              <button type="button" (click)="addArrayItem(dataTypeMap[type])">Add {{ dataTypeMap[type].name }}</button>
+            </li>
+            } } }
+          </ul>
+        </ngx-dropdown-menu>
+      </ngx-dropdown>
+    </div>
+  </div>
+  }
+</div>
 }
 
 <!-- Property Config Dialog -->
@@ -129,6 +106,6 @@
     [formats]="context.formats"
     [arrayItem]="true"
     (updateProperty)="context.apply($event)"
-    >
+  >
   </ngx-property-config>
 </ng-template>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor-flat/json-editor-node-flat/node-types/object-node-flat/object-node-flat.component.html
@@ -4,190 +4,162 @@
   cdkDropList
   [cdkDropListDisabled]="!schemaBuilderMode"
   (cdkDropListDropped)="drop($event)"
-  >
+>
   @for (prop of propertyIndex | objectValues; track trackBy(index, prop); let index = $index) {
-    <div
-      cdkDrag
-      cdkDragLockAxis="y"
-      class="object-node-content"
-      >
-      <ngx-json-editor-node-flat
-        [model]="model[$any(prop).propertyName]"
-        (modelChange)="updateProp($any(prop).id, $event)"
-        [schema]="prop"
-        [schemaRef]="schemaRef && schemaRef.properties ? schemaRef.properties[$any(prop).propertyName] : null"
-        [required]="!!requiredCache[$any(prop).propertyName]"
-        [inline]="$any(prop).type !== 'array' && $any(prop).type !== 'object'"
-        [path]="path + getPath($any(prop).propertyName)"
-        [errors]="errors"
-        [hideRoot]="hideRoot"
-        [typeCheckOverrides]="typeCheckOverrides"
-        [level]="level"
-        [schemaBuilderMode]="schemaBuilderMode"
-        [formats]="formats"
-        [indentationArray]="indentationArray"
-        [showKnownProperties]="showKnownProperties"
-        [passwordToggleEnabled]="passwordToggleEnabled"
-        [inputControlTemplate]="inputControlTemplate"
-        [isDuplicated]="duplicatedFields.has($any(prop).id)"
-        (schemaUpdate)="schemaUpdate.emit(schemaRef)"
-        (updatePropertyNameEvent)="onUpdatePropertyName($event)"
-        >
-        <div class="node-options" node-options>
-          @if (schemaBuilderMode) {
-            <button
-              type="button"
-              class="node-options-btn"
-              (click)="onPropertyConfig(prop, index)"
-              >
-              <i class="ngx-icon ngx-cog"></i>
-            </button>
-          }
-          <ngx-dropdown>
-            <ngx-dropdown-toggle>
-              <button type="button" class="node-options-btn">
-                <i class="ngx-icon ngx-dots-vert-round"></i>
-              </button>
-            </ngx-dropdown-toggle>
-            <ngx-dropdown-menu class="ngx-dropdown-menu align-right">
-              <ul class="vertical-list">
-                <li>
-                  <button
-                    type="button"
-                    (click)="deleteProperty($any(prop).propertyName)"
-                    [disabled]="requiredCache[$any(prop).propertyName] && !schemaBuilderMode"
-                    >
-                    {{ !schema.properties?.[$any(prop).propertyName] ? 'Delete' : 'Remove' }}
-                  </button>
-                </li>
-                @if ($any(prop)?.$meta?.type && !schemaBuilderMode) {
-                  @for (type of $any(prop)?.$meta?.type; track type) {
-                    <li>
-                      <button
-                        type="button"
-                        (click)="changePropertyType(prop, type)"
-                        [disabled]="$any(prop).$meta.currentType === type"
-                        >
-                        Change type to {{ dataTypeMap[type].name }}
-                      </button>
-                    </li>
-                  }
-                }
-              </ul>
-            </ngx-dropdown-menu>
-          </ngx-dropdown>
-        </div>
+  <div cdkDrag cdkDragLockAxis="y" class="object-node-content">
+    <ngx-json-editor-node-flat
+      [model]="model[$any(prop).propertyName]"
+      (modelChange)="updateProp($any(prop).id, $event)"
+      [schema]="prop"
+      [schemaRef]="schemaRef && schemaRef.properties ? schemaRef.properties[$any(prop).propertyName] : null"
+      [required]="!!requiredCache[$any(prop).propertyName]"
+      [inline]="$any(prop).type !== 'array' && $any(prop).type !== 'object'"
+      [path]="path + getPath($any(prop).propertyName)"
+      [errors]="errors"
+      [hideRoot]="hideRoot"
+      [typeCheckOverrides]="typeCheckOverrides"
+      [level]="level"
+      [schemaBuilderMode]="schemaBuilderMode"
+      [formats]="formats"
+      [indentationArray]="indentationArray"
+      [showKnownProperties]="showKnownProperties"
+      [passwordToggleEnabled]="passwordToggleEnabled"
+      [inputControlTemplate]="inputControlTemplate"
+      [isDuplicated]="duplicatedFields.has($any(prop).id)"
+      (schemaUpdate)="schemaUpdate.emit(schemaRef)"
+      (updatePropertyNameEvent)="onUpdatePropertyName($event)"
+    >
+      <div class="node-options" node-options>
         @if (schemaBuilderMode) {
-          <div class="drag-drop-handle" cdkDragHandle>
-            <i class="ngx-icon ngx-handle"></i>
-          </div>
+        <button type="button" class="node-options-btn" (click)="onPropertyConfig(prop, index)">
+          <i class="ngx-icon ngx-cog"></i>
+        </button>
         }
-      </ngx-json-editor-node-flat>
-      <div
-        *cdkDragPlaceholder
-        class="indentation-placeholder"
-        [ngStyle]="{ width: 'calc(100% + ' + level * 20 + 'px)' }"
-      ></div>
-    </div>
-  }
-
-  @if (showKnownProperties) {
-    @for (prop of schema.properties | keyvalue; track prop) {
-      @if (model[prop.key] === undefined) {
-        <div class="node-container add-button add-prop-button">
-          @for (separator of indentationArray; track separator) {
-            <span class="json-editor--vertical-separator"></span>
-          }
-          @if (level === 0) {
-            <div [style.marginLeft]="'15px'" class="indentation"></div>
-          }
-          @if (level !== 0 && !hideRoot) {
-            <div class="indentation"></div>
-          }
-          <div
-            class="node"
-            [style.marginLeft]="level === 0 ? '0px' : hideRoot ? '15px' : '1px'"
-            (click)="addSchemaProperty(prop.key)"
-            >
-            <div class="left-options"></div>
-            <div class="node-content">
-              <div class="node-info">
-                <ngx-json-editor-node-info
-                  [nameEditable]="false"
-                  [propertyName]="prop.key"
-                  [title]="prop.value.title ? prop.value.title : prop.key"
-                  [type]="(prop.value.format || ($any(prop.value.type) | titlecase)) + (prop.value.enum?.length ? ' + Enum' : '')"
-                  [description]="prop.value?.description"
-                  [examples]="prop.value.examples"
-                  [required]="required"
-                  >
-                </ngx-json-editor-node-info>
-              </div>
-              <div class="indented-content">
-                <button type="button">
-                  <i class="ngx-icon ngx-tree-expand"></i>
-                  <span>Include</span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      }
-    }
-  }
-
-  @if (!showKnownProperties || schema.additionalProperties !== false) {
-    <div
-      class="add-button"
-      [class.background]="hideRoot ? level > -1 : level"
-      >
-      @for (separator of indentationArray; track separator) {
-        <span class="json-editor--vertical-separator"></span>
-      }
-      <div class="indented-content" [class.indented-content--root]="isRoot" [class.indented-content--indent]="indentAdd">
-        <ngx-dropdown>
-          <ngx-dropdown-toggle [disabled]="isDuplicated">
-            <button type="button">
-              <i class="ngx-icon ngx-tree-expand"></i>
-              <span class="dropdown-text">Add a property</span>
+        <ngx-dropdown ngxDropdownPortal portalPanelClass="ngx-json-editor-dropdown-panel">
+          <ngx-dropdown-toggle>
+            <button type="button" class="node-options-btn">
+              <i class="ngx-icon ngx-dots-vert-round"></i>
             </button>
           </ngx-dropdown-toggle>
-          <ngx-dropdown-menu class="ngx-dropdown-menu">
-            @if (schema.properties && !schemaBuilderMode && !showKnownProperties) {
-              <ul
-                class="vertical-list dropdown-column"
+          <ngx-dropdown-menu class="ngx-dropdown-menu align-right">
+            <ul class="vertical-list">
+              <li>
+                <button
+                  type="button"
+                  (click)="deleteProperty($any(prop).propertyName)"
+                  [disabled]="requiredCache[$any(prop).propertyName] && !schemaBuilderMode"
                 >
-                @for (prop of schema.properties | keyvalue; track prop) {
-                  <li (click)="addSchemaProperty(prop.key)">
-                    <button [disabled]="model[prop.key] !== undefined" type="button">
-                      {{ prop?.value?.title ? prop.value.title : prop.key }}
-                    </button>
-                  </li>
-                }
-              </ul>
-            }
-            @if (!schema || schema.patternProperties || schema.additionalProperties !== false) {
-              <ul
-                class="vertical-list dropdown-column"
+                  {{ !schema.properties?.[$any(prop).propertyName] ? 'Delete' : 'Remove' }}
+                </button>
+              </li>
+              @if ($any(prop)?.$meta?.type && !schemaBuilderMode) { @for (type of $any(prop)?.$meta?.type; track type) {
+              <li>
+                <button
+                  type="button"
+                  (click)="changePropertyType(prop, type)"
+                  [disabled]="$any(prop).$meta.currentType === type"
                 >
-                @for (prop of schema.patternProperties | keyvalue; track prop) {
-                  <li (click)="addSchemaPatternProperty(prop.key)">
-                    <button type="button">{{ prop.value.title ? prop.value.title : prop.key }}</button>
-                  </li>
-                }
-                @if (!schema || schema.additionalProperties !== false) {
-                  @for (dataType of dataTypes; track dataType) {
-                    <li (click)="addProperty(dataType)">
-                      <button type="button">{{ dataType.name }}</button>
-                    </li>
-                  }
-                }
-              </ul>
-            }
+                  Change type to {{ dataTypeMap[type].name }}
+                </button>
+              </li>
+              } }
+            </ul>
           </ngx-dropdown-menu>
         </ngx-dropdown>
       </div>
+      @if (schemaBuilderMode) {
+      <div class="drag-drop-handle" cdkDragHandle>
+        <i class="ngx-icon ngx-handle"></i>
+      </div>
+      }
+    </ngx-json-editor-node-flat>
+    <div
+      *cdkDragPlaceholder
+      class="indentation-placeholder"
+      [ngStyle]="{ width: 'calc(100% + ' + level * 20 + 'px)' }"
+    ></div>
+  </div>
+  } @if (showKnownProperties) { @for (prop of schema.properties | keyvalue; track prop) { @if (model[prop.key] ===
+  undefined) {
+  <div class="node-container add-button add-prop-button">
+    @for (separator of indentationArray; track separator) {
+    <span class="json-editor--vertical-separator"></span>
+    } @if (level === 0) {
+    <div [style.marginLeft]="'15px'" class="indentation"></div>
+    } @if (level !== 0 && !hideRoot) {
+    <div class="indentation"></div>
+    }
+    <div
+      class="node"
+      [style.marginLeft]="level === 0 ? '0px' : hideRoot ? '15px' : '1px'"
+      (click)="addSchemaProperty(prop.key)"
+    >
+      <div class="left-options"></div>
+      <div class="node-content">
+        <div class="node-info">
+          <ngx-json-editor-node-info
+            [nameEditable]="false"
+            [propertyName]="prop.key"
+            [title]="prop.value.title ? prop.value.title : prop.key"
+            [type]="
+              (prop.value.format || ($any(prop.value.type) | titlecase)) + (prop.value.enum?.length ? ' + Enum' : '')
+            "
+            [description]="prop.value?.description"
+            [examples]="prop.value.examples"
+            [required]="required"
+          >
+          </ngx-json-editor-node-info>
+        </div>
+        <div class="indented-content">
+          <button type="button">
+            <i class="ngx-icon ngx-tree-expand"></i>
+            <span>Include</span>
+          </button>
+        </div>
+      </div>
     </div>
+  </div>
+  } } } @if (!showKnownProperties || schema.additionalProperties !== false) {
+  <div class="add-button" [class.background]="hideRoot ? level > -1 : level">
+    @for (separator of indentationArray; track separator) {
+    <span class="json-editor--vertical-separator"></span>
+    }
+    <div class="indented-content" [class.indented-content--root]="isRoot" [class.indented-content--indent]="indentAdd">
+      <ngx-dropdown ngxDropdownPortal portalPanelClass="ngx-json-editor-dropdown-panel">
+        <ngx-dropdown-toggle [disabled]="isDuplicated">
+          <button type="button">
+            <i class="ngx-icon ngx-tree-expand"></i>
+            <span class="dropdown-text">Add a property</span>
+          </button>
+        </ngx-dropdown-toggle>
+        <ngx-dropdown-menu class="ngx-dropdown-menu">
+          @if (schema.properties && !schemaBuilderMode && !showKnownProperties) {
+          <ul class="vertical-list dropdown-column">
+            @for (prop of schema.properties | keyvalue; track prop) {
+            <li (click)="addSchemaProperty(prop.key)">
+              <button [disabled]="model[prop.key] !== undefined" type="button">
+                {{ prop?.value?.title ? prop.value.title : prop.key }}
+              </button>
+            </li>
+            }
+          </ul>
+          } @if (!schema || schema.patternProperties || schema.additionalProperties !== false) {
+          <ul class="vertical-list dropdown-column">
+            @for (prop of schema.patternProperties | keyvalue; track prop) {
+            <li (click)="addSchemaPatternProperty(prop.key)">
+              <button type="button">{{ prop.value.title ? prop.value.title : prop.key }}</button>
+            </li>
+            } @if (!schema || schema.additionalProperties !== false) { @for (dataType of dataTypes; track dataType) {
+            <li (click)="addProperty(dataType)">
+              <button type="button">{{ dataType.name }}</button>
+            </li>
+            } }
+          </ul>
+          }
+        </ngx-dropdown-menu>
+      </ngx-dropdown>
+    </div>
+  </div>
   }
 </div>
 
@@ -200,6 +172,6 @@
     [formats]="context.formats"
     [isNew]="context.isNew"
     (updateProperty)="context.apply($event)"
-    >
+  >
   </ngx-property-config>
 </ng-template>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/array-node/array-node.component.html
@@ -1,45 +1,43 @@
 <div [hidden]="!expanded">
   @for (value of model; track arrayTrackBy($index); let i = $index) {
-    <div>
-      <div class="property-def">
-        <ngx-dropdown>
-          <ngx-dropdown-toggle>
-            <div class="type-icon" tooltipPlacement="top">
-              <ngx-icon [fontIcon]="schemas[i]?.$meta.icon"> </ngx-icon>
-            </div>
-          </ngx-dropdown-toggle>
-          <ngx-dropdown-menu class="ngx-dropdown-menu">
-            <ul class="vertical-list">
-              <li><button type="button" (click)="deleteArrayItem(i)">Delete</button></li>
-              @if (schemas[i]?.$meta?.type) {
-                @for (type of schemas[i]?.$meta?.type; track type) {
-                  <li>
-                    <button type="button" (click)="changeItemType(i, type)" [disabled]="schemas[i].currentType === type">
-                      Change type to {{ dataTypeMap[type].name }}
-                    </button>
-                  </li>
-                }
-              }
-            </ul>
-          </ngx-dropdown-menu>
-        </ngx-dropdown>
-      </div>
-      <ngx-json-editor-node
-        [model]="value"
-        (modelChange)="updateArrayItem(i, $event)"
-        [schema]="schemas[i]"
-        [path]="path + '[' + i + ']'"
-        [errors]="errors"
-        [isDuplicated]="isDuplicated"
-        [typeCheckOverrides]="typeCheckOverrides"
-        [showKnownProperties]="showKnownProperties"
-        [passwordToggleEnabled]="passwordToggleEnabled"
-        >
-      </ngx-json-editor-node>
+  <div>
+    <div class="property-def">
+      <ngx-dropdown ngxDropdownPortal portalPanelClass="ngx-json-editor-dropdown-panel" [portalOffsetX]="16">
+        <ngx-dropdown-toggle>
+          <div class="type-icon" tooltipPlacement="top">
+            <ngx-icon [fontIcon]="schemas[i]?.$meta.icon"> </ngx-icon>
+          </div>
+        </ngx-dropdown-toggle>
+        <ngx-dropdown-menu class="ngx-dropdown-menu">
+          <ul class="vertical-list">
+            <li><button type="button" (click)="deleteArrayItem(i)">Delete</button></li>
+            @if (schemas[i]?.$meta?.type) { @for (type of schemas[i]?.$meta?.type; track type) {
+            <li>
+              <button type="button" (click)="changeItemType(i, type)" [disabled]="schemas[i].currentType === type">
+                Change type to {{ dataTypeMap[type].name }}
+              </button>
+            </li>
+            } }
+          </ul>
+        </ngx-dropdown-menu>
+      </ngx-dropdown>
     </div>
+    <ngx-json-editor-node
+      [model]="value"
+      (modelChange)="updateArrayItem(i, $event)"
+      [schema]="schemas[i]"
+      [path]="path + '[' + i + ']'"
+      [errors]="errors"
+      [isDuplicated]="isDuplicated"
+      [typeCheckOverrides]="typeCheckOverrides"
+      [showKnownProperties]="showKnownProperties"
+      [passwordToggleEnabled]="passwordToggleEnabled"
+    >
+    </ngx-json-editor-node>
+  </div>
   }
 
-  <ngx-dropdown>
+  <ngx-dropdown ngxDropdownPortal portalPanelClass="ngx-json-editor-dropdown-panel" [portalOffsetX]="16">
     <ngx-dropdown-toggle [disabled]="isDuplicated">
       <div class="add-button">
         <ngx-icon fontIcon="plus-bold"></ngx-icon>
@@ -47,27 +45,19 @@
     </ngx-dropdown-toggle>
     <ngx-dropdown-menu class="ngx-dropdown-menu">
       <ul class="vertical-list">
-        @if (!schema || !schema.items || !schema.items.type) {
-          @for (dataType of dataTypes; track dataType) {
-            <li (click)="addArrayItem(dataType)">
-              <button type="button">{{ dataType.name }}</button>
-            </li>
-          }
-        }
-        @if (schema?.items?.type) {
-          @if (!_array.isArray(schema.items.type)) {
-            <li>
-              <button [disabled]="isDuplicated" type="button" (click)="addArrayItem()">Add</button>
-            </li>
-          }
-          @if (_array.isArray(schema.items.type)) {
-            @for (type of schema.items.type; track type) {
-              <li>
-                <button type="button" (click)="addArrayItem(dataTypeMap[type])">Add {{ dataTypeMap[type].name }}</button>
-              </li>
-            }
-          }
-        }
+        @if (!schema || !schema.items || !schema.items.type) { @for (dataType of dataTypes; track dataType) {
+        <li (click)="addArrayItem(dataType)">
+          <button type="button">{{ dataType.name }}</button>
+        </li>
+        } } @if (schema?.items?.type) { @if (!_array.isArray(schema.items.type)) {
+        <li>
+          <button [disabled]="isDuplicated" type="button" (click)="addArrayItem()">Add</button>
+        </li>
+        } @if (_array.isArray(schema.items.type)) { @for (type of schema.items.type; track type) {
+        <li>
+          <button type="button" (click)="addArrayItem(dataTypeMap[type])">Add {{ dataTypeMap[type].name }}</button>
+        </li>
+        } } }
       </ul>
     </ngx-dropdown-menu>
   </ngx-dropdown>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor-node/node-types/object-node/object-node.component.html
@@ -1,76 +1,77 @@
 <div [hidden]="!expanded">
   @for (prop of propertyIndex | objectValues; track trackBy($index, prop)) {
-    <div>
-      <div class="property-def" [class.invalid]="duplicatedFields.has($any(prop).id)">
-        <ngx-dropdown>
-          <ngx-dropdown-toggle>
-            <div class="type-icon">
-              <ngx-icon [fontIcon]="$any(prop).$meta.icon"></ngx-icon>
-            </div>
-          </ngx-dropdown-toggle>
-          <ngx-dropdown-menu class="ngx-dropdown-menu">
-            <ul class="vertical-list">
-              <li>
-                <button
-                  type="button"
-                  (click)="deleteProperty($any(prop).propertyName)"
-                  [disabled]="requiredCache[$any(prop).propertyName]"
-                  >
-                  Delete
-                </button>
-              </li>
-              @if ($any(prop)?.$meta?.type) {
-                @for (type of $any(prop)?.$meta?.type; track type) {
-                  <li>
-                    <button
-                      type="button"
-                      (click)="changePropertyType(prop, type)"
-                      [disabled]="$any(prop).$meta.currentType === type"
-                      >
-                      Change type to {{ dataTypeMap[type].name }}
-                    </button>
-                  </li>
-                }
-              }
-            </ul>
-          </ngx-dropdown-menu>
-        </ngx-dropdown>
-        <div class="property-name">
-          @if ($any(prop).nameEditable) {
-            <input
-              type="text"
-              [ngModel]="$any(prop).propertyName"
-              (ngModelChange)="updatePropertyName($any(prop).id, $event)"
-              />
-          }
-          @if (!$any(prop)?.nameEditable) {
-            <div class="title" ngx-tooltip [tooltipTitle]="$any(prop)?.description ? $any(prop)?.description : $any(prop)?.propertyName">
-              {{ $any(prop)?.title ? $any(prop)?.title : $any(prop)?.propertyName }}
-              @if (requiredCache[$any(prop).propertyName]) {
-                <span>*</span>
-              }
-            </div>
+  <div>
+    <div class="property-def" [class.invalid]="duplicatedFields.has($any(prop).id)">
+      <ngx-dropdown ngxDropdownPortal portalPanelClass="ngx-json-editor-dropdown-panel" [portalOffsetX]="16">
+        <ngx-dropdown-toggle>
+          <div class="type-icon">
+            <ngx-icon [fontIcon]="$any(prop).$meta.icon"></ngx-icon>
+          </div>
+        </ngx-dropdown-toggle>
+        <ngx-dropdown-menu class="ngx-dropdown-menu">
+          <ul class="vertical-list">
+            <li>
+              <button
+                type="button"
+                (click)="deleteProperty($any(prop).propertyName)"
+                [disabled]="requiredCache[$any(prop).propertyName]"
+              >
+                Delete
+              </button>
+            </li>
+            @if ($any(prop)?.$meta?.type) { @for (type of $any(prop)?.$meta?.type; track type) {
+            <li>
+              <button
+                type="button"
+                (click)="changePropertyType(prop, type)"
+                [disabled]="$any(prop).$meta.currentType === type"
+              >
+                Change type to {{ dataTypeMap[type].name }}
+              </button>
+            </li>
+            } }
+          </ul>
+        </ngx-dropdown-menu>
+      </ngx-dropdown>
+      <div class="property-name">
+        @if ($any(prop).nameEditable) {
+        <input
+          type="text"
+          [ngModel]="$any(prop).propertyName"
+          (ngModelChange)="updatePropertyName($any(prop).id, $event)"
+        />
+        } @if (!$any(prop)?.nameEditable) {
+        <div
+          class="title"
+          ngx-tooltip
+          [tooltipTitle]="$any(prop)?.description ? $any(prop)?.description : $any(prop)?.propertyName"
+        >
+          {{ $any(prop)?.title ? $any(prop)?.title : $any(prop)?.propertyName }}
+          @if (requiredCache[$any(prop).propertyName]) {
+          <span>*</span>
           }
         </div>
+        }
       </div>
-      <ngx-json-editor-node
-        [model]="model[$any(prop).propertyName]"
-        (modelChange)="updateProp($any(prop).id, $event)"
-        [schema]="prop"
-        [required]="!!requiredCache[$any(prop).propertyName]"
-        [inline]="$any(prop).type !== 'array' && $any(prop).type !== 'object'"
-        [path]="path + getPath($any(prop).propertyName)"
-        [isDuplicated]="duplicatedFields.has($any(prop).id)"
-        [errors]="errors"
-        [typeCheckOverrides]="typeCheckOverrides"
-        [showKnownProperties]="showKnownProperties"
-        [passwordToggleEnabled]="passwordToggleEnabled"
-        >
-      </ngx-json-editor-node>
     </div>
+    <ngx-json-editor-node
+      [model]="model[$any(prop).propertyName]"
+      (modelChange)="updateProp($any(prop).id, $event)"
+      [schema]="prop"
+      [required]="!!requiredCache[$any(prop).propertyName]"
+      [inline]="$any(prop).type !== 'array' && $any(prop).type !== 'object'"
+      [path]="path + getPath($any(prop).propertyName)"
+      [isDuplicated]="duplicatedFields.has($any(prop).id)"
+      [errors]="errors"
+      [typeCheckOverrides]="typeCheckOverrides"
+      [showKnownProperties]="showKnownProperties"
+      [passwordToggleEnabled]="passwordToggleEnabled"
+    >
+    </ngx-json-editor-node>
+  </div>
   }
 
-  <ngx-dropdown>
+  <ngx-dropdown ngxDropdownPortal portalPanelClass="ngx-json-editor-dropdown-panel" [portalOffsetX]="16">
     <ngx-dropdown-toggle [disabled]="isDuplicated">
       <div class="add-button">
         <ngx-icon fontIcon="plus-bold"></ngx-icon>
@@ -78,33 +79,27 @@
     </ngx-dropdown-toggle>
     <ngx-dropdown-menu class="ngx-dropdown-menu">
       @if (schema.properties) {
-        <ul class="vertical-list dropdown-column">
-          @for (prop of schema.properties | keyvalue; track prop) {
-            <li (click)="addSchemaProperty(prop.key)">
-              <button [disabled]="model[prop.key] !== undefined" type="button">
-                {{ prop.value.title ? prop.value.title : prop.key }}
-              </button>
-            </li>
-          }
-        </ul>
-      }
-      @if (!schema || schema.patternProperties || schema.additionalProperties !== false) {
-        <ul
-          class="vertical-list dropdown-column"
-          >
-          @for (prop of schema.patternProperties | keyvalue; track prop) {
-            <li (click)="addSchemaPatternProperty(prop.key)">
-              <button type="button">{{ prop.value.title ? prop.value.title : prop.key }}</button>
-            </li>
-          }
-          @if (!schema || schema.additionalProperties !== false) {
-            @for (dataType of dataTypes; track dataType) {
-              <li (click)="addProperty(dataType)">
-                <button type="button">{{ dataType.name }}</button>
-              </li>
-            }
-          }
-        </ul>
+      <ul class="vertical-list dropdown-column">
+        @for (prop of schema.properties | keyvalue; track prop) {
+        <li (click)="addSchemaProperty(prop.key)">
+          <button [disabled]="model[prop.key] !== undefined" type="button">
+            {{ prop.value.title ? prop.value.title : prop.key }}
+          </button>
+        </li>
+        }
+      </ul>
+      } @if (!schema || schema.patternProperties || schema.additionalProperties !== false) {
+      <ul class="vertical-list dropdown-column">
+        @for (prop of schema.patternProperties | keyvalue; track prop) {
+        <li (click)="addSchemaPatternProperty(prop.key)">
+          <button type="button">{{ prop.value.title ? prop.value.title : prop.key }}</button>
+        </li>
+        } @if (!schema || schema.additionalProperties !== false) { @for (dataType of dataTypes; track dataType) {
+        <li (click)="addProperty(dataType)">
+          <button type="button">{{ dataType.name }}</button>
+        </li>
+        } }
+      </ul>
       }
     </ngx-dropdown-menu>
   </ngx-dropdown>

--- a/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/json-editor/json-editor/json-editor.component.ts
@@ -16,7 +16,7 @@ import type { QueryList } from '@angular/core';
 @Component({
   selector: 'ngx-json-editor',
   templateUrl: './json-editor.component.html',
-  styleUrls: ['./json-editor.component.scss'],
+  styleUrls: ['./json-editor.component.scss', '../json-editor-dropdown-panel.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false

--- a/projects/swimlane/ngx-ui/src/lib/styles/components/dropdown-portal.scss
+++ b/projects/swimlane/ngx-ui/src/lib/styles/components/dropdown-portal.scss
@@ -1,0 +1,17 @@
+@use '@angular/cdk' as cdk;
+
+@include cdk.overlay();
+
+.cdk-overlay-pane.ngx-dropdown-portal-panel {
+  position: absolute;
+  padding-bottom: 0;
+
+  .ngx-dropdown-menu {
+    position: static;
+  }
+
+  .ngx-dropdown-menu--upwards {
+    bottom: auto;
+    margin-bottom: 0;
+  }
+}

--- a/projects/swimlane/ngx-ui/src/lib/styles/components/index.scss
+++ b/projects/swimlane/ngx-ui/src/lib/styles/components/index.scss
@@ -10,3 +10,4 @@
 @forward 'hr';
 @forward 'scrollbars';
 @forward 'datatable';
+@forward 'dropdown-portal';

--- a/projects/swimlane/ngx-ui/src/public_api.ts
+++ b/projects/swimlane/ngx-ui/src/public_api.ts
@@ -120,6 +120,7 @@ export * from './lib/components/dropdown/dropdown.module';
 export * from './lib/components/dropdown/dropdown.component';
 export * from './lib/components/dropdown/dropdown-toggle.directive';
 export * from './lib/components/dropdown/dropdown-menu.directive';
+export * from './lib/components/dropdown/dropdown-portal.directive';
 export * from './lib/components/dropdown/dropdown.show-types.enum';
 
 export * from './lib/components/dropzone/dropzone.module';

--- a/scripts/prep-global-styles.js
+++ b/scripts/prep-global-styles.js
@@ -31,7 +31,7 @@ const compileCss = () =>
       sass.render(
         {
           data: `$pkgVersion:'${version}';${data}`,
-          includePaths: ['dist/swimlane/ngx-ui/lib/styles', 'dist/swimlane/ngx-ui/lib/assets']
+          includePaths: ['dist/swimlane/ngx-ui/lib/styles', 'dist/swimlane/ngx-ui/lib/assets', 'node_modules']
         },
         (err, result) => {
           if (err) {

--- a/src/app/components/dropdown-page/dropdown-page.component.html
+++ b/src/app/components/dropdown-page/dropdown-page.component.html
@@ -273,12 +273,14 @@
       <p>
         Add <code>ngxDropdownPortal</code> to move the menu into a CDK overlay. Use this when a parent
         with <code>overflow</code> would clip the menu. By default the menu tracks the trigger while
-        scrollable ancestors move (<code>portalFollowScroll</code>).
+        scrollable ancestors move (<code>portalFollowScroll</code>), and closes when the trigger
+        scrolls fully out of view.
       </p>
 
       <div class="portal-demo-clip">
         <p class="portal-demo-clip__hint">
-          Open the menu, then scroll this box — the portaled menu stays attached instead of clipping.
+          Scroll down to the button and open the menu. Small scrolls keep the menu attached; keep
+          scrolling until the button passes the top or bottom edge and the menu closes.
         </p>
         <div class="portal-demo-clip__spacer" aria-hidden="true"></div>
         <ngx-dropdown ngxDropdownPortal>
@@ -812,7 +814,8 @@
           </th>
           <td>
             When true, the portaled menu tracks the trigger as scrollable ancestors move. Set to
-            false to leave the menu fixed in the viewport.
+            false to leave the menu fixed in the viewport. In either case, the dropdown closes when
+            the trigger scrolls fully out of the viewport or a scrollable ancestor.
           </td>
         </tr>
         <tr>

--- a/src/app/components/dropdown-page/dropdown-page.component.html
+++ b/src/app/components/dropdown-page/dropdown-page.component.html
@@ -268,6 +268,81 @@
         </ngx-dropdown-menu>
       </ngx-dropdown>
     </ngx-section>
+
+    <ngx-section class="shadow" sectionTitle="Portal Dropdown">
+      <p>
+        Add <code>ngxDropdownPortal</code> to move the menu into a CDK overlay. Use this when a parent
+        with <code>overflow</code> would clip the menu. By default the menu tracks the trigger while
+        scrollable ancestors move (<code>portalFollowScroll</code>).
+      </p>
+
+      <div class="portal-demo-clip">
+        <p class="portal-demo-clip__hint">
+          Open the menu, then scroll this box — the portaled menu stays attached instead of clipping.
+        </p>
+        <div class="portal-demo-clip__spacer" aria-hidden="true"></div>
+        <ngx-dropdown ngxDropdownPortal>
+          <ngx-dropdown-toggle>
+            <button class="btn" type="button">
+              Portal Menu
+            </button>
+          </ngx-dropdown-toggle>
+          <ngx-dropdown-menu>
+            <ul class="vertical-list">
+              <li>
+                <button type="button">Button 1</button>
+              </li>
+              <li>
+                <button type="button">Button 2</button>
+              </li>
+              <li>
+                <a href="/">Link 1</a>
+              </li>
+              <li>
+                <a href="/">Link 2</a>
+              </li>
+            </ul>
+          </ngx-dropdown-menu>
+        </ngx-dropdown>
+        <div class="portal-demo-clip__spacer" aria-hidden="true"></div>
+      </div>
+
+      <br />
+      <br />
+      <app-prism>
+    <![CDATA[<div class="overflow-container">
+  <ngx-dropdown ngxDropdownPortal>
+    <ngx-dropdown-toggle>
+      <button class="btn" type="button">
+        Portal Menu
+      </button>
+    </ngx-dropdown-toggle>
+    <ngx-dropdown-menu>
+      <ul class="vertical-list">
+        <li><button type="button">Button 1</button></li>
+        <li><button type="button">Button 2</button></li>
+        <li><a href="/">Link 1</a></li>
+        <li><a href="/">Link 2</a></li>
+      </ul>
+    </ngx-dropdown-menu>
+  </ngx-dropdown>
+</div>
+
+<!-- Optional: leave the menu fixed in the viewport while scrolling -->
+<ngx-dropdown ngxDropdownPortal [portalFollowScroll]="false">
+  ...
+</ngx-dropdown>
+
+<!-- Optional: offset and panel class for consumer-specific styles -->
+<ngx-dropdown
+  ngxDropdownPortal
+  [portalOffsetX]="8"
+  [portalOffsetY]="4"
+  portalPanelClass="my-dropdown-panel">
+  ...
+</ngx-dropdown>]]>
+      </app-prism>
+    </ngx-section>
     
     <ngx-section sectionTitle="Dropdown Appearances">
       <table class="appearance-table">
@@ -603,6 +678,7 @@
     <a class="documentation-content" (click)="scrollTo('ngx-dropdown-toggle-outputs')">ngx-dropdown-toggle Outputs</a>
     <a class="documentation-content" (click)="scrollTo('ngx-dropdown-menu-outputs')">ngx-dropdown-menu Inputs</a>
     <a class="documentation-content" (click)="scrollTo('ngx-dropdown-menu-outputs')">ngx-dropdown-menu Outputs</a>
+    <a class="documentation-content" (click)="scrollTo('ngx-dropdown-portal-inputs')">ngxDropdownPortal Inputs</a>
     <hr>
 
     <h3 class="style-header" id="ngx-dropdown-inputs">ngx-dropdown Inputs</h3>
@@ -715,6 +791,57 @@
     <hr>
     <h3 class="style-header" id="ngx-dropdown-menu-outputs">ngx-dropdown-menu Outputs</h3>
     <h4>No component outputs to display.</h4>
+    <hr>
+    <h3 class="style-header" id="ngx-dropdown-portal-inputs">ngxDropdownPortal Inputs</h3>
+    <p>
+      Opt-in attribute directive on <code>ngx-dropdown</code>. Structural portal styles ship in the
+      library global CSS (<code>ngx-dropdown-portal-panel</code>).
+    </p>
+    <table class="table documentation-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>portalFollowScroll: boolean = true</code>
+          </th>
+          <td>
+            When true, the portaled menu tracks the trigger as scrollable ancestors move. Set to
+            false to leave the menu fixed in the viewport.
+          </td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>portalOffsetX: number = 0</code>
+          </th>
+          <td>Horizontal offset applied to the connected overlay position.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>portalOffsetY: number = 0</code>
+          </th>
+          <td>Vertical offset applied to the connected overlay position.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>portalPanelClass: string | string[]</code>
+          </th>
+          <td>
+            Extra CSS class(es) added to the CDK overlay pane, in addition to
+            <code>ngx-dropdown-portal-panel</code>. Useful for consumer-specific menu styles once the
+            menu is moved out of the component DOM.
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </ngx-tab>
 </ngx-tabs>
 

--- a/src/app/components/dropdown-page/dropdown-page.component.scss
+++ b/src/app/components/dropdown-page/dropdown-page.component.scss
@@ -11,7 +11,7 @@
 
 .portal-demo-clip {
   max-width: 360px;
-  height: 160px;
+  height: 180px;
   overflow: auto;
   border: 1px solid var(--color-blue-grey-600, #455066);
   border-radius: 4px;
@@ -24,7 +24,9 @@
     color: var(--color-blue-grey-300, #afb7c8);
   }
 
+  // Must exceed the box's visible height so the trigger can scroll fully past
+  // either edge, which is what triggers the close-when-hidden behavior.
   &__spacer {
-    height: 120px;
+    height: 320px;
   }
 }

--- a/src/app/components/dropdown-page/dropdown-page.component.scss
+++ b/src/app/components/dropdown-page/dropdown-page.component.scss
@@ -8,3 +8,23 @@
     vertical-align: top;
   }
 }
+
+.portal-demo-clip {
+  max-width: 360px;
+  height: 160px;
+  overflow: auto;
+  border: 1px solid var(--color-blue-grey-600, #455066);
+  border-radius: 4px;
+  padding: 12px;
+  background: var(--color-blue-grey-800, #1b1e27);
+
+  &__hint {
+    margin: 0 0 12px;
+    font-size: 0.875rem;
+    color: var(--color-blue-grey-300, #afb7c8);
+  }
+
+  &__spacer {
+    height: 120px;
+  }
+}


### PR DESCRIPTION
## Summary

This addresses a long standing issue where dropdowns are stuck in the layer in the stack where they are defined, opening up the possibility for scrollable containers or overflow: none to crop parts of the dropdown. Added an optional Directive for projecting ngx-dropdown through CDK Portal. It requires adding the Directive and importing some global CSS for ease of use. Added documentation and used the Directive in JSON Editor.

<img width="963" height="869" alt="Screenshot 2026-07-30 at 1 39 39 PM" src="https://github.com/user-attachments/assets/13006f5c-8266-4acf-b45f-11cb3c96e949" />



## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared dropdown overlay lifecycle (scroll listeners, detach/close sync) and changes default JSON Editor menu DOM placement; regressions would show as mispositioned menus or flaky E2E, not auth/data risk.
> 
> **Overview**
> Adds an **opt-in** `ngxDropdownPortal` directive on `ngx-dropdown` that moves the menu into an Angular CDK overlay (`DomPortal`) so menus are not clipped by `overflow` on ancestors. Configurable offsets, `portalPanelClass`, and `portalFollowScroll` (menu tracks the trigger on scroll; closes when the trigger leaves the viewport or a scroll parent). Global styles ship via `dropdown-portal.scss` in the library CSS bundle; the global-styles build adds `node_modules` to Sass include paths for CDK overlay mixins.
> 
> **JSON Editor** type-picker and options menus (flat and classic tree) now use `ngxDropdownPortal` with `ngx-json-editor-dropdown-panel` so add-property / add-item / node-options menus render above scrollable editor UI.
> 
> **Tests & docs:** Cypress JSON editor specs query menus in `.cdk-overlay-container`; the dropdown demo page adds a scroll-clipping portal example and API table for the new inputs. `DropdownPortalDirective` is exported from `public_api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9160ef877141a8028766ea16432e1fdc2ba65d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->