### PR TITLE
(release): 52.2.0

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 52.2.0 (2026-07-30)
+
 - Feature (`ngx-dropdown`): Added opt-in `ngxDropdownPortal` directive to render dropdown menus via Angular CDK Overlay, avoiding clipping inside overflow containers. Supports `portalOffsetX`, `portalOffsetY`, `portalPanelClass`, and `portalFollowScroll` (default `true`). Closes when the trigger scrolls fully out of view. Global portal styles are included in the library CSS bundle.
 - Feature: Applied `ngxDropdownPortal` to JSON Editor type-picker dropdowns.
 

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "52.1.0",
+  "version": "52.2.0",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Summary

- Feature (`ngx-dropdown`): Added opt-in `ngxDropdownPortal` directive to render dropdown menus via Angular CDK Overlay, avoiding clipping inside overflow containers. Supports `portalOffsetX`, `portalOffsetY`, `portalPanelClass`, and `portalFollowScroll` (default `true`). Closes when the trigger scrolls fully out of view. Global portal styles are included in the library CSS bundle.
- Feature: Applied `ngxDropdownPortal` to JSON Editor type-picker dropdowns.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only metadata and changelog updates; no runtime code changes in this diff.
> 
> **Overview**
> **Release 52.2.0** — bumps `@swimlane/ngx-ui` from **52.1.0** to **52.2.0** and records the shipped features under a dated **52.2.0 (2026-07-30)** section in the changelog (HEAD stays empty for unreleased work).
> 
> The changelog entries for this version describe **opt-in `ngxDropdownPortal`** on `ngx-dropdown` (CDK Overlay menus to avoid overflow clipping, with portal offset/class options and scroll-follow behavior) and **use of that directive on JSON Editor type-picker dropdowns**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 462021ba632171c9dfda20d1a1e836915a46b522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->