### PR TITLE
fix: dropdown CDK should scroll in nested containers 

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-dropdown`): `ngxDropdownPortal` should ignore parents that do not have dimension. 
+
 ## 52.2.0 (2026-07-30)
 
 - Feature (`ngx-dropdown`): Added opt-in `ngxDropdownPortal` directive to render dropdown menus via Angular CDK Overlay, avoiding clipping inside overflow containers. Supports `portalOffsetX`, `portalOffsetY`, `portalPanelClass`, and `portalFollowScroll` (default `true`). Closes when the trigger scrolls fully out of view. Global portal styles are included in the library CSS bundle.

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Fix (`ngx-dropdown`): `ngxDropdownPortal` should ignore parents that do not have dimension. 
+- Fix (`ngx-dropdown`): `ngxDropdownPortal` should ignore parents that do not have dimension.
 
 ## 52.2.0 (2026-07-30)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-portal.directive.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/dropdown/dropdown-portal.directive.ts
@@ -171,7 +171,12 @@ export class DropdownPortalDirective implements DoCheck, OnDestroy {
         bottom: window.innerHeight,
         right: window.innerWidth
       },
-      ...this.getScrollParents(this.elementRef.nativeElement).map(parent => parent.getBoundingClientRect())
+      // A scrollable ancestor with a collapsed box clips nothing, so it cannot
+      // hide the trigger. Hosts commonly give `body` a scrollbar style while
+      // laying their content out with fixed positioning, which collapses it.
+      ...this.getScrollParents(this.elementRef.nativeElement)
+        .filter(parent => parent.clientWidth > 0 && parent.clientHeight > 0)
+        .map(parent => parent.getBoundingClientRect())
     ];
 
     return boundsList.some(bounds => {


### PR DESCRIPTION
## Summary

Fixed an issue when the dropdown is nested within a container that has no dimension, it can't find the scroll container and then enable scrolling inline with the scroll container.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to dropdown portal visibility logic with no auth, data, or API surface impact.
> 
> **Overview**
> **Fixes `ngxDropdownPortal` closing or failing to track scroll** when the trigger sits inside a scrollable ancestor that has no layout box (e.g. `body` styled for scrollbars while the app uses fixed positioning).
> 
> In `isOriginFullyHidden`, scroll parents are now **filtered to those with `clientWidth` and `clientHeight` greater than zero** before their bounds are used. Collapsed scroll containers no longer count as clipping regions, so the trigger is not treated as off-screen and nested scroll listeners/repositioning behave as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfad092d4e4196977e97bb4717eff60fe30240a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->