### PR TITLE
(fix): Firefox 153+ black scrollbar gutters

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`scrollbars`): Firefox 153+ partially honors `::-webkit-scrollbar` with non-zero width/height but does not style thumbs/tracks, which produced black scrollbar rectangles under `.ngx-scroll *`. Keep Chromium/Safari webkit styling; under Firefox apply standard `scrollbar-width` / `scrollbar-color` and reset webkit sizing. (SPT-67000)
+
 ## 52.2.0 (2026-07-30)
 
 - Feature (`ngx-dropdown`): Added opt-in `ngxDropdownPortal` directive to render dropdown menus via Angular CDK Overlay, avoiding clipping inside overflow containers. Supports `portalOffsetX`, `portalOffsetY`, `portalPanelClass`, and `portalFollowScroll` (default `true`). Closes when the trigger scrolls fully out of view. Global portal styles are included in the library CSS bundle.

--- a/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.directive.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/tooltip/tooltip.directive.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 
 import { ToolTipFixtureComponent } from './fixtures/tooltip.fixture';
 import { TooltipModule } from './tooltip.module';
@@ -138,15 +138,15 @@ describe('TooltipDirective', () => {
       vi.restoreAllMocks();
     });
 
-    it('should show tooltip', async () => {
+    it('should show tooltip', fakeAsync(() => {
       const spy = vi.spyOn(directive.show, 'emit');
       directive.showTooltip(true);
 
-      await new Promise<void>(resolve => setTimeout(resolve, 0));
+      tick();
       expect(spy).toHaveBeenCalled();
-    });
+    }));
 
-    it('should add hide listeners to component if exists', async () => {
+    it('should add hide listeners to component if exists', fakeAsync(() => {
       const spy = vi.spyOn(directive, 'addHideListeners');
       vi.spyOn(service, 'create').mockReturnValue({
         instance: {
@@ -159,11 +159,11 @@ describe('TooltipDirective', () => {
       // Outer delay skipped; addHideListeners still runs after inner 10ms in showTooltip.
       directive.showTooltip(true);
 
-      await new Promise<void>(resolve => setTimeout(resolve, 20));
+      tick(10);
       expect(spy).toHaveBeenCalled();
-    });
+    }));
 
-    it('should add hide listeners to component if exists without tooltipCloseOnMouseLeave', async () => {
+    it('should add hide listeners to component if exists without tooltipCloseOnMouseLeave', fakeAsync(() => {
       const spy = vi.spyOn(directive, 'addHideListeners');
       vi.spyOn(service, 'create').mockReturnValue({
         instance: {
@@ -176,11 +176,11 @@ describe('TooltipDirective', () => {
       directive.tooltipCloseOnMouseLeave = false;
       directive.showTooltip(true);
 
-      await new Promise<void>(resolve => setTimeout(resolve, 20));
+      tick(10);
       expect(spy).toHaveBeenCalled();
-    });
+    }));
 
-    it('should add hide listeners to component if exists without tooltipCloseOnClickOutside', async () => {
+    it('should add hide listeners to component if exists without tooltipCloseOnClickOutside', fakeAsync(() => {
       const spy = vi.spyOn(directive, 'addHideListeners');
       vi.spyOn(service, 'create').mockReturnValue({
         instance: {
@@ -193,9 +193,9 @@ describe('TooltipDirective', () => {
       directive.tooltipCloseOnClickOutside = false;
       directive.showTooltip(true);
 
-      await new Promise<void>(resolve => setTimeout(resolve, 20));
+      tick(10);
       expect(spy).toHaveBeenCalled();
-    });
+    }));
 
     it('should not show tooltip when component exists', () => {
       const spy = vi.spyOn(directive.show, 'emit');
@@ -206,7 +206,7 @@ describe('TooltipDirective', () => {
   });
 
   describe('hideTooltip', () => {
-    it('should hide tooltip with timeout set', async () => {
+    it('should hide tooltip with timeout set', fakeAsync(() => {
       const spy = vi.spyOn(directive.hide, 'emit');
       vi.spyOn(service, 'create').mockReturnValue({
         instance: {
@@ -218,13 +218,13 @@ describe('TooltipDirective', () => {
 
       directive.showTooltip(true);
 
-      await new Promise<void>(resolve => setTimeout(resolve, 20));
+      tick(10);
 
       directive.hideTooltip();
 
-      await new Promise<void>(resolve => setTimeout(resolve, directive.tooltipHideTimeout));
+      tick(directive.tooltipHideTimeout);
 
       expect(spy).toHaveBeenCalled();
-    });
+    }));
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/styles/components/scrollbars.scss
+++ b/projects/swimlane/ngx-ui/src/lib/styles/components/scrollbars.scss
@@ -78,3 +78,42 @@
     background-color: rgba(colors.$color-blue-grey-550, 1);
   }
 }
+
+/*
+ * Firefox 153+: ::-webkit-scrollbar is recognized but not fully styled.
+ * Non-zero width/height creates unstyled (black) classic scrollbar gutters.
+ *
+ * Do not set scrollbar-width/color globally — Chrome 121+ disables
+ * ::-webkit-scrollbar (and thumb :hover) when those properties are set.
+ * Scope standard scrollbar props + webkit size reset to Firefox only.
+ */
+@supports (-moz-appearance: none) {
+  .ngx-scroll,
+  .ngx-scroll-overlay,
+  .ngx-scroll-muted,
+  .ngx-scroll * {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(colors.$color-blue-grey-550, 0.5) transparent;
+
+    &::-webkit-scrollbar {
+      width: auto;
+      height: auto;
+    }
+  }
+
+  .ngx-scroll-overlay {
+    scrollbar-width: none;
+
+    &:hover {
+      scrollbar-width: thin;
+    }
+  }
+
+  .ngx-scroll-muted {
+    scrollbar-color: rgba(colors.$color-blue-grey-550, 0.3) transparent;
+
+    &:hover {
+      scrollbar-color: rgba(colors.$color-blue-grey-550, 0.5) transparent;
+    }
+  }
+}

--- a/projects/swimlane/swim-ui/src/styles/scrollbars.ts
+++ b/projects/swimlane/swim-ui/src/styles/scrollbars.ts
@@ -13,18 +13,6 @@ import { css } from 'lit';
  * still apply.)
  */
 export const scrollbarStyles = css`
-  /* Only set standard scrollbar props in browsers that don't support -webkit-scrollbar.
-   * Chrome 121+ disables ::-webkit-scrollbar (and thumb :hover) when scrollbar-color/width are set. */
-  @supports not selector(::-webkit-scrollbar) {
-    .swim-scroll,
-    .swim-scroll-overlay,
-    .swim-scroll-muted,
-    .swim-scroll * {
-      scrollbar-width: thin;
-      scrollbar-color: rgb(80, 92, 117) transparent;
-    }
-  }
-
   /* Base: make element scrollable so scrollbar styling applies (matches overlay/muted) */
   .swim-scroll {
     overflow: auto;
@@ -129,5 +117,48 @@ export const scrollbarStyles = css`
 
   .swim-scroll-muted:hover::-webkit-scrollbar-thumb:hover {
     background-color: rgb(80, 92, 117);
+  }
+
+  /*
+   * Firefox 153+: ::-webkit-scrollbar is recognized but not fully styled.
+   * Non-zero width/height creates unstyled (black) classic scrollbar gutters.
+   *
+   * Do not set scrollbar-width/color globally — Chrome 121+ disables
+   * ::-webkit-scrollbar (and thumb :hover) when those properties are set.
+   * Scope standard scrollbar props + webkit size reset to Firefox only.
+   * Matches ngx-ui scrollbars.scss (SPT-67000).
+   */
+  @supports (-moz-appearance: none) {
+    .swim-scroll,
+    .swim-scroll-overlay,
+    .swim-scroll-muted,
+    .swim-scroll * {
+      scrollbar-width: thin;
+      scrollbar-color: rgba(80, 92, 117, 0.5) transparent;
+    }
+
+    .swim-scroll::-webkit-scrollbar,
+    .swim-scroll-overlay::-webkit-scrollbar,
+    .swim-scroll-muted::-webkit-scrollbar,
+    .swim-scroll *::-webkit-scrollbar {
+      width: auto;
+      height: auto;
+    }
+
+    .swim-scroll-overlay {
+      scrollbar-width: none;
+    }
+
+    .swim-scroll-overlay:hover {
+      scrollbar-width: thin;
+    }
+
+    .swim-scroll-muted {
+      scrollbar-color: rgba(80, 92, 117, 0.3) transparent;
+    }
+
+    .swim-scroll-muted:hover {
+      scrollbar-color: rgba(80, 92, 117, 0.5) transparent;
+    }
   }
 `;


### PR DESCRIPTION

<img width="1414" height="259" alt="image" src="https://github.com/user-attachments/assets/6c38b09d-8a9f-4953-aa6f-d9248872ccb1" />


## Summary

Firefox 153+ partially honors `::-webkit-scrollbar` with non-zero sizing but does not style thumbs/tracks, which produced black scrollbar rectangles under `.ngx-scroll *` / `.swim-scroll *`. Scope standard `scrollbar-width` / `scrollbar-color` and webkit size reset to Firefox only so Chromium/Safari keep webkit styling.

## Checklist

- ~~[] *Added unit tests~~ not needed only css change
- [x] *Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- ~~[ ] Updated the demo page~~ no change
- [x] Included screenshots of visual changes

_*required_

Made with [Cursor](https://cursor.com)