### PR TITLE
(release): 53.0.0 

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## HEAD (unreleased)
 
-- Enhancement: Added support for Angular 22
+## 53.0.1 (2026-08-10)
+
 - Breaking: Require Angular 22 (peers are now `22.x`); drop Angular 19/20/21. Uses Angular 22-only APIs such as `ChangeDetectionStrategy.Eager` and `$safeNavigationMigration`.
+- Fix (`scrollbars`): Firefox 153+ partially honors `::-webkit-scrollbar` with non-zero width/height but does not style thumbs/tracks, which produced black scrollbar rectangles under `.ngx-scroll *`. Keep Chromium/Safari webkit styling; under Firefox apply standard `scrollbar-width` / `scrollbar-color` and reset webkit sizing. (SPT-67000)
+
+## 53.0.0 (2026-07-28)
+
+- Enhancement: Added support for Angular 22
+- Breaking: Removing Angular 19 support (peers are now `20.x || 21.x || 22.x`)
 - Chore: Migrated ESLint to flat config (`eslint.config.js`) required by angular-eslint v22
 - Chore: CI/Volta pin updated to Node 24.18.0
-- Fix (`scrollbars`): Firefox 153+ partially honors `::-webkit-scrollbar` with non-zero width/height but does not style thumbs/tracks, which produced black scrollbar rectangles under `.ngx-scroll *`. Keep Chromium/Safari webkit styling; under Firefox apply standard `scrollbar-width` / `scrollbar-color` and reset webkit sizing. (SPT-67000)
 
 ## 52.2.1 (2026-07-31)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,17 +2,13 @@
 
 ## HEAD (unreleased)
 
-## 53.0.1 (2026-08-10)
-
-- Breaking: Require Angular 22 (peers are now `22.x`); drop Angular 19/20/21. Uses Angular 22-only APIs such as `ChangeDetectionStrategy.Eager` and `$safeNavigationMigration`.
-- Fix (`scrollbars`): Firefox 153+ partially honors `::-webkit-scrollbar` with non-zero width/height but does not style thumbs/tracks, which produced black scrollbar rectangles under `.ngx-scroll *`. Keep Chromium/Safari webkit styling; under Firefox apply standard `scrollbar-width` / `scrollbar-color` and reset webkit sizing. (SPT-67000)
-
 ## 53.0.0 (2026-07-28)
 
 - Enhancement: Added support for Angular 22
-- Breaking: Removing Angular 19 support (peers are now `20.x || 21.x || 22.x`)
+- Breaking: Require Angular 22 (peers are now `22.x`); drop Angular 19/20/21. Uses Angular 22-only APIs such as `ChangeDetectionStrategy.Eager` and `$safeNavigationMigration`.
 - Chore: Migrated ESLint to flat config (`eslint.config.js`) required by angular-eslint v22
 - Chore: CI/Volta pin updated to Node 24.18.0
+- Fix (`scrollbars`): Firefox 153+ partially honors `::-webkit-scrollbar` with non-zero width/height but does not style thumbs/tracks, which produced black scrollbar rectangles under `.ngx-scroll *`. Keep Chromium/Safari webkit styling; under Firefox apply standard `scrollbar-width` / `scrollbar-color` and reset webkit sizing. (SPT-67000)
 
 ## 52.2.1 (2026-07-31)
 

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "52.2.1",
+  "version": "53.0.1",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "53.0.1",
+  "version": "53.0.0",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },


### PR DESCRIPTION
## Summary

Replace me with a description of changes. Include screenshots where appropriate.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Publishing a major version with breaking Angular peer requirements affects all consumers; the PR diff itself is only version and changelog metadata.
> 
> **Overview**
> **Release 53.0.0** — bumps `@swimlane/ngx-ui` from `52.2.1` to `53.0.0` and moves the existing unreleased CHANGELOG bullets into a dated `53.0.0` section (HEAD unreleased is now empty).
> 
> What ships with this version (documented in CHANGELOG, not in the diff): **breaking** Angular 22-only peer dependencies (drops 19–21), Angular 22 APIs, ESLint flat config for angular-eslint v22, CI Node **24.18.0**, and a **Firefox 153+** scrollbar styling fix under `.ngx-scroll *` (SPT-67000).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2303bb698521da0ea40a2f3bd79c2260835dffcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->