### PR TITLE
fix(radiobutton): keep selection on re-click (select-only)

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-radiobutton`): Radios are select-only. Clicking an already selected radio toggled `checked` off, which visually cleared the radio while the radio group / form value stayed unchanged. Clicking a selected radio is now a no-op, matching native radio behaviour and the existing Space key handling. `RadioButtonComponent.toggle()` is deprecated.
+
 ## 53.0.0 (2026-07-28)
 
 - Enhancement: Added support for Angular 22

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "53.0.0",
+  "version": "53.0.1-beta.2",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },

--- a/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton-group.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton-group.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
@@ -62,5 +62,48 @@ describe('RadioButtonGroupComponent', () => {
         expect(component.radioButtonGroup.selected.value).toEqual(component.value as any);
       });
     });
+  });
+
+  describe('click', () => {
+    function clickRadio(index: number) {
+      const hosts: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('ngx-radiobutton'));
+      hosts[index].dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      tick();
+      fixture.detectChanges();
+    }
+
+    it('should keep the selected radio checked when it is clicked again', fakeAsync(() => {
+      const radios = component.radioButtonGroup._radios.toArray();
+      expect(radios[0].checked).toBe(true);
+
+      clickRadio(0);
+
+      expect(radios[0].checked).toBe(true);
+      expect(component.radioButtonGroup.value).toBe('one');
+      expect(component.value).toBe('one');
+    }));
+
+    it('should select a sibling and deselect the previous radio', fakeAsync(() => {
+      const radios = component.radioButtonGroup._radios.toArray();
+
+      clickRadio(1);
+
+      expect(radios[0].checked).toBe(false);
+      expect(radios[1].checked).toBe(true);
+      expect(component.radioButtonGroup.value).toBe('two');
+      expect(component.radioButtonGroup.selected).toBe(radios[1]);
+    }));
+
+    it('should not change selection when the group is disabled', fakeAsync(() => {
+      component.disabled$.next(true);
+      fixture.detectChanges();
+      const radios = component.radioButtonGroup._radios.toArray();
+
+      clickRadio(1);
+
+      expect(radios[0].checked).toBe(true);
+      expect(radios[1].checked).toBe(false);
+      expect(component.radioButtonGroup.value).toBe('one');
+    }));
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton.component.fixture.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton.component.fixture.ts
@@ -22,6 +22,8 @@ import { RadioButtonComponent } from './radiobutton.component';
       [checked]="checked$ | async"
       [disabled]="disabled$ | async"
     ></ngx-radiobutton>
+
+    <ngx-radiobutton #three tabindex="2" value="three" [disabled]="disabled$ | async"></ngx-radiobutton>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false
@@ -36,4 +38,7 @@ export class RadioButtonComponentFixture {
 
   @ViewChild('two', { static: false })
   readonly two: RadioButtonComponent;
+
+  @ViewChild('three', { static: false })
+  readonly three: RadioButtonComponent;
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton.component.spec.ts
@@ -58,4 +58,58 @@ describe('RadioButtonComponent', () => {
       expect(component.one.checked).toBe(true);
     });
   });
+
+  describe('onClick', () => {
+    function clickThree() {
+      const hosts: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('ngx-radiobutton'));
+      hosts[2].dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      fixture.detectChanges();
+    }
+
+    it('should check an unchecked radio', () => {
+      expect(component.three.checked).toBe(false);
+
+      clickThree();
+
+      expect(component.three.checked).toBe(true);
+    });
+
+    it('should stay checked when an already checked radio is clicked', () => {
+      component.three.checked = true;
+      fixture.detectChanges();
+
+      clickThree();
+
+      expect(component.three.checked).toBe(true);
+    });
+
+    it('should not emit change when an already checked radio is clicked', () => {
+      component.three.checked = true;
+      fixture.detectChanges();
+      const spy = vi.spyOn(component.three.change, 'emit');
+
+      clickThree();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should ignore clicks when disabled', () => {
+      component.disabled$.next(true);
+      fixture.detectChanges();
+
+      clickThree();
+
+      expect(component.three.checked).toBe(false);
+    });
+  });
+
+  describe('onSpace', () => {
+    it('should check an unchecked radio', () => {
+      expect(component.three.checked).toBe(false);
+
+      component.three.onSpace(new KeyboardEvent('keydown', { key: ' ', code: 'Space' }));
+
+      expect(component.three.checked).toBe(true);
+    });
+  });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/radiobutton/radiobutton.component.ts
@@ -42,7 +42,8 @@ export class RadioButtonComponent implements ControlValueAccessor {
   @HostListener('click', ['$event']) onClick(ev: Event) {
     ev.preventDefault();
     if (!this.disabled) {
-      this.toggle();
+      // Radios are select-only: clicking an already selected radio must not deselect it.
+      this.checked = true;
     }
   }
 
@@ -139,6 +140,10 @@ export class RadioButtonComponent implements ControlValueAccessor {
     this.checked = true;
   }
 
+  /**
+   * @deprecated Radios are select-only; toggling can leave the radio group value out of sync
+   * with the rendered state. Set `checked` to `true` or change the group value instead.
+   */
   toggle(): void {
     this.checked = !this.checked;
   }


### PR DESCRIPTION
## Summary

Radios are select-only. Clicking an already selected `ngx-radiobutton` used `toggle()`, which cleared `checked` visually while the radio group / form value stayed unchanged. `onClick` now sets `checked = true` (matching Space / native radio behavior), deprecates `toggle()`, and adds unit coverage for re-click, sibling select, and disabled clicks.


https://github.com/user-attachments/assets/685c161b-f60c-4ea3-aa71-4401513a4637


## Checklist

- [x] *Added unit tests
- [ ] *Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] ~~Updated the demo page~~
- [ ] ~~Included screenshots of visual changes~~

_*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI behavior fix in radiobutton click handling with solid test coverage. Soft deprecation of `toggle()` may affect rare programmatic callers, but the method still works.
> 
> **Overview**
> Fixes a desync where clicking an already selected `ngx-radiobutton` called `toggle()`, clearing the visual checked state while the radio group / form value stayed set.
> 
> `onClick` now sets `checked = true` (matching Space and native radios). `toggle()` remains but is **deprecated**. Adds unit coverage for re-click, sibling selection, disabled clicks, and Space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c341f723568f0d984ad30c43ab3ba5787571e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->