### PR TITLE
(release): 53.0.1

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD (unreleased)
 
+## 53.0.1 (2026-08-12)
+
+- Chore: Synced the `52.2.x` maintenance line into the Angular 22 (`53.x`) release line.
+
 ## 53.0.0 (2026-07-28)
 
 - Enhancement: Added support for Angular 22

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "53.0.0",
+  "version": "53.0.1",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },


### PR DESCRIPTION
## Summary

- Release `@swimlane/ngx-ui@53.0.1` for the Angular 22 (`53.x`) line.
- Syncs the `52.2.x` maintenance line into `53.x` so Angular 22 consumers pick up maintenance-line work without downgrading.
- Keeps `latest` on `53.x`; `release-52` remains on `52.2.1`.

## Checklist

- [x] \*Added unit tests
- [ ] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only metadata changes (version bump and changelog); no runtime or API code is modified in this PR.
> 
> **Overview**
> Releases **`53.0.1`** by bumping `@swimlane/ngx-ui` from `53.0.0` and adding a changelog entry noting that the `52.2.x` maintenance line was synced into the Angular 22 (`53.x`) release line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd690ee8a8d48bf3d16d19192c73194166f9d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->