### PR TITLE
(release): 53.2.0

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 53.2.0 (2026-08-21)
+
 - Feature (`ngx-list`): Added nested rows (`children` / `parentId`) with depth indent, host-owned multi-select (`selectedIds` / `onSelectionChange`, select-all + indeterminate), and `nestMode` (`stagger` | `aligned`).
 
 - Fix (`ngx-radiobutton`): Radios are select-only. Clicking an already selected radio toggled `checked` off, which visually cleared the radio while the radio group / form value stayed unchanged. Clicking a selected radio is now a no-op, matching native radio behaviour and the existing Space key handling. `RadioButtonComponent.toggle()` is deprecated.

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "53.0.1",
+  "version": "53.2.0",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },


### PR DESCRIPTION
## Summary

(release): 53.2.0 — nested selectable ngx-list rows and select-only ngx-radiobutton.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release metadata; no runtime or security-sensitive code changes.
> 
> **Overview**
> Cuts **@swimlane/ngx-ui 53.2.0** by bumping `package.json` from `53.0.1` and promoting the unreleased notes into a dated changelog section.
> 
> The release notes cover nested `ngx-list` rows/selection and the `ngx-radiobutton` select-only click fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a1fb16e7b7ac3fc770bd29c3b432591cd07e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->