### PR TITLE
fix: plus menu optional chaining check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 projects/swimlane/ngx-ui/src/lib/assets/icons/
 projects/swimlane/ngx-ui-testing/dist/
+projects/swimlane/swim-ui/dist/

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-plus-menu`): Added check for items to prevent error
+
 ## 53.2.0 (2026-08-21)
 
 - Feature (`ngx-list`): Added nested rows (`children` / `parentId`) with depth indent, host-owned multi-select (`selectedIds` / `onSelectionChange`, select-all + indeterminate), and `nestMode` (`stagger` | `aligned`).

--- a/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/plus-menu/plus-menu.component.ts
@@ -41,11 +41,11 @@ export class PlusMenuComponent implements OnInit, OnDestroy {
   @Output() toggleMenu = new EventEmitter<boolean>();
 
   get itemColor0() {
-    return this.items[0].color || this.menuColor;
+    return this.items[0]?.color || this.menuColor;
   }
 
   get itemColor1() {
-    return this.items[1].color || this.menuColor;
+    return this.items[1]?.color || this.menuColor;
   }
 
   get itemColor2() {


### PR DESCRIPTION
- fix: plus menu optional chaining check
- fix: ignore dist for prettier

## Summary
This fixes an issue where plus menu can cause an infinite loop erroring if one of the items is missing. Also addressed a local build issue caused by a missing ignore in the prettier config.

## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small null-safety and ignore-file changes; no auth, data, or API behavior changes.
> 
> **Overview**
> Prevents `ngx-plus-menu` from throwing when `items` has fewer than two entries. `itemColor0` and `itemColor1` now use optional chaining (same as `itemColor2`) and fall back to `menuColor`.
> 
> Also ignores `projects/swimlane/swim-ui/dist/` in `.prettierignore` so local dist output is not formatted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7fbaee37f6a4908a7eaf14304d45172391d7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->