### PR TITLE
(release): 53.2.1

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 53.2.1 (2026-08-25)
+
 - Fix (`ngx-list`): Stop passing an undeclared `row` input through `NgComponentOutlet`, which threw NG0303 under `errorOnUnknownProperties`.
 
 - Fix (`ngx-plus-menu`): Added check for items to prevent error

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "53.2.0",
+  "version": "53.2.1",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },


### PR DESCRIPTION
## Summary

Release 53.2.1: fix ngx-list NG0303 from an undeclared row input, and guard ngx-plus-menu when items are missing.
## Checklist

- [ ] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version and changelog); no source changes in this diff.
> 
> **Overview**
> **Patch release** that publishes `@swimlane/ngx-ui` **53.2.1** and records it in the changelog (2026-08-25).
> 
> The only file changes here are **`package.json`** (`53.2.0` → `53.2.1`) and a new **`53.2.1`** section under **`CHANGELOG.md`**, which documents two bugfixes already merged for this line: **`ngx-list`** no longer forwards an undeclared `row` input via `NgComponentOutlet` (avoids NG0303 when `errorOnUnknownProperties` is on), and **`ngx-plus-menu`** guards against missing/empty `items` to prevent runtime errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da182782a68e21868c47d480b8e723f45eb84f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->