### PR TITLE
Fix- treat virtual-scroll placeholder rows as undefined

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix (`ngx-list`): Nested flatten/sort no longer assume every dataSource slot is a row object. Virtual/paged lists keep unloaded indexes as `undefined` (length matches totalCount), so search results spanning more than one page no longer throw.
+
 ## 53.2.1 (2026-08-25)
 
 - Fix (`ngx-list`): Stop passing an undeclared `row` input through `NgComponentOutlet`, which threw NG0303 under `errorOnUnknownProperties`.

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-nest.utils.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-nest.utils.spec.ts
@@ -17,9 +17,36 @@ describe('list-nest.utils', () => {
       expect(listDataSourceNeedsFlatten([{ id: 1, children: ['a', 'b'] }])).toBe(false);
       expect(listDataSourceNeedsFlatten([{ id: 1, children: [1, 2] }])).toBe(false);
     });
+
+    it('ignores undefined placeholder rows used by virtual scrolling', () => {
+      expect(listDataSourceNeedsFlatten([undefined, { id: 1, name: 'a' }, undefined])).toBe(false);
+      expect(listDataSourceNeedsFlatten([undefined, { id: 1, children: [{ id: 2 }] }])).toBe(true);
+    });
   });
 
   describe('flattenListDataSource', () => {
+    it('keeps undefined placeholder rows in place for virtual scrolling', () => {
+      const rows = flattenListDataSource([undefined, { id: 'a', name: 'A' }, undefined, { id: 'b', name: 'B' }]);
+
+      expect(rows).toHaveLength(4);
+      expect(rows[0]).toBeUndefined();
+      expect(rows[2]).toBeUndefined();
+      expect(rows[1]).toEqual({
+        id: 'a',
+        name: 'A',
+        [LIST_ID_KEY]: 'a',
+        [LIST_PARENT_ID_KEY]: null,
+        [LIST_DEPTH_KEY]: 0
+      });
+      expect(rows[3]).toEqual({
+        id: 'b',
+        name: 'B',
+        [LIST_ID_KEY]: 'b',
+        [LIST_PARENT_ID_KEY]: null,
+        [LIST_DEPTH_KEY]: 0
+      });
+    });
+
     it('annotates plain flat rows with depth 0', () => {
       const rows = flattenListDataSource([
         { id: 'a', name: 'A' },
@@ -104,6 +131,17 @@ describe('list-nest.utils', () => {
       expect(rows.map(row => row[LIST_DEPTH_KEY])).toEqual([0, 1, 2, 0]);
     });
 
+    it('skips undefined placeholder rows when flattening parentId-linked data', () => {
+      const rows = flattenListDataSource([
+        undefined,
+        { id: 'c', name: 'Child', parentId: 'a' },
+        undefined,
+        { id: 'a', name: 'Root' }
+      ]);
+
+      expect(rows.map(row => row?.id)).toEqual(['a', 'c']);
+    });
+
     it('assigns unique fallback ids when nested rows omit id', () => {
       const rows = flattenListDataSource([
         {
@@ -165,6 +203,8 @@ describe('list-nest.utils', () => {
       expect(getListRowDepth(row)).toBe(2);
       expect(getListRowId(row)).toBe('x');
       expect(getListRowDepth({})).toBe(0);
+      expect(getListRowDepth(undefined)).toBe(0);
+      expect(getListRowId(undefined, 3)).toBe(3);
     });
   });
 });

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-nest.utils.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-nest.utils.ts
@@ -23,8 +23,21 @@ function nestedRowChildren(value: unknown): ListItemModel[] {
   return value.filter(isListRowObject);
 }
 
+function rowHasNestedChildren(row: unknown, childrenKey: string): boolean {
+  return isListRowObject(row) && nestedRowChildren(row[childrenKey]).length > 0;
+}
+
+function rowHasParentLink(row: unknown, parentIdKey: string): boolean {
+  if (!isListRowObject(row)) {
+    return false;
+  }
+
+  const parentId = row[parentIdKey];
+  return parentId !== undefined && parentId !== null && parentId !== '';
+}
+
 export function listDataSourceNeedsFlatten(
-  rows: Array<Record<string, unknown>> | null | undefined,
+  rows: Array<Record<string, unknown> | null | undefined> | null | undefined,
   options: FlattenListOptions = {}
 ): boolean {
   if (!rows?.length) {
@@ -33,40 +46,30 @@ export function listDataSourceNeedsFlatten(
 
   const { parentIdKey, childrenKey } = { ...DEFAULT_OPTIONS, ...options };
 
-  return rows.some(row => {
-    if (nestedRowChildren(row[childrenKey]).length > 0) {
-      return true;
-    }
-
-    const parentId = row[parentIdKey];
-    return parentId !== undefined && parentId !== null && parentId !== '';
-  });
+  return rows.some(row => rowHasNestedChildren(row, childrenKey) || rowHasParentLink(row, parentIdKey));
 }
 
 export function flattenListDataSource(
-  rows: Array<Record<string, unknown>> | null | undefined,
+  rows: Array<Record<string, unknown> | null | undefined> | null | undefined,
   options: FlattenListOptions = {}
-): Array<Record<string, unknown>> {
+): Array<Record<string, unknown> | undefined> {
   if (!rows?.length) {
     return [];
   }
 
   const opts = { ...DEFAULT_OPTIONS, ...options };
 
-  if (rows.some(row => nestedRowChildren(row[opts.childrenKey]).length > 0)) {
-    return flattenTreeRows(rows as ListItemModel[], opts, 0, null);
+  if (rows.some(row => rowHasNestedChildren(row, opts.childrenKey))) {
+    return flattenTreeRows(rows, opts, 0, null);
   }
 
-  if (
-    rows.some(row => {
-      const parentId = row[opts.parentIdKey];
-      return parentId !== undefined && parentId !== null && parentId !== '';
-    })
-  ) {
-    return flattenParentLinkedRows(rows as ListItemModel[], opts);
+  if (rows.some(row => rowHasParentLink(row, opts.parentIdKey))) {
+    return flattenParentLinkedRows(rows, opts);
   }
 
-  return rows.map(row => annotateRow(row, resolveRowId(row, opts.idKey, anonymousIdForRow), null, 0));
+  return rows.map(row =>
+    isListRowObject(row) ? annotateRow(row, resolveRowId(row, opts.idKey, anonymousIdForRow), null, 0) : undefined
+  );
 }
 
 /** Stable across re-flattens of the same source object so track-by-id survives sort/refresh. */
@@ -84,7 +87,7 @@ function anonymousIdForRow(row: Record<string, unknown>): string {
 }
 
 function flattenTreeRows(
-  rows: ListItemModel[],
+  rows: Array<Record<string, unknown> | null | undefined>,
   opts: Required<FlattenListOptions>,
   depth: number,
   parentId: ListRowId | null
@@ -114,11 +117,14 @@ function flattenTreeRows(
 }
 
 function flattenParentLinkedRows(
-  rows: ListItemModel[],
+  rows: Array<Record<string, unknown> | null | undefined>,
   opts: Required<FlattenListOptions>
 ): Array<Record<string, unknown>> {
   const rowIds = new Map<ListItemModel, ListRowId>();
   rows.forEach(row => {
+    if (!isListRowObject(row)) {
+      return;
+    }
     rowIds.set(row, resolveRowId(row, opts.idKey, anonymousIdForRow));
   });
 
@@ -126,6 +132,9 @@ function flattenParentLinkedRows(
   const ids = new Set(Array.from(rowIds.values(), id => String(id)));
 
   rows.forEach(row => {
+    if (!isListRowObject(row)) {
+      return;
+    }
     const parentId = row[opts.parentIdKey];
     const parentKey =
       parentId === undefined || parentId === null || parentId === '' || !ids.has(String(parentId))
@@ -158,6 +167,9 @@ function flattenParentLinkedRows(
 
   // Cycles with no true root never enter visit(''). Promote remaining rows as roots.
   rows.forEach(row => {
+    if (!isListRowObject(row)) {
+      return;
+    }
     const id = rowIds.get(row) as ListRowId;
     const idKey = String(id);
     if (visited.has(idKey)) {
@@ -186,15 +198,15 @@ function annotateRow(
 }
 
 export function resolveRowId(
-  row: Record<string, unknown>,
+  row: Record<string, unknown> | null | undefined,
   idKey: string,
   fallback: number | ((row: Record<string, unknown>) => ListRowId)
 ): ListRowId {
-  const value = row[idKey];
+  const value = row?.[idKey];
   if (typeof value === 'string' || typeof value === 'number') {
     return value;
   }
-  return typeof fallback === 'function' ? fallback(row) : fallback;
+  return typeof fallback === 'function' ? fallback(row ?? {}) : fallback;
 }
 
 export function getListRowDepth(row: Record<string, unknown> | null | undefined): number {

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-row/list-row.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-row/list-row.component.ts
@@ -41,7 +41,11 @@ export class ListRowComponent {
   @Input() selectionEnabled = false;
   @Input() selected = false;
   @Input() indeterminate = false;
-  @Input() onCheckedChange: (data: Record<string, unknown>, index: number, selected: boolean) => void;
+  @Input() onCheckedChange: (
+    data: Record<string, unknown> | null | undefined,
+    index: number,
+    selected: boolean
+  ) => void;
 
   columnComponent = ListColumnComponent;
 

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.spec.ts
@@ -88,6 +88,12 @@ describe('list-sort.utils', () => {
       sortListRows(rows, { prop: 'name', dir: 'asc' }, [header('name')]);
       expect(rows.map(r => r.name)).toEqual(['B', 'A']);
     });
+
+    it('should skip undefined placeholder rows', () => {
+      const rows = [undefined, { name: 'B' }, undefined, { name: 'A' }];
+      const sorted = sortListRows(rows, { prop: 'name', dir: 'asc' }, [header('name')]);
+      expect(sorted.map(r => r.name)).toEqual(['A', 'B']);
+    });
   });
 
   describe('parseListSortDate', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list-sort.utils.ts
@@ -87,21 +87,22 @@ export function getNextListSort(
 }
 
 export function sortListRows(
-  rows: Array<Record<string, unknown>>,
+  rows: Array<Record<string, unknown> | null | undefined>,
   sort: ListSortPropDir | null,
   headers: Iterable<ListHeaderComponent>
 ): Array<Record<string, unknown>> {
+  const definedRows = rows.filter((row): row is Record<string, unknown> => !!row);
   if (!sort?.prop) {
-    return [...rows];
+    return [...definedRows];
   }
 
   const header = Array.from(headers).find(item => item?.prop === sort.prop);
-  const isDateSort = !header.comparator && getListHeaderSortType(header ?? { prop: sort.prop }) === 'date';
-  const comparator = header.comparator ? header.comparator : defaultListSortComparator;
+  const isDateSort = !header?.comparator && getListHeaderSortType(header ?? { prop: sort.prop }) === 'date';
+  const comparator = header?.comparator ? header.comparator : defaultListSortComparator;
 
-  const parsedDates = isDateSort ? new Map(rows.map(row => [row, parseListSortDate(row[sort.prop])])) : null;
+  const parsedDates = isDateSort ? new Map(definedRows.map(row => [row, parseListSortDate(row[sort.prop])])) : null;
 
-  return [...rows].sort((rowA, rowB) => {
+  return [...definedRows].sort((rowA, rowB) => {
     let result: number;
     if (parsedDates) {
       const valueA = parsedDates.get(rowA);

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list.component.spec.ts
@@ -308,13 +308,13 @@ describe('ListComponent', () => {
       const header = createSortableHeader('name');
 
       component.onHeaderSort(header);
-      expect(component.displayDataSource.map(row => row.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+      expect(component.displayDataSource.map(row => row?.name)).toEqual(['Alice', 'Bob', 'Charlie']);
 
       component.onHeaderSort(header);
-      expect(component.displayDataSource.map(row => row.name)).toEqual(['Charlie', 'Bob', 'Alice']);
+      expect(component.displayDataSource.map(row => row?.name)).toEqual(['Charlie', 'Bob', 'Alice']);
 
       component.onHeaderSort(header);
-      expect(component.displayDataSource.map(row => row.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+      expect(component.displayDataSource.map(row => row?.name)).toEqual(['Alice', 'Bob', 'Charlie']);
     });
 
     it('should not reorder rows in external sorting mode', () => {
@@ -323,7 +323,7 @@ describe('ListComponent', () => {
 
       component.onHeaderSort(header);
 
-      expect(component.displayDataSource.map(row => row.name)).toEqual(['Charlie', 'Alice', 'Bob']);
+      expect(component.displayDataSource.map(row => row?.name)).toEqual(['Charlie', 'Alice', 'Bob']);
     });
 
     it('should respect pre-seeded sort input', () => {
@@ -343,7 +343,7 @@ describe('ListComponent', () => {
         }
       });
 
-      expect(component.displayDataSource.map(row => row.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+      expect(component.displayDataSource.map(row => row?.name)).toEqual(['Alice', 'Bob', 'Charlie']);
       expect(component.getSortDirection(createSortableHeader('name'))).toBe('asc');
     });
 
@@ -364,7 +364,7 @@ describe('ListComponent', () => {
         }
       });
 
-      expect(component.displayDataSource.map(row => row.name)).toEqual(['Amy', 'Zoe']);
+      expect(component.displayDataSource.map(row => row?.name)).toEqual(['Amy', 'Zoe']);
     });
 
     it('should reset scroll position after local sort', () => {
@@ -407,8 +407,28 @@ describe('ListComponent', () => {
         }
       });
 
-      expect(component.displayDataSource.map(row => row.name)).toEqual(['Root', 'Child']);
-      expect(component.displayDataSource.map(row => row['_listDepth'])).toEqual([0, 1]);
+      expect(component.displayDataSource.map(row => row?.name)).toEqual(['Root', 'Child']);
+      expect(component.displayDataSource.map(row => row?.['_listDepth'])).toEqual([0, 1]);
+    });
+
+    it('keeps undefined virtual-scroll placeholders without throwing', () => {
+      component.dataSource = [undefined, { id: 'a', name: 'A' }, undefined, { id: 'b', name: 'B' }];
+      component.selectable = true;
+      component.ngOnChanges({
+        dataSource: {
+          currentValue: component.dataSource,
+          previousValue: [],
+          firstChange: true,
+          isFirstChange: () => true
+        }
+      });
+
+      expect(component.displayDataSource).toHaveLength(4);
+      expect(component.displayDataSource[0]).toBeUndefined();
+      expect(component.displayDataSource[1]?.name).toBe('A');
+      expect(component.isRowSelectable(undefined)).toBe(false);
+      expect(component.isRowSelected(undefined, 0)).toBe(false);
+      expect(component.onRowCheckedChange(undefined, 0, true)).toBeUndefined();
     });
 
     it('ignores row changes that match the current selection state', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/list/list.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/list/list.component.ts
@@ -47,7 +47,7 @@ import { flattenListDataSource, getListRowId } from './list-nest.utils';
 })
 export class ListComponent implements AfterContentInit, AfterViewInit, OnChanges, OnDestroy {
   @Input() columnLayout: Partial<CSSStyleDeclaration>;
-  @Input() dataSource: Array<Record<string, unknown>> = [];
+  @Input() dataSource: Array<Record<string, unknown> | undefined> = [];
   @Input() externalSorting = false;
   @Input() sort: ListSortPropDir | null = null;
   @Input() height: number;
@@ -83,7 +83,7 @@ export class ListComponent implements AfterContentInit, AfterViewInit, OnChanges
     display: 'grid',
     gap: '1rem'
   };
-  displayDataSource: Array<Record<string, unknown>> = [];
+  displayDataSource: Array<Record<string, unknown> | undefined> = [];
   isNested = false;
   maxDepth = 0;
   hasScrollbar = false;
@@ -260,25 +260,28 @@ export class ListComponent implements AfterContentInit, AfterViewInit, OnChanges
     }
   }
 
-  isRowSelectable = (data: Record<string, unknown>): boolean => {
-    return this.selectable && data?.selectable !== false;
+  isRowSelectable = (data: Record<string, unknown> | null | undefined): boolean => {
+    return this.selectable && !!data && data.selectable !== false;
   };
 
-  trackRowBy = (index: number, data: Record<string, unknown>): ListRowId => {
+  trackRowBy = (index: number, data: Record<string, unknown> | null | undefined): ListRowId => {
     return getListRowId(data, index);
   };
 
-  isRowSelected = (data: Record<string, unknown>, index: number): boolean => {
-    return this.selectedIdSet.has(getListRowId(data, index));
+  isRowSelected = (data: Record<string, unknown> | null | undefined, index: number): boolean => {
+    return !!data && this.selectedIdSet.has(getListRowId(data, index));
   };
 
-  isRowIndeterminate = (data: Record<string, unknown>, index: number): boolean => {
+  isRowIndeterminate = (data: Record<string, unknown> | null | undefined, index: number): boolean => {
+    if (!data) {
+      return false;
+    }
     const id = getListRowId(data, index);
     return !this.selectedIdSet.has(id) && this.indeterminateIdSet.has(id);
   };
 
-  onRowCheckedChange = (data: Record<string, unknown>, index: number, selected: boolean): void => {
-    if (!this.isRowSelectable(data) || data?.disabled === true) {
+  onRowCheckedChange = (data: Record<string, unknown> | null | undefined, index: number, selected: boolean): void => {
+    if (!data || !this.isRowSelectable(data) || data.disabled === true) {
       return;
     }
 
@@ -342,32 +345,35 @@ export class ListComponent implements AfterContentInit, AfterViewInit, OnChanges
     }
 
     this.maxDepth = this.displayDataSource.reduce(
-      (deepest, row) => Math.max(deepest, (row[LIST_DEPTH_KEY] as number) ?? 0),
+      (deepest, row) => Math.max(deepest, (row?.[LIST_DEPTH_KEY] as number) ?? 0),
       0
     );
     this.isNested = this.maxDepth > 0;
 
     this.selectableIds = this.displayDataSource
       .map((row, index) => ({ row, id: getListRowId(row, index) }))
-      .filter(({ row }) => row?.selectable !== false && row?.disabled !== true)
+      .filter(({ row }) => !!row && row.selectable !== false && row.disabled !== true)
       .map(({ id }) => id);
 
     this.refreshSelectionState();
   }
 
-  private sortFlattenedRows(rows: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  private sortFlattenedRows(
+    rows: Array<Record<string, unknown> | undefined>
+  ): Array<Record<string, unknown> | undefined> {
     if (!this._sort) {
       return rows;
     }
 
-    const roots = rows.filter(row => (row[LIST_DEPTH_KEY] as number) === 0);
+    const definedRows = rows.filter((row): row is Record<string, unknown> => !!row);
+    const roots = definedRows.filter(row => (row[LIST_DEPTH_KEY] as number) === 0);
     if (!roots.length) {
-      return sortListRows(rows, this._sort, this.getHeaderList());
+      return sortListRows(definedRows, this._sort, this.getHeaderList());
     }
 
     // Sort roots only; keep relative child order under each root.
     const childrenByParent = new Map<string, Array<Record<string, unknown>>>();
-    rows.forEach(row => {
+    definedRows.forEach(row => {
       const depth = row[LIST_DEPTH_KEY] as number;
       if (!depth) {
         return;


### PR DESCRIPTION
## Summary

Paged/virtual ngx-list sources are sparse by design: length ≈ totalCount, unloaded indexes are undefined so CDK can size the viewport.

Nest flatten/sort assumed every slot was a row object (row[childrenKey], row[parentIdKey], annotate/sort on the full array) and crashed when search results spanned more than one page.

Flat lists now skip non-objects and keep holes at the same index. Nested walks skip holes. Selection does not treat placeholders as rows. Local sort no longer throws on undefined

## Checklist

- [x] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to ngx-ui list utilities and selection/sort edge cases for undefined rows; behavior for fully-defined data sources is unchanged aside from safer optional handling.
> 
> **Overview**
> **Fixes list handling when `dataSource` includes `undefined` entries used as virtual-scroll placeholders**, so flattening, sorting, and selection no longer throw or mis-treat those slots.
> 
> For **flat** data, `flattenListDataSource` now preserves `undefined` at the same indices while still annotating real rows. Nested **tree** and **parentId** flatten paths skip placeholders when building hierarchy; `listDataSourceNeedsFlatten` ignores them when detecting flat vs nested data. Row helpers (`getListRowDepth`, `getListRowId`, `resolveRowId`) and shared checks use `isListRowObject`-style guards via new `rowHasNestedChildren` / `rowHasParentLink` helpers.
> 
> **Sorting** filters to defined rows only (`sortListRows` and nested root sorting in `ListComponent`). **Selection** treats placeholders as non-selectable and no-ops checkbox changes. Types on `ListComponent`, `displayDataSource`, and row callbacks widen to `Record<string, unknown> | undefined`. Unit tests cover placeholders through flatten, sort, and component integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65feb13cada05a039ae7afb5f3c2bd8c521110fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->