### PR TITLE
(release): 53.2.2

### DIFF
--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ## HEAD (unreleased)
 
+## 53.2.2 (2026-09-01)
+
 - Fix (`ngx-list`): Nested flatten/sort no longer assume every dataSource slot is a row object. Virtual/paged lists keep unloaded indexes as `undefined` (length matches totalCount), so search results spanning more than one page no longer throw.
 
 ## 53.2.1 (2026-08-25)
 
 - Fix (`ngx-list`): Stop passing an undeclared `row` input through `NgComponentOutlet`, which threw NG0303 under `errorOnUnknownProperties`.
-
 - Fix (`ngx-plus-menu`): Added check for items to prevent error
 
 ## 53.2.0 (2026-08-21)
 
 - Feature (`ngx-list`): Added nested rows (`children` / `parentId`) with depth indent, host-owned multi-select (`selectedIds` / `onSelectionChange`, select-all + indeterminate), and `nestMode` (`stagger` | `aligned`).
-
 - Fix (`ngx-radiobutton`): Radios are select-only. Clicking an already selected radio toggled `checked` off, which visually cleared the radio while the radio group / form value stayed unchanged. Clicking a selected radio is now a no-op, matching native radio behaviour and the existing Space key handling. `RadioButtonComponent.toggle()` is deprecated.
 
 ## 53.0.1 (2026-08-12)

--- a/projects/swimlane/ngx-ui/package.json
+++ b/projects/swimlane/ngx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-ui",
-  "version": "53.2.1",
+  "version": "53.2.2",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },


### PR DESCRIPTION
## Summary


- Fix (`ngx-list`): Nested flatten/sort no longer assume every dataSource slot is a row object. Virtual/paged lists keep unloaded indexes as `undefined` (length matches totalCount), so search results spanning more than one page no longer throw.

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [ ] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version and changelog); no application code changes in this diff.
> 
> **Overview**
> **Release 53.2.2** — bumps `@swimlane/ngx-ui` from **53.2.1** to **53.2.2** and adds the dated **53.2.2 (2026-09-01)** section to `CHANGELOG.md`.
> 
> The release notes document a fix for **`ngx-list`**: nested flatten/sort no longer treat every `dataSource` index as a loaded row. Virtual/paged lists can leave unloaded slots as `undefined` while the array length still matches `totalCount`, which avoids runtime errors when search/filter results span multiple pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83c8762c7612f4d9ce311162effec07c68c1a031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->