### PR TITLE
feat(swim-select): filter icon, clear button, and custom empty slot (SPT-68046)

### DIFF
--- a/.cursor/skills/use-swim-ui/SKILL.md
+++ b/.cursor/skills/use-swim-ui/SKILL.md
@@ -86,7 +86,7 @@ Use `event.detail` for payloads where the component defines it.
 Common patterns:
 
 - **Default slot**: main content (e.g. `swim-card`, `swim-dialog`, `swim-drawer`, `swim-tab` body).
-- **Named slots**: `slot="header"`, `slot="footer"`, `slot="hint"`, `slot="prefix"`, `slot="suffix"`, `slot="content"` (tooltip), `slot="label"` (tab), `slot="avatar"`, `slot="title"`, `slot="subtitle"`.
+- **Named slots**: `slot="header"`, `slot="footer"`, `slot="hint"`, `slot="empty"` (select empty-state), `slot="prefix"`, `slot="suffix"`, `slot="content"` (tooltip), `slot="label"` (tab), `slot="avatar"`, `slot="title"`, `slot="subtitle"`.
 
 Use the component’s JSDoc `@slot` in `projects/swimlane/swim-ui/src/components/<name>/*.component.ts` for the exact list.
 

--- a/.cursor/skills/use-swim-ui/reference.md
+++ b/.cursor/skills/use-swim-ui/reference.md
@@ -72,10 +72,10 @@ Use this when you need exact property names, attribute names, events, and slots 
 
 ## swim-select
 
-**Properties:** `label`, `placeholder`, `hint`, `empty-placeholder`, `filter-placeholder`, `options` (array of {name, value, …}), `value` (single or array if multiple), `name`, `id`, `disabled`, `required`, `appearance`, `size`, `marginless`, `withHint`, `filterable`, `multiple`.  
-**Slots:** default (swim-option children), `hint`.  
-**Events:** `change`, `dropdown-open`, `dropdown-close`.  
-**Parts:** `select`, `dropdown`.  
+**Properties:** `label`, `placeholder`, `hint`, `empty-placeholder`, `filter-placeholder`, `filter-icon` (swim-icon name, default `search`; empty hides), `filter-empty-placeholder`, `options` (array of {name, value, …}), `value` (single or array if multiple), `name`, `id`, `disabled`, `required`, `appearance`, `size`, `marginless`, `withHint`, `filterable`, `multiple`.  
+**Slots:** default (swim-option children), `hint`, `empty` (custom empty-state when the dropdown has nothing to show; not used while `loading`).  
+**Events:** `change`, `filter-change`, `dropdown-open`, `dropdown-close`.  
+**Parts:** `select`, `dropdown`, `empty`.  
 **Options:** Use `<swim-option name="Label" value="val">` or `options` property.
 
 ---

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Feature (`swim-select`): Filter field now shows a default `search` icon (overridable via `filter-icon`, empty string hides it) and a clear button when the query is non-empty.
+- Feature (`swim-select`): Custom empty-state markup via `slot="empty"` (overrides `empty-placeholder` / `filter-empty-placeholder`; skipped while `loading`).
+
 ## 53.2.2 (2026-09-01)
 
 - Fix (`ngx-list`): Nested flatten/sort no longer assume every dataSource slot is a row object. Virtual/paged lists keep unloaded indexes as `undefined` (length matches totalCount), so search results spanning more than one page no longer throw.

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## HEAD (unreleased)
 
-- Feature (`swim-select`): Filter field now shows a default `search` icon (overridable via `filter-icon`, empty string hides it) and a clear button when the query is non-empty.
-- Feature (`swim-select`): Custom empty-state markup via `slot="empty"` (overrides `empty-placeholder` / `filter-empty-placeholder`; skipped while `loading`).
-
 ## 53.2.2 (2026-09-01)
 
 - Fix (`ngx-list`): Nested flatten/sort no longer assume every dataSource slot is a row object. Virtual/paged lists keep unloaded indexes as `undefined` (length matches totalCount), so search results spanning more than one page no longer throw.

--- a/projects/swimlane/swim-ui-testing/src/components/select/select.component.spec.ts
+++ b/projects/swimlane/swim-ui-testing/src/components/select/select.component.spec.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { fixture, removeAndFlush, assertAccessible, createFormWithControl, waitForUpdate } from '../../test-utils.js';
 
+const sampleOptions = [
+  { name: 'A', value: 'a' },
+  { name: 'B', value: 'b' }
+];
+
+async function openDropdown(el: HTMLElement) {
+  const trigger = el.shadowRoot?.querySelector('[part="select"]') as HTMLElement;
+  trigger.click();
+  await waitForUpdate(el);
+}
+
 import '../../../../swim-ui/src/components/select/index.js';
 
 describe('swim-select', () => {
@@ -77,6 +88,16 @@ describe('swim-select', () => {
     expect(el.filterable).toBe(true);
   });
 
+  it('defaults filterIcon to search', async () => {
+    const el = await fixture<HTMLElement & { filterIcon: string }>('swim-select', {});
+    expect(el.filterIcon).toBe('search');
+  });
+
+  it('accepts filterIcon property', async () => {
+    const el = await fixture<HTMLElement & { filterIcon: string }>('swim-select', { filterIcon: 'globe' });
+    expect(el.filterIcon).toBe('globe');
+  });
+
   it('accepts multiple property', async () => {
     const el = await fixture<HTMLElement & { multiple: boolean }>('swim-select', { multiple: true });
     expect(el.multiple).toBe(true);
@@ -90,6 +111,108 @@ describe('swim-select', () => {
   it('has css part select', async () => {
     const el = await fixture<HTMLElement>('swim-select', {});
     expect(el.shadowRoot?.querySelector('[part="select"]')).toBeTruthy();
+  });
+
+  describe('filter field', () => {
+    it('shows the default search icon when opened', async () => {
+      const el = await fixture<HTMLElement & { options: { name: string; value: string }[] }>('swim-select', {
+        options: sampleOptions
+      });
+      await openDropdown(el);
+      const icon = el.shadowRoot?.querySelector('.select-filter-icon') as HTMLElement & { fontIcon: string };
+      expect(icon).toBeTruthy();
+      expect(icon.fontIcon).toBe('search');
+    });
+
+    it('renders a custom filter-icon name', async () => {
+      const el = await fixture<HTMLElement & { filterIcon: string; options: { name: string; value: string }[] }>(
+        'swim-select',
+        { filterIcon: 'globe', options: sampleOptions }
+      );
+      await openDropdown(el);
+      const icon = el.shadowRoot?.querySelector('.select-filter-icon') as HTMLElement & { fontIcon: string };
+      expect(icon.fontIcon).toBe('globe');
+    });
+
+    it('hides the filter icon when filterIcon is empty', async () => {
+      const el = await fixture<HTMLElement & { filterIcon: string; options: { name: string; value: string }[] }>(
+        'swim-select',
+        { filterIcon: '', options: sampleOptions }
+      );
+      await openDropdown(el);
+      expect(el.shadowRoot?.querySelector('.select-filter-icon')).toBeFalsy();
+      expect(el.shadowRoot?.querySelector('.select-filter--has-icon')).toBeFalsy();
+    });
+
+    it('shows a clear button after typing in the filter and clears on click', async () => {
+      const el = await fixture<HTMLElement & { options: { name: string; value: string }[] }>('swim-select', {
+        options: sampleOptions
+      });
+      await openDropdown(el);
+      const input = el.shadowRoot?.querySelector('.select-filter-input') as HTMLInputElement;
+      expect(el.shadowRoot?.querySelector('.select-filter-clear')).toBeFalsy();
+
+      input.value = 'A';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await waitForUpdate(el);
+
+      const clear = el.shadowRoot?.querySelector('.select-filter-clear') as HTMLButtonElement;
+      expect(clear).toBeTruthy();
+      clear.click();
+      await waitForUpdate(el);
+
+      const after = el.shadowRoot?.querySelector('.select-filter-input') as HTMLInputElement;
+      expect(after.value).toBe('');
+      expect(el.shadowRoot?.querySelector('.select-filter-clear')).toBeFalsy();
+    });
+  });
+
+  describe('empty state slot', () => {
+    async function selectWithEmptySlot(props: Record<string, unknown> = {}) {
+      const el = document.createElement('swim-select') as HTMLElement & Record<string, unknown>;
+      for (const [key, value] of Object.entries(props)) {
+        el[key] = value;
+      }
+      const custom = document.createElement('div');
+      custom.slot = 'empty';
+      custom.textContent = 'No tools available';
+      el.appendChild(custom);
+      document.body.appendChild(el);
+      await waitForUpdate(el);
+      return el;
+    }
+
+    it('renders string empty-placeholder when no slot is provided', async () => {
+      const el = await fixture<HTMLElement & { options: unknown[]; emptyPlaceholder: string }>('swim-select', {
+        options: [],
+        emptyPlaceholder: 'No options available'
+      });
+      await openDropdown(el);
+      const empty = el.shadowRoot?.querySelector('.select-empty');
+      expect(empty?.textContent).toContain('No options available');
+      expect(el.shadowRoot?.querySelector('slot[name="empty"]')).toBeFalsy();
+    });
+
+    it('renders slot="empty" instead of the string placeholder', async () => {
+      const el = await selectWithEmptySlot({ options: [] });
+      await openDropdown(el);
+
+      expect(el.shadowRoot?.querySelector('slot[name="empty"]')).toBeTruthy();
+      expect(el.shadowRoot?.querySelector('.select-empty--custom')).toBeTruthy();
+      expect(el.shadowRoot?.querySelector('[part="empty"]')).toBeTruthy();
+    });
+
+    it('keeps the searching placeholder while loading even with an empty slot', async () => {
+      const el = await selectWithEmptySlot({
+        options: [],
+        loading: true,
+        filterSearchingPlaceholder: 'Searching…'
+      });
+      await openDropdown(el);
+
+      expect(el.shadowRoot?.querySelector('slot[name="empty"]')).toBeFalsy();
+      expect(el.shadowRoot?.querySelector('.select-empty')?.textContent).toContain('Searching');
+    });
   });
 
   describe('dynamic property changes', () => {

--- a/projects/swimlane/swim-ui-testing/src/components/select/select.component.spec.ts
+++ b/projects/swimlane/swim-ui-testing/src/components/select/select.component.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { fixture, removeAndFlush, assertAccessible, createFormWithControl, waitForUpdate } from '../../test-utils.js';
+import '../../../../swim-ui/src/components/select/index.js';
 
 const sampleOptions = [
   { name: 'A', value: 'a' },
@@ -11,8 +12,6 @@ async function openDropdown(el: HTMLElement) {
   trigger.click();
   await waitForUpdate(el);
 }
-
-import '../../../../swim-ui/src/components/select/index.js';
 
 describe('swim-select', () => {
   it('renders without throwing', async () => {

--- a/projects/swimlane/swim-ui/CHANGELOG.md
+++ b/projects/swimlane/swim-ui/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## HEAD (unreleased)
+
+- Feature (`swim-select`): Filter field now shows a default `search` icon (overridable via `filter-icon`, empty string hides it) and a clear button when the query is non-empty.
+- Feature (`swim-select`): Custom empty-state markup via `slot="empty"` (overrides `empty-placeholder` / `filter-empty-placeholder`; skipped while `loading`).

--- a/projects/swimlane/swim-ui/demo/index.html
+++ b/projects/swimlane/swim-ui/demo/index.html
@@ -63,27 +63,43 @@
         /* Typography – align with swim-ui global and typography/font */
         --font-family: 'Source Sans Pro', 'Open Sans', Arial, sans-serif;
         --font-size-base: 16px;
+        --font-size-xxs: 0.625rem;
         --font-size-xs: 0.75rem;
-        --font-size-s: 0.8125rem;
+        --font-size-s: 0.875rem;
         --font-size-m: 1rem;
+        --font-size-l: 1.125rem;
         --font-size-xl: 1.25rem;
+        --font-size-2xl: 1.5rem;
+        --font-size-3xl: 1.75rem;
+        --font-size-4xl: 2rem;
+        --font-size-5xl: 2.25rem;
+        --font-size-6xl: 3rem;
         --font-weight-bold: 700;
         --font-weight-semibold: 600;
         --font-line-height: 1.4;
         --font-line-height-400: 40px;
 
-        --spacing-0: 0;
+        --spacing-0: 0px;
         --spacing-2: 2px;
         --spacing-4: 4px;
+        --spacing-6: 6px;
         --spacing-8: 8px;
         --spacing-10: 10px;
+        --spacing-12: 12px;
+        --spacing-14: 14px;
         --spacing-16: 16px;
+        --spacing-18: 18px;
         --spacing-20: 20px;
         --spacing-24: 24px;
+        --spacing-30: 30px;
+        --spacing-36: 36px;
+        --spacing-40: 40px;
+        --spacing-48: 48px;
 
-        --radius-0: 0;
+        --radius-0: 0px;
         --radius-2: 2px;
         --radius-4: 4px;
+        --radius-6: 6px;
         --radius-8: 8px;
 
         --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.3);
@@ -302,7 +318,9 @@
 
       /* No leading gap or rule when section content loads (all sections consistent) */
       #page-sections > hr:first-child,
-      #page-sections > .section-divider:first-child {
+      #page-sections > .section-divider:first-child,
+      #page-sections > div:first-child > hr:first-child,
+      #page-sections > div:first-child > .section-divider:first-child {
         display: none;
       }
       #page-sections > *:first-child {

--- a/projects/swimlane/swim-ui/demo/public/sections/button-group.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/button-group.css
@@ -1,0 +1,24 @@
+.button-group-page {
+  .muted {
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-16);
+  }
+
+  .mb-sm {
+    margin-bottom: var(--spacing-8);
+  }
+
+  .stack-lg {
+    flex-direction: column;
+    gap: var(--spacing-24);
+  }
+
+  .grid-wide {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/button-group.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/button-group.html
@@ -1,16 +1,17 @@
+<div class="button-group-page">
 <hr class="section-divider" />
 
 <!-- Button Group (mirrors ngx-ui button-group-page) -->
 <h1 id="button-group" class="page-title">Button Group</h1>
 <p class="subtitle">Group buttons with shared styling, orientation, and variant (contained or text).</p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/button-group.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/button-group.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Color variants (button-group-style)">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       All button group color styles: default (grey) and primary (blue).
     </p>
-    <div class="demo-grid" style="grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))">
+    <div class="demo-grid grid-wide">
       <div class="demo-item">
         <div class="demo-label">Default (horizontal)</div>
         <swim-button-group>
@@ -63,10 +64,10 @@
 
 <section class="section">
   <swim-section section-title="Variants (contained vs text)">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       The <code>variant</code> attribute: contained (solid buttons) or text (link-style with dividers).
     </p>
-    <div class="demo-grid" style="grid-template-columns: repeat(auto-fill, minmax(280px, 1fr))">
+    <div class="demo-grid grid-wide">
       <div class="demo-item">
         <div class="demo-label">Contained (default, horizontal)</div>
         <swim-button-group variant="contained">
@@ -117,9 +118,9 @@
 
 <section class="section">
   <swim-section section-title="Basic Button Group">
-    <div class="demo-row" style="flex-direction: column; gap: 1.5rem">
+    <div class="demo-row stack-lg">
       <div>
-        <div class="demo-label" style="margin-bottom: 0.5rem">Horizontal default</div>
+        <div class="demo-label mb-sm">Horizontal default</div>
         <swim-button-group>
           <swim-button type="button">Default</swim-button>
           <swim-button type="button">Default</swim-button>
@@ -127,7 +128,7 @@
         </swim-button-group>
       </div>
       <div>
-        <div class="demo-label" style="margin-bottom: 0.5rem">Horizontal primary</div>
+        <div class="demo-label mb-sm">Horizontal primary</div>
         <swim-button-group button-group-style="primary">
           <swim-button type="button">Primary</swim-button>
           <swim-button type="button">Primary</swim-button>
@@ -135,7 +136,7 @@
         </swim-button-group>
       </div>
       <div>
-        <div class="demo-label" style="margin-bottom: 0.5rem">Vertical primary</div>
+        <div class="demo-label mb-sm">Vertical primary</div>
         <swim-button-group button-group-style="primary" orientation="vertical">
           <swim-button type="button">Primary</swim-button>
           <swim-button type="button">Primary</swim-button>
@@ -177,7 +178,7 @@
 
 <section class="section">
   <swim-section section-title="Button Group Usage">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Import and use the button group component in your application:
     </p>
     <pre class="demo-pre"
@@ -212,3 +213,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/button-toggle.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/button-toggle.css
@@ -1,0 +1,10 @@
+.button-toggle-page {
+  .api-tag-gap {
+    margin-top: var(--spacing-20);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/button-toggle.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/button-toggle.html
@@ -1,3 +1,4 @@
+<div class="button-toggle-page">
 <hr class="section-divider" />
 
 <!-- Button Toggle (mirrors ngx-ui button-toggle-page) -->
@@ -6,7 +7,7 @@
   Single-selection toggle group. Use <code>swim-button-toggle-group</code> with
   <code>swim-button-toggle</code> children; value tracks the selected toggle.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/button-toggle.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/button-toggle.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Basic">
@@ -103,7 +104,7 @@
           </tbody>
         </table>
       </div>
-      <div style="margin-top:1.25rem"><span class="api-tag-name">&lt;swim-button-toggle&gt;</span></div>
+      <div class="api-tag-gap"><span class="api-tag-name">&lt;swim-button-toggle&gt;</span></div>
       <h4 class="api-heading">Child Properties</h4>
       <div class="api-table-wrap">
         <table class="api-table">
@@ -118,3 +119,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/buttons.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/buttons.css
@@ -1,0 +1,88 @@
+.buttons-page {
+  .muted-tight {
+    color: var(--grey-300);
+    margin: var(--spacing-0) var(--spacing-0) var(--spacing-12);
+  }
+
+  .muted {
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-16);
+  }
+
+  .code-caption {
+    color: var(--grey-400);
+    margin: var(--spacing-12) var(--spacing-0) var(--spacing-4);
+    font-size: var(--font-size-s);
+  }
+
+  .code-ref {
+    color: var(--grey-400);
+    margin-top: var(--spacing-20);
+    margin-bottom: var(--spacing-6);
+    font-size: var(--font-size-s);
+  }
+
+  .host-pill {
+    --swim-button-padding: 0.5em 1.5em;
+    --swim-button-outline-color: var(--orange-400);
+  }
+
+  .host-dense {
+    --swim-button-padding: 0.4em;
+    --swim-button-border-width: 2px;
+    --swim-button-border-color: var(--green-400);
+    --swim-button-hover-border-color: var(--green-500);
+    --swim-button-color: var(--green-400);
+    --swim-button-hover-color: var(--green-500);
+    --swim-button-background: var(--grey-800);
+    --swim-button-hover-background: var(--grey-750);
+  }
+
+  .host-gradient {
+    --swim-button-padding: 0.65em 1.1em;
+    --swim-button-background: linear-gradient(120deg, var(--purple-500), var(--blue-500));
+    --swim-button-hover-background: linear-gradient(120deg, var(--purple-600), var(--blue-600));
+    --swim-button-border-width: 2px;
+    --swim-button-border-style: solid;
+    --swim-button-border-color: rgba(255, 255, 255, 0.35);
+    --swim-button-hover-border-color: rgba(255, 255, 255, 0.55);
+    --swim-button-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
+  }
+
+  .icon-row-wrap {
+    align-items: center;
+    gap: var(--spacing-12);
+    flex-wrap: wrap;
+  }
+
+  .icon-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+  }
+
+  .icon-row-mb {
+    align-items: center;
+    gap: var(--spacing-12);
+    flex-wrap: wrap;
+    margin-bottom: var(--spacing-16);
+  }
+
+  .hint {
+    color: var(--grey-400);
+    margin-bottom: var(--spacing-8);
+    font-size: var(--font-size-s);
+  }
+
+  .icon-row {
+    align-items: center;
+    gap: var(--spacing-12);
+    flex-wrap: wrap;
+    margin-bottom: var(--spacing-12);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/buttons.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/buttons.html
@@ -1,3 +1,4 @@
+<div class="buttons-page">
 <hr class="section-divider" />
 <h1 id="buttons" class="page-title">Buttons</h1>
 <p class="subtitle">
@@ -5,7 +6,7 @@
   <code>&lt;swim-icon&gt;</code> (leading, trailing, stacked, icon-only), host styling via <code>--swim-button-*</code> CSS
   variables, and states (active, in-progress, success, fail, disabled). Supports promise-based loading state.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/button.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/button.js';</code></p>
 
 <!-- Button variants (mirrors ngx-ui buttons-page) -->
 <section class="section">
@@ -64,21 +65,21 @@
 <!-- Buttons with text + swim-icons (mirrors ngx-ui "Buttons with Icons") -->
 <section class="section">
   <swim-section section-title="Buttons with swim-icons">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Combine label text with <code>&lt;swim-icon font-icon="…"&gt;</code> in the default slot. A short
       <code>inline-flex</code> wrapper with <code>gap</code> matches ngx-ui spacing (<code>has-text</code> /
       <code>has-text-left</code> on <code>ngx-icon</code>). Stacked icons use a JSON array on
       <code>font-icon</code> (same as the Icons demo).
     </p>
-    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.75rem">
+    <div class="demo-row icon-row">
       <swim-button variant="primary">
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <swim-icon font-icon="plus"></swim-icon>
           <span>Add</span>
         </span>
       </swim-button>
       <swim-button variant="primary">
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <span>Next</span>
           <swim-icon font-icon="chevron-bold-right"></swim-icon>
         </span>
@@ -87,15 +88,15 @@
         <swim-icon font-icon="arrow-bold-down"></swim-icon>
       </swim-button>
     </div>
-    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.75rem">
+    <div class="demo-row icon-row">
       <swim-button variant="bordered">
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <swim-icon font-icon="plus"></swim-icon>
           <span>Add</span>
         </span>
       </swim-button>
       <swim-button variant="bordered">
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <span>Next</span>
           <swim-icon font-icon="chevron-bold-right"></swim-icon>
         </span>
@@ -104,15 +105,15 @@
         <swim-icon font-icon="arrow-bold-down"></swim-icon>
       </swim-button>
     </div>
-    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.75rem">
+    <div class="demo-row icon-row">
       <swim-button variant="link">
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <swim-icon font-icon="plus"></swim-icon>
           <span>Link</span>
         </span>
       </swim-button>
       <swim-button variant="link">
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <span>Link</span>
           <swim-icon font-icon="chevron-bold-right"></swim-icon>
         </span>
@@ -121,15 +122,15 @@
         <swim-icon font-icon="arrow-bold-down"></swim-icon>
       </swim-button>
     </div>
-    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1rem">
+    <div class="demo-row icon-row-mb">
       <swim-button variant="primary" disabled>
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <swim-icon font-icon="plus"></swim-icon>
           <span>Add</span>
         </span>
       </swim-button>
       <swim-button variant="bordered" disabled>
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <span>Next</span>
           <swim-icon font-icon="chevron-bold-right"></swim-icon>
         </span>
@@ -138,12 +139,12 @@
         <swim-icon font-icon="arrow-bold-down"></swim-icon>
       </swim-button>
     </div>
-    <p style="color: var(--grey-400); margin-bottom: 0.5rem; font-size: 0.875rem">
+    <p class="hint">
       <strong>Stacked font icons</strong> — badge-style overlay (see Icons page for more stacks):
     </p>
-    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1rem">
+    <div class="demo-row icon-row-mb">
       <swim-button variant="primary">
-        <span style="display: inline-flex; align-items: center; gap: 0.35em">
+        <span class="icon-label">
           <swim-icon font-icon='["field-users", "circle-filled :text-red :icon-fx-badge"]'></swim-icon>
           <span>Assignees</span>
         </span>
@@ -184,11 +185,11 @@
 <!-- Icon-only buttons -->
 <section class="section">
   <swim-section section-title="Icon-only buttons">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Put a <code>&lt;swim-icon&gt;</code> in the default slot. Always set <code>aria-label</code> (or <code>title</code>) so the
       control has an accessible name when there is no visible text.
     </p>
-    <div class="demo-row" style="align-items: center; gap: 0.75rem; flex-wrap: wrap">
+    <div class="demo-row icon-row-wrap">
       <swim-button variant="default" aria-label="Add">
         <swim-icon font-icon="plus"></swim-icon>
       </swim-button>
@@ -214,7 +215,7 @@
         <swim-icon font-icon="cloud-upload"></swim-icon>
       </swim-button>
     </div>
-    <p style="color: var(--grey-400); margin-top: 1.25rem; margin-bottom: 0.35rem; font-size: 0.875rem">
+    <p class="code-ref">
       <strong>Code reference</strong> — import the icon entry when you use <code>&lt;swim-icon&gt;</code> (CDN or package path may differ).
     </p>
     <pre class="demo-pre"
@@ -253,66 +254,34 @@
 <!-- Host styling: CSS custom properties -->
 <section class="section">
   <swim-section section-title="Host styling (CSS custom properties)">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Set <code>--swim-button-*</code> on <code>&lt;swim-button&gt;</code> (or an ancestor). They override every
       <code>variant</code>, including hover fallbacks, unless you rely on the built-in token defaults.
     </p>
     <div class="demo-grid">
       <div class="demo-item">
         <div class="demo-label">Gradient + border + shadow</div>
-        <swim-button
-          variant="primary"
-          aria-label="Gradient action"
-          style="
-            --swim-button-padding: 0.65em 1.1em;
-            --swim-button-background: linear-gradient(120deg, var(--purple-500), var(--blue-500));
-            --swim-button-hover-background: linear-gradient(120deg, var(--purple-600), var(--blue-600));
-            --swim-button-border-width: 2px;
-            --swim-button-border-style: solid;
-            --swim-button-border-color: rgba(255, 255, 255, 0.35);
-            --swim-button-hover-border-color: rgba(255, 255, 255, 0.55);
-            --swim-button-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
-          "
-        >
+        <swim-button class="host-gradient" variant="primary" aria-label="Gradient action">
           Gradient
         </swim-button>
       </div>
       <div class="demo-item">
         <div class="demo-label">Dense icon-only (padding, border, surface)</div>
-        <swim-button
-          variant="bordered"
-          aria-label="Filter"
-          style="
-            --swim-button-padding: 0.4em;
-            --swim-button-border-width: 2px;
-            --swim-button-border-color: var(--green-400);
-            --swim-button-hover-border-color: var(--green-500);
-            --swim-button-color: var(--green-400);
-            --swim-button-hover-color: var(--green-500);
-            --swim-button-background: var(--grey-800);
-            --swim-button-hover-background: var(--grey-750);
-          "
-        >
+        <swim-button class="host-dense" variant="bordered" aria-label="Filter">
           <swim-icon font-icon="filter"></swim-icon>
         </swim-button>
       </div>
       <div class="demo-item">
         <div class="demo-label">Pill-style primary (padding + outline)</div>
-        <swim-button
-          variant="primary"
-          style="
-            --swim-button-padding: 0.5em 1.5em;
-            --swim-button-outline-color: var(--orange-400);
-          "
-        >
+        <swim-button class="host-pill" variant="primary">
           Pill outline
         </swim-button>
       </div>
     </div>
-    <p style="color: var(--grey-400); margin-top: 1.25rem; margin-bottom: 0.35rem; font-size: 0.875rem">
+    <p class="code-ref">
       <strong>Code reference</strong> — same <code>style</code> values as the examples above (tokens such as <code>var(--purple-500)</code> come from swim-ui base styles on the host).
     </p>
-    <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Gradient + border + shadow</p>
+    <p class="code-caption">Gradient + border + shadow</p>
     <pre class="demo-pre"
     ><code>&lt;swim-button
   variant="primary"
@@ -328,7 +297,7 @@
     --swim-button-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
   "
 &gt;Gradient&lt;/swim-button&gt;</code></pre>
-    <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Dense icon-only (padding, border, surface)</p>
+    <p class="code-caption">Dense icon-only (padding, border, surface)</p>
     <pre class="demo-pre"
     ><code>&lt;swim-button
   variant="bordered"
@@ -346,7 +315,7 @@
 &gt;
   &lt;swim-icon font-icon="filter"&gt;&lt;/swim-icon&gt;
 &lt;/swim-button&gt;</code></pre>
-    <p style="color: var(--grey-400); margin: 0.75rem 0 0.25rem; font-size: 0.8125rem">Pill-style primary (padding + focus ring)</p>
+    <p class="code-caption">Pill-style primary (padding + focus ring)</p>
     <pre class="demo-pre"
     ><code>&lt;swim-button
   variant="primary"
@@ -361,7 +330,7 @@
 <!-- Button States Section -->
 <section class="section">
   <swim-section section-title="Button States">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Static state examples. Use <code>timeout="0"</code> on in-progress, success, and fail so they do not auto-return to active.
     </p>
     <div class="demo-grid">
@@ -410,7 +379,7 @@
 <!-- Button state from JS variable (cycles periodically) -->
 <section class="section">
   <swim-section section-title="Cycling state (JS variable)">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       The button below is bound to a variable that cycles through states every 2 seconds. Current state: <strong id="cyclingStateLabel">active</strong>.
     </p>
     <div class="demo-row">
@@ -432,7 +401,7 @@ setInterval(() =&gt; {
 <!-- Interactive Demo Section -->
 <section class="section">
   <swim-section section-title="Interactive Demo - Promise Handling">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       These buttons demonstrate automatic state management with promises.
     </p>
     <div class="demo-row">
@@ -485,7 +454,7 @@ setInterval(() =&gt; {
 <!-- Usage Section -->
 <section class="section">
   <swim-section section-title="Usage">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">Import and use the button component in your application:</p>
+    <p class="muted">Import and use the button component in your application:</p>
     <pre class="demo-pre"
     ><code>&lt;script type="module"&gt;
   import '@swimlane/swim-ui/button';
@@ -517,7 +486,7 @@ setInterval(() =&gt; {
         </table>
       </div>
       <h4 class="api-heading">CSS custom properties (host)</h4>
-      <p style="color: var(--grey-300); margin: 0 0 0.75rem">
+      <p class="muted-tight">
         Set on <code>&lt;swim-button&gt;</code> or an ancestor. Override built-in variant defaults (including hover).
       </p>
       <div class="api-table-wrap">
@@ -547,3 +516,4 @@ setInterval(() =&gt; {
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/card.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/card.css
@@ -1,0 +1,145 @@
+.card-page {
+  .demo-row--cards {
+    gap: var(--spacing-30);
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .demo-label--spaced {
+    margin-top: var(--spacing-16);
+  }
+
+  .card-demo-stats {
+    display: flex;
+    gap: var(--spacing-16);
+    width: 100%;
+    margin-bottom: var(--spacing-20);
+  }
+
+  .card-demo-stat-item {
+    flex: 1;
+    background: var(--grey-750);
+    border-radius: var(--radius-4);
+    padding: var(--spacing-12);
+    text-align: center;
+  }
+
+  .card-demo-stat-value {
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-semibold);
+    color: var(--grey-050);
+  }
+
+  .card-demo-stat-label {
+    font-size: var(--font-size-xxs);
+    color: var(--grey-350);
+    text-transform: uppercase;
+  }
+
+  .card-demo-meta {
+    font-size: var(--font-size-s);
+    color: var(--grey-350);
+  }
+
+  .card-demo-actions {
+    display: flex;
+    gap: var(--spacing-16);
+    align-items: center;
+  }
+
+  .card-demo-icon {
+    cursor: pointer;
+    font-size: 1.2em;
+    color: var(--grey-300);
+  }
+
+  .card-demo--mt {
+    margin-top: var(--spacing-16);
+  }
+
+  .soc-card-demo {
+    --swim-card-min-width: 0;
+    cursor: pointer;
+  }
+  .soc-card-demo:hover {
+    filter: brightness(1.15);
+  }
+  .soc-card-demo:focus-visible {
+    outline: 2px solid var(--blue-500);
+    outline-offset: 2px;
+    border-radius: var(--radius-4);
+  }
+  .soc-badge-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-8);
+    flex-wrap: wrap;
+  }
+  .soc-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--spacing-2) var(--spacing-8);
+    border-radius: 3px;
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+  }
+  .soc-badge--id {
+    font-weight: var(--font-weight-semibold);
+  }
+  .soc-badge--malicious {
+    background: rgba(255, 69, 52, 0.15);
+    color: var(--red-400);
+  }
+  .soc-badge--suspicious {
+    background: rgba(255, 168, 20, 0.15);
+    color: var(--orange-400);
+  }
+  .soc-badge--benign {
+    background: rgba(46, 204, 113, 0.15);
+    color: var(--green-400);
+  }
+  .soc-badge--escalated {
+    background: rgba(255, 69, 52, 0.12);
+    color: var(--red-400);
+  }
+  .soc-badge--new {
+    background: rgba(20, 131, 255, 0.12);
+    color: var(--blue-400);
+  }
+  .soc-confidence {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+  }
+  .soc-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-12);
+    font-size: var(--font-size-xs);
+    color: var(--grey-300);
+    flex-wrap: wrap;
+  }
+
+  .api-tag-gap {
+    margin-top: var(--spacing-20);
+  }
+
+  .color-green {
+    color: var(--green-400);
+  }
+
+  .color-orange {
+    color: var(--orange-400);
+  }
+
+  .color-red {
+    color: var(--red-400);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/card.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/card.html
@@ -1,70 +1,11 @@
-<style>
-  .demo-row--cards {
-    gap: 2rem;
-    align-items: flex-start;
-    flex-wrap: wrap;
-  }
-
-  .demo-label--spaced {
-    margin-top: 1rem;
-  }
-
-  .card-demo-stats {
-    display: flex;
-    gap: 1rem;
-    width: 100%;
-    margin-bottom: var(--spacing-20);
-  }
-
-  .card-demo-stat-item {
-    flex: 1;
-    background: var(--grey-750);
-    border-radius: var(--radius-4);
-    padding: 12px;
-    text-align: center;
-  }
-
-  .card-demo-stat-value {
-    font-size: var(--font-size-xl);
-    font-weight: var(--font-weight-semibold);
-    color: var(--grey-050);
-  }
-
-  .card-demo-stat-label {
-    font-size: var(--font-size-xxs);
-    color: var(--grey-350);
-    text-transform: uppercase;
-  }
-
-  .card-demo-meta {
-    font-size: var(--font-size-s);
-    color: var(--grey-350);
-  }
-
-  .card-demo-actions {
-    display: flex;
-    gap: var(--spacing-16);
-    align-items: center;
-  }
-
-  .card-demo-icon {
-    cursor: pointer;
-    font-size: 1.2em;
-    color: var(--grey-300);
-  }
-
-  .card-demo--mt {
-    margin-top: 1rem;
-  }
-</style>
-
+<div class="card-page">
 <h1 id="card" class="page-title">Card</h1>
 <p class="subtitle">
   Card container with horizontal or vertical layout, optional status, selection, and outline. Use
   <code>swim-card</code> with <code>swim-card-header</code>, <code>swim-card-footer</code>,
   <code>swim-card-avatar</code>, and <code>swim-card-placeholder</code>.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/card.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/card.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Horizontal card">
@@ -280,26 +221,6 @@
       Card with <code>swim-card-body</code> containing free-form content — badges, multi-line text, and metadata.
       Styled as a clickable SOC signal card from the AI SOC Platform.
     </p>
-    <style>
-      .soc-card-demo { --swim-card-min-width: 0; cursor: pointer; }
-      .soc-card-demo:hover { filter: brightness(1.15); }
-      .soc-card-demo:focus-visible { outline: 2px solid var(--blue-500); outline-offset: 2px; border-radius: var(--radius-4); }
-      .soc-badge-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-      .soc-badge {
-        display: inline-flex; align-items: center;
-        padding: 2px 8px; border-radius: 3px;
-        font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold);
-        text-transform: uppercase; letter-spacing: 0.03em; white-space: nowrap;
-      }
-      .soc-badge--id { font-weight: var(--font-weight-semibold); }
-      .soc-badge--malicious { background: rgba(255, 69, 52, 0.15); color: var(--red-400); }
-      .soc-badge--suspicious { background: rgba(255, 168, 20, 0.15); color: var(--orange-400); }
-      .soc-badge--benign { background: rgba(46, 204, 113, 0.15); color: var(--green-400); }
-      .soc-badge--escalated { background: rgba(255, 69, 52, 0.12); color: var(--red-400); }
-      .soc-badge--new { background: rgba(20, 131, 255, 0.12); color: var(--blue-400); }
-      .soc-confidence { font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); }
-      .soc-meta { display: flex; align-items: center; gap: 12px; font-size: var(--font-size-xs); color: var(--grey-300); flex-wrap: wrap; }
-    </style>
     <div class="demo-row demo-row--column">
       <div class="demo-label">Malicious signal (escalated)</div>
       <swim-card class="soc-card-demo" hide-accent role="button" tabindex="0"
@@ -310,7 +231,7 @@
           <div class="soc-badge-row">
             <span class="soc-badge--id">SIG-10421</span>
             <span class="soc-badge soc-badge--malicious">Malicious</span>
-            <span class="soc-confidence" style="color: var(--red-400)">92%</span>
+            <span class="soc-confidence color-red">92%</span>
             <span class="soc-badge soc-badge--escalated">Escalated</span>
           </div>
           <div>Suspicious outbound traffic to 185.220.101.34 detected on finance-srv-02</div>
@@ -329,7 +250,7 @@
           <div class="soc-badge-row">
             <span class="soc-badge--id">SIG-10427</span>
             <span class="soc-badge soc-badge--suspicious">Suspicious</span>
-            <span class="soc-confidence" style="color: var(--orange-400)">72%</span>
+            <span class="soc-confidence color-orange">72%</span>
             <span class="soc-badge soc-badge--new">New</span>
           </div>
           <div>Anomalous data transfer of 2.3GB from database server DB-PROD-01 to external IP</div>
@@ -347,7 +268,7 @@
           <div class="soc-badge-row">
             <span class="soc-badge--id">SIG-10425</span>
             <span class="soc-badge soc-badge--benign">Benign</span>
-            <span class="soc-confidence" style="color: var(--green-400)">88%</span>
+            <span class="soc-confidence color-green">88%</span>
             <span class="soc-badge soc-badge--new">Triaged</span>
           </div>
           <div>VPN connection from user jsmith from location inconsistent with travel records</div>
@@ -418,7 +339,7 @@
           </tbody>
         </table>
       </div>
-      <div style="margin-top:1.25rem"><span class="api-tag-name">&lt;swim-card-header / swim-card-body / swim-card-footer&gt;</span></div>
+      <div class="api-tag-gap"><span class="api-tag-name">&lt;swim-card-header / swim-card-body / swim-card-footer&gt;</span></div>
       <h4 class="api-heading">Child Properties</h4>
       <div class="api-table-wrap">
         <table class="api-table">
@@ -434,3 +355,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/checkbox.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/checkbox.css
@@ -1,0 +1,6 @@
+.checkbox-page {
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/checkbox.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/checkbox.html
@@ -1,3 +1,4 @@
+<div class="checkbox-page">
 <hr class="section-divider" />
 
 <h1 id="checkbox" class="page-title">Checkbox</h1>
@@ -5,7 +6,7 @@
   Checkbox control matching swim-checkbox (swim-ui): checked, indeterminate, disabled, and round variants. Use
   <code>swim-checkbox</code> with slot content as the label. Supports form association and keyboard (Space to toggle).
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/checkbox.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/checkbox.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Basic">
@@ -123,3 +124,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/date-display.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/date-display.css
@@ -1,0 +1,3 @@
+/* date-display section styles */
+.date-display-page {
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/date-display.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/date-display.html
@@ -1,3 +1,4 @@
+<div class="date-display-page">
 <hr class="section-divider" />
 <h1 id="date-display" class="page-title">Date/Time Display</h1>
 <p class="subtitle">Read-only date and time with formats, relative mode, time zones, and optional multi-zone tooltip (ngx-time parity).</p>
@@ -101,3 +102,4 @@
 &lt;swim-date-display datetime="2011-03-11T05:46:24Z" mode="local"&gt;&lt;/swim-date-display&gt;</code></pre>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/datetime.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/datetime.css
@@ -1,0 +1,49 @@
+.datetime-page {
+  .td-api {
+    padding: var(--spacing-6) var(--spacing-8);
+  }
+
+  .th-api {
+    text-align: left;
+    padding: var(--spacing-8);
+    color: var(--grey-300);
+    border-bottom: 1px solid var(--grey-700);
+  }
+
+  .table-full {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .mt-xl {
+    margin-top: var(--spacing-30);
+  }
+
+  .td {
+    padding: var(--spacing-8);
+  }
+
+  .td-label {
+    padding: var(--spacing-8);
+    color: var(--grey-300);
+  }
+
+  .th-col {
+    text-align: left;
+    padding: var(--spacing-8);
+    color: var(--grey-300);
+    width: 40%;
+  }
+
+  .th-label {
+    text-align: left;
+    padding: var(--spacing-8);
+    color: var(--grey-300);
+    width: 20%;
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/datetime.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/datetime.html
@@ -1,7 +1,8 @@
+<div class="datetime-page">
 <hr class="section-divider" />
 <h1 id="datetime" class="page-title">Date Time</h1>
 <p class="subtitle">Date, time, and datetime picker with formatting, timezone support, and form association.</p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/date-time.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/date-time.js';</code></p>
 
 <!-- ================================================================ -->
 <!-- Date Input -->
@@ -289,21 +290,21 @@
 <!-- ================================================================ -->
 <section class="section">
   <swim-section section-title="Appearances">
-    <table style="width: 100%; border-collapse: collapse">
+    <table class="table-full">
       <thead>
         <tr>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); width: 20%"></th>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); width: 40%">Default</th>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); width: 40%">Fill</th>
+          <th class="th-label"></th>
+          <th class="th-col">Default</th>
+          <th class="th-col">Fill</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td style="padding: 8px; color: var(--grey-300)">Filled</td>
-          <td style="padding: 8px">
+          <td class="td-label">Filled</td>
+          <td class="td">
             <swim-date-time id="appFilled" label="Label" hint="A brief bit of help text"></swim-date-time>
           </td>
-          <td style="padding: 8px">
+          <td class="td">
             <swim-date-time
               id="appFilledFill"
               appearance="fill"
@@ -313,11 +314,11 @@
           </td>
         </tr>
         <tr>
-          <td style="padding: 8px; color: var(--grey-300)">Required</td>
-          <td style="padding: 8px">
+          <td class="td-label">Required</td>
+          <td class="td">
             <swim-date-time id="appRequired" required label="Label" hint="A brief bit of help text"></swim-date-time>
           </td>
-          <td style="padding: 8px">
+          <td class="td">
             <swim-date-time
               id="appRequiredFill"
               appearance="fill"
@@ -328,22 +329,22 @@
           </td>
         </tr>
         <tr>
-          <td style="padding: 8px; color: var(--grey-300)">Empty w/o Placeholder</td>
-          <td style="padding: 8px"><swim-date-time label="Label" hint="A brief bit of help text"></swim-date-time></td>
-          <td style="padding: 8px">
+          <td class="td-label">Empty w/o Placeholder</td>
+          <td class="td"><swim-date-time label="Label" hint="A brief bit of help text"></swim-date-time></td>
+          <td class="td">
             <swim-date-time appearance="fill" label="Label" hint="A brief bit of help text"></swim-date-time>
           </td>
         </tr>
         <tr>
-          <td style="padding: 8px; color: var(--grey-300)">Empty w/ Placeholder</td>
-          <td style="padding: 8px">
+          <td class="td-label">Empty w/ Placeholder</td>
+          <td class="td">
             <swim-date-time
               label="Label"
               hint="A brief bit of help text"
               placeholder="Placeholder Text"
             ></swim-date-time>
           </td>
-          <td style="padding: 8px">
+          <td class="td">
             <swim-date-time
               appearance="fill"
               label="Label"
@@ -353,8 +354,8 @@
           </td>
         </tr>
         <tr>
-          <td style="padding: 8px; color: var(--grey-300)">Time</td>
-          <td style="padding: 8px">
+          <td class="td-label">Time</td>
+          <td class="td">
             <swim-date-time
               id="appTime"
               input-type="time"
@@ -363,7 +364,7 @@
               placeholder="Placeholder Text"
             ></swim-date-time>
           </td>
-          <td style="padding: 8px">
+          <td class="td">
             <swim-date-time
               id="appTimeFill"
               input-type="time"
@@ -375,8 +376,8 @@
           </td>
         </tr>
         <tr>
-          <td style="padding: 8px; color: var(--grey-300)">Date/Time</td>
-          <td style="padding: 8px">
+          <td class="td-label">Date/Time</td>
+          <td class="td">
             <swim-date-time
               id="appDateTime"
               input-type="datetime"
@@ -385,7 +386,7 @@
               placeholder="Placeholder Text"
             ></swim-date-time>
           </td>
-          <td style="padding: 8px">
+          <td class="td">
             <swim-date-time
               id="appDateTimeFill"
               input-type="datetime"
@@ -397,8 +398,8 @@
           </td>
         </tr>
         <tr>
-          <td style="padding: 8px; color: var(--grey-300)">Disabled</td>
-          <td style="padding: 8px">
+          <td class="td-label">Disabled</td>
+          <td class="td">
             <swim-date-time
               id="appDisabled"
               disabled
@@ -407,7 +408,7 @@
               placeholder="Placeholder Text"
             ></swim-date-time>
           </td>
-          <td style="padding: 8px">
+          <td class="td">
             <swim-date-time
               id="appDisabledFill"
               disabled
@@ -446,175 +447,175 @@
   @date-time-selected="\${handleSelected}"
 &gt;&lt;/swim-date-time&gt;</code></pre>
 
-    <h3 class="section-title" style="margin-top: 2rem">Properties</h3>
-    <table style="width: 100%; border-collapse: collapse">
+    <h3 class="section-title mt-xl">Properties</h3>
+    <table class="table-full">
       <thead>
         <tr>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); border-bottom: 1px solid var(--grey-700)">
+          <th class="th-api">
             Property
           </th>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); border-bottom: 1px solid var(--grey-700)">
+          <th class="th-api">
             Attribute
           </th>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); border-bottom: 1px solid var(--grey-700)">
+          <th class="th-api">
             Type
           </th>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); border-bottom: 1px solid var(--grey-700)">
+          <th class="th-api">
             Default
           </th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td style="padding: 6px 8px"><code>value</code></td>
-          <td style="padding: 6px 8px">—</td>
-          <td style="padding: 6px 8px">Date | string</td>
-          <td style="padding: 6px 8px">null</td>
+          <td class="td-api"><code>value</code></td>
+          <td class="td-api">—</td>
+          <td class="td-api">Date | string</td>
+          <td class="td-api">null</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>inputType</code></td>
-          <td style="padding: 6px 8px">input-type</td>
-          <td style="padding: 6px 8px">'date' | 'time' | 'datetime'</td>
-          <td style="padding: 6px 8px">'date'</td>
+          <td class="td-api"><code>inputType</code></td>
+          <td class="td-api">input-type</td>
+          <td class="td-api">'date' | 'time' | 'datetime'</td>
+          <td class="td-api">'date'</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>label</code></td>
-          <td style="padding: 6px 8px">label</td>
-          <td style="padding: 6px 8px">string</td>
-          <td style="padding: 6px 8px">''</td>
+          <td class="td-api"><code>label</code></td>
+          <td class="td-api">label</td>
+          <td class="td-api">string</td>
+          <td class="td-api">''</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>hint</code></td>
-          <td style="padding: 6px 8px">hint</td>
-          <td style="padding: 6px 8px">string</td>
-          <td style="padding: 6px 8px">''</td>
+          <td class="td-api"><code>hint</code></td>
+          <td class="td-api">hint</td>
+          <td class="td-api">string</td>
+          <td class="td-api">''</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>placeholder</code></td>
-          <td style="padding: 6px 8px">placeholder</td>
-          <td style="padding: 6px 8px">string</td>
-          <td style="padding: 6px 8px">''</td>
+          <td class="td-api"><code>placeholder</code></td>
+          <td class="td-api">placeholder</td>
+          <td class="td-api">string</td>
+          <td class="td-api">''</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>format</code></td>
-          <td style="padding: 6px 8px">format</td>
-          <td style="padding: 6px 8px">string</td>
-          <td style="padding: 6px 8px">auto</td>
+          <td class="td-api"><code>format</code></td>
+          <td class="td-api">format</td>
+          <td class="td-api">string</td>
+          <td class="td-api">auto</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>precision</code></td>
-          <td style="padding: 6px 8px">precision</td>
-          <td style="padding: 6px 8px">'year' | 'month' | 'hour' | 'minute' | 'second' | 'millisecond'</td>
-          <td style="padding: 6px 8px">—</td>
+          <td class="td-api"><code>precision</code></td>
+          <td class="td-api">precision</td>
+          <td class="td-api">'year' | 'month' | 'hour' | 'minute' | 'second' | 'millisecond'</td>
+          <td class="td-api">—</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>timezone</code></td>
-          <td style="padding: 6px 8px">timezone</td>
-          <td style="padding: 6px 8px">string (IANA)</td>
-          <td style="padding: 6px 8px">—</td>
+          <td class="td-api"><code>timezone</code></td>
+          <td class="td-api">timezone</td>
+          <td class="td-api">string (IANA)</td>
+          <td class="td-api">—</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>displayMode</code></td>
-          <td style="padding: 6px 8px">display-mode</td>
-          <td style="padding: 6px 8px">'human' | 'timezone' | 'local' | 'custom'</td>
-          <td style="padding: 6px 8px">'local'</td>
+          <td class="td-api"><code>displayMode</code></td>
+          <td class="td-api">display-mode</td>
+          <td class="td-api">'human' | 'timezone' | 'local' | 'custom'</td>
+          <td class="td-api">'local'</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>size</code></td>
-          <td style="padding: 6px 8px">size</td>
-          <td style="padding: 6px 8px">'sm' | 'md' | 'lg'</td>
-          <td style="padding: 6px 8px">'sm'</td>
+          <td class="td-api"><code>size</code></td>
+          <td class="td-api">size</td>
+          <td class="td-api">'sm' | 'md' | 'lg'</td>
+          <td class="td-api">'sm'</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>appearance</code></td>
-          <td style="padding: 6px 8px">appearance</td>
-          <td style="padding: 6px 8px">'legacy' | 'fill'</td>
-          <td style="padding: 6px 8px">'legacy'</td>
+          <td class="td-api"><code>appearance</code></td>
+          <td class="td-api">appearance</td>
+          <td class="td-api">'legacy' | 'fill'</td>
+          <td class="td-api">'legacy'</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>disabled</code></td>
-          <td style="padding: 6px 8px">disabled</td>
-          <td style="padding: 6px 8px">boolean</td>
-          <td style="padding: 6px 8px">false</td>
+          <td class="td-api"><code>disabled</code></td>
+          <td class="td-api">disabled</td>
+          <td class="td-api">boolean</td>
+          <td class="td-api">false</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>required</code></td>
-          <td style="padding: 6px 8px">required</td>
-          <td style="padding: 6px 8px">boolean</td>
-          <td style="padding: 6px 8px">false</td>
+          <td class="td-api"><code>required</code></td>
+          <td class="td-api">required</td>
+          <td class="td-api">boolean</td>
+          <td class="td-api">false</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>minDate</code></td>
-          <td style="padding: 6px 8px">min-date</td>
-          <td style="padding: 6px 8px">string | Date</td>
-          <td style="padding: 6px 8px">—</td>
+          <td class="td-api"><code>minDate</code></td>
+          <td class="td-api">min-date</td>
+          <td class="td-api">string | Date</td>
+          <td class="td-api">—</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>maxDate</code></td>
-          <td style="padding: 6px 8px">max-date</td>
-          <td style="padding: 6px 8px">string | Date</td>
-          <td style="padding: 6px 8px">—</td>
+          <td class="td-api"><code>maxDate</code></td>
+          <td class="td-api">max-date</td>
+          <td class="td-api">string | Date</td>
+          <td class="td-api">—</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>autosize</code></td>
-          <td style="padding: 6px 8px">autosize</td>
-          <td style="padding: 6px 8px">boolean</td>
-          <td style="padding: 6px 8px">false</td>
+          <td class="td-api"><code>autosize</code></td>
+          <td class="td-api">autosize</td>
+          <td class="td-api">boolean</td>
+          <td class="td-api">false</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>marginless</code></td>
-          <td style="padding: 6px 8px">marginless</td>
-          <td style="padding: 6px 8px">boolean</td>
-          <td style="padding: 6px 8px">false</td>
+          <td class="td-api"><code>marginless</code></td>
+          <td class="td-api">marginless</td>
+          <td class="td-api">boolean</td>
+          <td class="td-api">false</td>
         </tr>
       </tbody>
     </table>
 
-    <h3 class="section-title" style="margin-top: 2rem">Events</h3>
-    <table style="width: 100%; border-collapse: collapse">
+    <h3 class="section-title mt-xl">Events</h3>
+    <table class="table-full">
       <thead>
         <tr>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); border-bottom: 1px solid var(--grey-700)">
+          <th class="th-api">
             Event
           </th>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); border-bottom: 1px solid var(--grey-700)">
+          <th class="th-api">
             Detail
           </th>
-          <th style="text-align: left; padding: 8px; color: var(--grey-300); border-bottom: 1px solid var(--grey-700)">
+          <th class="th-api">
             Description
           </th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td style="padding: 6px 8px"><code>change</code></td>
-          <td style="padding: 6px 8px">Date | null</td>
-          <td style="padding: 6px 8px">Emitted when the value is valid or cleared.</td>
+          <td class="td-api"><code>change</code></td>
+          <td class="td-api">Date | null</td>
+          <td class="td-api">Emitted when the value is valid or cleared.</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>value-change</code></td>
-          <td style="padding: 6px 8px">any</td>
-          <td style="padding: 6px 8px">Emitted on any value change (valid or invalid).</td>
+          <td class="td-api"><code>value-change</code></td>
+          <td class="td-api">any</td>
+          <td class="td-api">Emitted on any value change (valid or invalid).</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>input-change</code></td>
-          <td style="padding: 6px 8px">any</td>
-          <td style="padding: 6px 8px">Emitted when the user types in the text input.</td>
+          <td class="td-api"><code>input-change</code></td>
+          <td class="td-api">any</td>
+          <td class="td-api">Emitted when the user types in the text input.</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>date-time-selected</code></td>
-          <td style="padding: 6px 8px">Date</td>
-          <td style="padding: 6px 8px">Emitted when a date is selected from the picker.</td>
+          <td class="td-api"><code>date-time-selected</code></td>
+          <td class="td-api">Date</td>
+          <td class="td-api">Emitted when a date is selected from the picker.</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>focus</code></td>
-          <td style="padding: 6px 8px">—</td>
-          <td style="padding: 6px 8px">Input focused.</td>
+          <td class="td-api"><code>focus</code></td>
+          <td class="td-api">—</td>
+          <td class="td-api">Input focused.</td>
         </tr>
         <tr>
-          <td style="padding: 6px 8px"><code>blur</code></td>
-          <td style="padding: 6px 8px">—</td>
-          <td style="padding: 6px 8px">Input blurred.</td>
+          <td class="td-api"><code>blur</code></td>
+          <td class="td-api">—</td>
+          <td class="td-api">Input blurred.</td>
         </tr>
       </tbody>
     </table>
@@ -666,3 +667,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/dialog.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/dialog.css
@@ -1,0 +1,130 @@
+.dialog-page {
+  .mt-0 {
+    margin-top: var(--spacing-0);
+  }
+
+  .events-log {
+    margin-top: var(--spacing-16);
+    max-height: 14rem;
+    overflow: auto;
+    text-align: left;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .row-center {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--spacing-12);
+  }
+
+  .desc-center-wide {
+    margin-top: var(--spacing-0);
+    max-width: 46rem;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+  }
+
+  .center-mt-sm {
+    text-align: center;
+    margin-top: var(--spacing-8);
+  }
+
+  .value-center {
+    font-size: var(--font-size-s);
+    color: var(--grey-350);
+    margin: var(--spacing-0);
+    text-align: center;
+  }
+
+  .value-center code {
+    color: var(--grey-200);
+  }
+
+  .stack-center-narrow {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-12);
+    width: 100%;
+    max-width: 500px;
+    margin: var(--spacing-0) auto;
+  }
+
+  .muted-center {
+    color: var(--grey-300);
+    margin: var(--spacing-0) var(--spacing-0) var(--spacing-16) var(--spacing-0);
+    text-align: center;
+    max-width: 36rem;
+  }
+
+  .stack-center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .link-accent {
+    color: var(--blue-400);
+  }
+
+  .desc-center {
+    margin-top: var(--spacing-0);
+    max-width: 42rem;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+  }
+
+  .row-center-wrap {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .muted-flush {
+    color: var(--grey-300);
+    margin: var(--spacing-0);
+  }
+
+  .row-center-mt {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--spacing-12);
+    margin-top: var(--spacing-8);
+  }
+
+  .m-0 {
+    margin: var(--spacing-0);
+  }
+
+  .host-dialog-theme {
+    --swim-dialog-bg: var(--grey-725);
+    --swim-dialog-header-color: var(--lightblue-300);
+    --swim-dialog-body-color: var(--grey-100);
+  }
+
+  .desc-center-wide-mt {
+    margin-top: var(--spacing-24);
+    max-width: 46rem;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+  }
+
+  .host-format-theme {
+    --swim-format-dialog-bg: var(--grey-900);
+    --swim-format-body-padding: var(--spacing-40);
+    --swim-format-header-padding-x: var(--spacing-40);
+    --swim-format-header-padding-end: var(--spacing-48);
+    --swim-format-border-radius: var(--radius-24);
+    --swim-format-divider: var(--spacing-2) solid var(--blue-500);
+    --swim-format-footer-gap: var(--spacing-16);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/dialog.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/dialog.html
@@ -1,9 +1,10 @@
+<div class="dialog-page">
 <hr class="section-divider" />
 <h1 id="dialog" class="page-title">Dialog</h1>
 <p class="subtitle">
   Modal dialog with title, slot content, and optional close button. Matches @swimlane/ngx-ui dialog behavior.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/dialog.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/dialog.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Content">
@@ -19,7 +20,7 @@
 
 <section class="section">
   <swim-section section-title="Backdrop and Escape">
-    <p class="section-desc" style="margin-top: 0; max-width: 42rem; margin-left: auto; margin-right: auto; text-align: center">
+    <p class="section-desc desc-center">
       Match ngx <code>closeOnBlur</code> / <code>closeOnEscape</code> with <code>close-on-blur</code> and
       <code>close-on-escape</code> on <code>swim-dialog</code>. This dialog keeps the dimmed backdrop but does
       <strong>not</strong> close when you click it; use Escape, the close button, or programmatic <code>hide()</code>.
@@ -122,32 +123,20 @@
 
 <section class="section">
   <swim-section section-title="Theming (CSS variables)">
-    <p class="section-desc" style="margin-top: 0; max-width: 46rem; margin-left: auto; margin-right: auto; text-align: center">
+    <p class="section-desc desc-center-wide">
       Set <code>--swim-format-*</code> on <code>swim-dialog</code> or an ancestor; they inherit into
       <code>swim-large-format-dialog-content</code> (padding, radius, dividers, footer gap, background). Regular dialogs
       respect <code>--swim-dialog-bg</code>, <code>--swim-dialog-header-color</code>, and
       <code>--swim-dialog-body-color</code>. Layout tokens such as <code>--spacing-40</code> from ngx-ui
       <code>layouts/_vars.scss</code> work as values when your app defines them on <code>:root</code>.
     </p>
-    <swim-dialog
-      id="dialogThemeVarsLargeDemo"
-      format="large"
-      style="
-        --swim-format-dialog-bg: var(--grey-900);
-        --swim-format-body-padding: var(--spacing-40, 2.5rem);
-        --swim-format-header-padding-x: var(--spacing-40, 2.5rem);
-        --swim-format-header-padding-end: var(--spacing-48, 3rem);
-        --swim-format-border-radius: var(--radius-24, 24px);
-        --swim-format-divider: 2px solid var(--blue-500);
-        --swim-format-footer-gap: var(--spacing-16, 1rem);
-      "
-    >
+    <swim-dialog class="host-format-theme" id="dialogThemeVarsLargeDemo" format="large">
       <swim-large-format-dialog-content
         format="large"
         dialog-title="Themed large dialog"
         dialog-subtitle="Variables set on swim-dialog"
       >
-        <p style="margin-top: 0">
+        <p class="mt-0">
           This panel uses wider body padding, a larger corner radius, blue dividers, and a darker shell background via
           inherited custom properties.
         </p>
@@ -157,24 +146,16 @@
         </swim-large-format-dialog-footer>
       </swim-large-format-dialog-content>
     </swim-dialog>
-    <div class="demo-row" style="flex-wrap: wrap; justify-content: center; gap: 0.75rem">
+    <div class="demo-row row-center">
       <swim-button type="button" id="dialogThemeVarsLargeOpen">Open themed large dialog</swim-button>
     </div>
-    <p class="section-desc" style="margin-top: 1.5rem; max-width: 46rem; margin-left: auto; margin-right: auto; text-align: center">
+    <p class="section-desc desc-center-wide-mt">
       Regular format: panel colors from <code>--swim-dialog-*</code> on the host.
     </p>
-    <swim-dialog
-      id="dialogThemeVarsRegularDemo"
-      dialog-title="Themed regular dialog"
-      style="
-        --swim-dialog-bg: var(--grey-725);
-        --swim-dialog-header-color: var(--lightblue-300);
-        --swim-dialog-body-color: var(--grey-100);
-      "
-    >
-      <p style="margin: 0">Header and body colors follow the variables above.</p>
+    <swim-dialog class="host-dialog-theme" id="dialogThemeVarsRegularDemo" dialog-title="Themed regular dialog">
+      <p class="m-0">Header and body colors follow the variables above.</p>
     </swim-dialog>
-    <div class="demo-row" style="flex-wrap: wrap; justify-content: center; gap: 0.75rem; margin-top: 0.5rem">
+    <div class="demo-row row-center-mt">
       <swim-button type="button" id="dialogThemeVarsRegularOpen">Open themed regular dialog</swim-button>
     </div>
     <br /><br />
@@ -200,7 +181,7 @@
 
 <section class="section">
   <swim-section section-title="Large format footer alignment">
-    <p class="section-desc" style="margin-top: 0; max-width: 42rem; margin-left: auto; margin-right: auto; text-align: center">
+    <p class="section-desc desc-center">
       <code>swim-large-format-dialog-footer</code> uses the <code>align</code> attribute for horizontal layout
       (<code>start</code> | <code>center</code> | <code>end</code> | <code>space-between</code> | <code>space-around</code> |
       <code>space-evenly</code>). Open the same dialog with different values to compare the footer row.
@@ -211,7 +192,7 @@
         dialog-title="Footer alignment"
         dialog-subtitle="align maps to flex justify-content"
       >
-        <p style="color: var(--grey-300); margin: 0">
+        <p class="muted-flush">
           Current <code>align</code> is set before the dialog opens. Default is <code>center</code>.
         </p>
         <swim-large-format-dialog-footer id="dialogFooterAlignFooter" slot="footer" format="medium" align="center">
@@ -220,7 +201,7 @@
         </swim-large-format-dialog-footer>
       </swim-large-format-dialog-content>
     </swim-dialog>
-    <div class="demo-row" style="flex-wrap: wrap; justify-content: center">
+    <div class="demo-row row-center-wrap">
       <swim-button type="button" id="dialogFooterAlignOpenStart">Open (align start)</swim-button>
       <swim-button type="button" id="dialogFooterAlignOpenCenter">Open (align center)</swim-button>
       <swim-button type="button" id="dialogFooterAlignOpenEnd">Open (align end)</swim-button>
@@ -236,10 +217,10 @@
 
 <section class="section">
   <swim-section section-title="Medium Format">
-    <p class="section-desc" style="margin-top: 0; max-width: 42rem; margin-left: auto; margin-right: auto; text-align: center">
+    <p class="section-desc desc-center">
       This example uses the same <strong>Remote search (GitHub users)</strong> pattern as the Select demo: type at least
       <strong>2 characters</strong> to query the
-      <a href="https://docs.github.com/en/rest/search/search#search-users" style="color: var(--blue-400)"
+      <a class="link-accent" href="https://docs.github.com/en/rest/search/search#search-users"
         >Search users</a
       >
       API inside a medium-format dialog body.
@@ -251,12 +232,12 @@
         dialog-title="Medium format dialog"
         dialog-subtitle="Remote search (GitHub users)"
       >
-        <div style="display: flex; flex-direction: column; align-items: center; width: 100%; box-sizing: border-box">
-          <p style="color: var(--grey-300); margin: 0 0 1rem 0; text-align: center; max-width: 36rem">
+        <div class="stack-center">
+          <p class="muted-center">
             Type at least <strong>2 characters</strong> to search public GitHub users.<br />
             Results load after the default <strong>500ms</strong> debounce on <code>filter-change</code>.
           </p>
-          <div style="display: flex; flex-direction: column; gap: 0.75rem; width: 100%; max-width: 500px; margin: 0 auto">
+          <div class="stack-center-narrow">
             <swim-select
               id="dialogMediumGithubUserSelect"
               label="GitHub user"
@@ -270,8 +251,8 @@
               dropdown-align="center"
               hint="Uses https://api.github.com/search/users (rate limits apply without auth)."
             ></swim-select>
-            <p style="font-size: var(--font-size-s); color: var(--grey-350); margin: 0; text-align: center">
-              Selected: <code id="dialogMediumGithubUserSelectValue" style="color: var(--grey-200)">—</code>
+            <p class="value-center">
+              Selected: <code id="dialogMediumGithubUserSelectValue">—</code>
             </p>
           </div>
         </div>
@@ -281,7 +262,7 @@
         </swim-large-format-dialog-footer>
       </swim-large-format-dialog-content>
     </swim-dialog>
-    <div style="text-align: center; margin-top: 0.5rem">
+    <div class="center-mt-sm">
       <swim-button type="button" id="dialogMediumFormatOpen">Open Medium Format Dialog</swim-button>
     </div>
     <br /><br />
@@ -386,21 +367,17 @@
 
 <section class="section">
   <swim-section section-title="Events (open, close, close-or-cancel)">
-    <p class="section-desc" style="margin-top: 0; max-width: 46rem; margin-left: auto; margin-right: auto; text-align: center">
+    <p class="section-desc desc-center-wide">
       <code>swim-dialog</code> dispatches <code>open</code> when <code>visible</code> becomes true and <code>close</code> when it becomes false. Host events use
       <code>bubbles: false</code> and <code>composed: false</code>, so attach listeners on the <code>swim-dialog</code> element itself, not on a parent for delegation.
       For large/medium layout, <code>swim-large-format-dialog-content</code> dispatches <code>close-or-cancel</code> (detail: dirty boolean) from the header control — listen on
       that element, then set the parent dialog’s <code>visible</code> to <code>false</code> if you want the overlay to dismiss.
     </p>
-    <div class="demo-row" style="flex-wrap: wrap; justify-content: center; gap: 0.75rem">
+    <div class="demo-row row-center">
       <swim-button type="button" id="dialogEventsOpen">Open dialog</swim-button>
       <swim-button type="button" variant="bordered" id="dialogEventsClearLog">Clear log</swim-button>
     </div>
-    <pre
-      id="dialogEventsLog"
-      class="demo-pre"
-      style="margin-top: 1rem; max-height: 14rem; overflow: auto; text-align: left; white-space: pre-wrap; word-break: break-word"
-    >(no events yet — open the dialog and try closing from the header, backdrop, Escape, or the footer button)</pre>
+    <pre id="dialogEventsLog" class="demo-pre events-log">(no events yet — open the dialog and try closing from the header, backdrop, Escape, or the footer button)</pre>
     <swim-dialog id="dialogEventsDemo" format="medium">
       <swim-large-format-dialog-content
         id="dialogEventsLargeContent"
@@ -408,7 +385,7 @@
         dialog-title="Dialog events"
         dialog-subtitle="Try different dismiss paths"
       >
-        <p style="margin-top: 0">
+        <p class="mt-0">
           Use the header close, click outside the panel, press <kbd>Escape</kbd>, or the footer button. Watch the log above.
         </p>
         <swim-large-format-dialog-footer slot="footer" format="medium">
@@ -462,3 +439,4 @@ panel?.addEventListener('close-or-cancel', e => {
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/drawer.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/drawer.css
@@ -1,0 +1,6 @@
+.drawer-page {
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/drawer.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/drawer.html
@@ -1,9 +1,10 @@
+<div class="drawer-page">
 <hr class="section-divider" />
 <h1 id="drawer" class="page-title">Drawer</h1>
 <p class="subtitle">
   Slide-in panel from the right (left drawer) or bottom. Matches @swimlane/ngx-ui drawer design. Use declarative swim-drawer or imperative openDrawer().
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/drawer.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/drawer.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Default">
@@ -193,3 +194,4 @@ close(); // or drawer.hide();</code></pre>
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/event-bubbling-matrix.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/event-bubbling-matrix.css
@@ -1,0 +1,31 @@
+.event-bubbling-matrix-page {
+  .matrix-shadow-host {
+    padding: var(--spacing-16);
+    background: var(--grey-800);
+    border-radius: var(--radius-4);
+    border: 1px solid var(--grey-600);
+  }
+
+  .matrix-shadow-title {
+    font-size: var(--font-size-s);
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-8);
+  }
+
+  .log {
+    min-height: 12rem;
+    white-space: pre-wrap;
+  }
+
+  .mt-lg {
+    margin-top: var(--spacing-24);
+  }
+
+  .mb {
+    margin-bottom: var(--spacing-16);
+  }
+
+  .mb-xl {
+    margin-bottom: var(--spacing-30);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/event-bubbling-matrix.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/event-bubbling-matrix.html
@@ -1,3 +1,4 @@
+<div class="event-bubbling-matrix-page">
 <section class="section" id="event-bubbling-matrix">
   <h1 class="page-title">Event propagation matrix</h1>
   <p class="section-desc">
@@ -12,7 +13,7 @@
     <p class="section-desc">
       Wrapper <code>.matrix-wrap-light</code> → <code>swim-checkbox</code>. Listeners: checkbox, wrapper (bubble), <code>document</code> (bubble).
     </p>
-    <div class="matrix-wrap-light demo-card-container" style="margin-bottom: 2rem">
+    <div class="matrix-wrap-light demo-card-container mb-xl">
       <swim-checkbox id="matrixCbLight" label="Toggle (light DOM)"></swim-checkbox>
     </div>
 
@@ -21,13 +22,14 @@
       The checkbox lives in an element's shadow root. With non-bubbling events, a listener on <code>document</code> does
       <strong>not</strong> receive <code>change</code> from inside the shadow subtree; listen on the checkbox node or the shadow host.
     </p>
-    <div id="matrixShadowMount" class="demo-card-container" style="margin-bottom: 1rem"></div>
+    <div id="matrixShadowMount" class="demo-card-container mb"></div>
 
     <div class="demo-row">
       <swim-button id="matrixClearLog" variant="bordered">Clear log</swim-button>
     </div>
 
-    <h3 class="style-header" style="margin-top: 1.5rem">Log</h3>
-    <pre id="eventBubblingMatrixLog" class="demo-pre" style="min-height: 12rem; white-space: pre-wrap"></pre>
+    <h3 class="style-header mt-lg">Log</h3>
+    <pre id="eventBubblingMatrixLog" class="demo-pre log"></pre>
   </div>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/home.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/home.css
@@ -1,0 +1,9 @@
+.home-page {
+  h2.style-header {
+    margin-top: var(--spacing-48);
+  }
+
+  .list-indent {
+    margin: var(--spacing-8) var(--spacing-0) var(--spacing-16) var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/home.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/home.html
@@ -1,8 +1,4 @@
-<style>
-  h2.style-header {
-    margin-top: 3rem;
-  }
-</style>
+<div class="home-page">
 <h1 id="home" class="page-title">Welcome to Swim-UI</h1>
 <p class="subtitle">
   Lit web component library matching Swimlane's ngx-ui design system. Use the sidebar to explore components.
@@ -42,7 +38,7 @@ import 'https://widgets.swimlane.app/swim-ui/swim-ui.js';
     <p class="section-desc">
       Pin the version in the URL to avoid unexpected updates. You can lock to <strong>major</strong>, <strong>minor</strong>, or <strong>patch</strong> (e.g. <code>1</code>, <code>1.0</code>, or <code>1.0.0</code>).
     </p>
-    <ul class="section-desc" style="margin: 0.5rem 0 1rem 1.5rem;">
+    <ul class="section-desc list-indent">
       <li><strong>Latest</strong> (no version) — always gets the newest release:<br />
         <code>https://widgets.swimlane.app/swim-ui/swim-ui.js</code><br /><br /></li>
       <li><strong>Major</strong> (e.g. <code>1</code>) — any 1.x.x (minor and patch updates):<br />
@@ -55,5 +51,4 @@ import 'https://widgets.swimlane.app/swim-ui/swim-ui.js';
 
   </swim-section>
 </section>
-
-
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/icons.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/icons.css
@@ -1,0 +1,95 @@
+.icons-page {
+  .icon-search-wrap {
+    position: relative;
+    max-width: 320px;
+    margin-bottom: var(--spacing-24);
+  }
+  .icon-search-wrap .icon-search-icon {
+    position: absolute;
+    left: var(--spacing-12);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--grey-400);
+    font-size: var(--font-size-l);
+    width: var(--font-size-l);
+    height: var(--font-size-l);
+    pointer-events: none;
+  }
+  .icon-search-input {
+    width: 100%;
+    height: var(--spacing-40);
+    padding: var(--spacing-0) var(--spacing-12) var(--spacing-0) var(--spacing-36);
+    background: var(--grey-800);
+    border: 1px solid var(--grey-700);
+    border-radius: var(--radius-4);
+    color: var(--grey-050);
+    font-size: var(--font-size-s);
+  }
+  .icon-search-input::placeholder {
+    color: var(--grey-400);
+  }
+  .icon-search-input:focus {
+    outline: none;
+    border-color: var(--blue-500);
+  }
+  .icons-preview li.icon-search-hidden {
+    display: none;
+  }
+  .icons-preview {
+    list-style: none;
+    padding: var(--spacing-0);
+    margin: var(--spacing-0);
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: var(--spacing-0);
+  }
+  @media (max-width: 1200px) {
+    .icons-preview {
+      grid-template-columns: repeat(4, 1fr);
+    }
+  }
+  @media (max-width: 768px) {
+    .icons-preview {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+  .icons-preview li {
+    height: 150px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-10) var(--spacing-4);
+    text-align: center;
+    margin: var(--spacing-10);
+    border: solid 1px var(--grey-800);
+    border-radius: var(--radius-2);
+    background: var(--grey-800);
+  }
+  .icons-preview li .icon-name {
+    color: var(--grey-400);
+    font-size: var(--font-size-s);
+    line-height: var(--font-size-m);
+    margin-top: var(--spacing-8);
+  }
+  .icons-preview li swim-icon {
+    font-size: 50px;
+    line-height: 1em;
+    color: var(--white);
+  }
+
+  .muted {
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-16);
+  }
+
+  .ml-sm {
+    margin-left: var(--spacing-8);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/icons.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/icons.html
@@ -1,91 +1,11 @@
-<style>
-  .icon-search-wrap {
-    position: relative;
-    max-width: 320px;
-    margin-bottom: 1.5rem;
-  }
-  .icon-search-wrap .icon-search-icon {
-    position: absolute;
-    left: 0.75rem;
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--grey-400);
-    font-size: 1.125rem;
-    width: 1.125rem;
-    height: 1.125rem;
-    pointer-events: none;
-  }
-  .icon-search-input {
-    width: 100%;
-    height: 40px;
-    padding: 0 0.75rem 0 2.25rem;
-    background: var(--grey-800);
-    border: 1px solid var(--grey-700);
-    border-radius: var(--radius-4);
-    color: var(--grey-050);
-    font-size: 0.9375rem;
-  }
-  .icon-search-input::placeholder {
-    color: var(--grey-400);
-  }
-  .icon-search-input:focus {
-    outline: none;
-    border-color: var(--blue-500);
-  }
-  .icons-preview li.icon-search-hidden {
-    display: none;
-  }
-  .icons-preview {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    gap: 0;
-  }
-  @media (max-width: 1200px) {
-    .icons-preview {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  }
-  @media (max-width: 768px) {
-    .icons-preview {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-  .icons-preview li {
-    height: 150px;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 10px 5px;
-    text-align: center;
-    margin: 10px;
-    border: solid 1px var(--grey-800);
-    border-radius: var(--radius-2);
-    background: var(--grey-800);
-  }
-  .icons-preview li .icon-name {
-    color: var(--grey-400);
-    font-size: 0.9rem;
-    line-height: 1rem;
-    margin-top: 0.5rem;
-  }
-  .icons-preview li swim-icon {
-    font-size: 50px;
-    line-height: 1em;
-    color: var(--white);
-  }
-</style>
+<div class="icons-page">
 <!-- ICON COMPONENT DEMOS (last in nav order) -->
 <h1 id="icons" class="page-title">Icon</h1>
 <p class="subtitle">
   Font icons and inline SVG, matching swim-ui (see src/app/icons-page). Uses swim-icon; the icon font is self-loaded by
   the component (no separate icon CSS required).
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/icon.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/icon.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Icons">
@@ -126,14 +46,14 @@
   <swim-section section-title="With alt (accessibility)">
     <div class="demo-item">
       <swim-icon font-icon="x" alt="Close"></swim-icon>
-      <span style="margin-left: 0.5rem">Icon with accessible name for screen readers</span>
+      <span class="ml-sm">Icon with accessible name for screen readers</span>
     </div>
   </swim-section>
 </section>
 
 <section class="section">
   <swim-section section-title="Icon Usage">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Import the icon component; the swim-icon font is self-loaded (no separate CSS required):
     </p>
     <pre class="demo-pre"
@@ -166,3 +86,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/input.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/input.css
@@ -1,0 +1,40 @@
+.input-page {
+  .divider {
+    border: none;
+    border-top: 1px solid var(--grey-700);
+    margin: 4rem var(--spacing-0);
+  }
+
+  .muted {
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-16);
+  }
+
+  .color-muted {
+    color: var(--grey-300);
+  }
+
+  .stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-16);
+    max-width: 500px;
+  }
+
+  .ml-sm {
+    margin-left: var(--spacing-8);
+  }
+
+  .mt {
+    margin-top: var(--spacing-16);
+  }
+
+  .narrow {
+    max-width: 500px;
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/input.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/input.html
@@ -1,7 +1,8 @@
+<div class="input-page">
 <hr class="section-divider" />
 <h1 id="input" class="page-title">Input Component</h1>
 <p class="subtitle">Text inputs with floating labels and validation</p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/input.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/input.js';</code></p>
 
 <!-- Input Types (mirrors ngx-ui inputs-page: Text and type variants) -->
 <section class="section">
@@ -43,7 +44,7 @@
 <!-- Input Sizes Section -->
 <section class="section">
   <swim-section section-title="Input Sizes">
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-input size="sm" label="Small Input" placeholder="Small size"></swim-input>
       <swim-input size="md" label="Medium Input" placeholder="Medium size"></swim-input>
       <swim-input size="lg" label="Large Input" placeholder="Large size"></swim-input>
@@ -58,7 +59,7 @@
 <!-- Input Appearances Section -->
 <section class="section">
   <swim-section section-title="Input Appearances">
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-input appearance="legacy" label="Legacy Appearance" placeholder="Default style"></swim-input>
       <swim-input appearance="fill" label="Fill Appearance" placeholder="Filled background"></swim-input>
     </div>
@@ -71,7 +72,7 @@
 <!-- Textarea Section -->
 <section class="section">
   <swim-section section-title="Textarea">
-    <div style="max-width: 500px">
+    <div class="narrow">
       <swim-input
         type="textarea"
         label="Comments"
@@ -94,7 +95,7 @@
 <!-- Input States Section -->
 <section class="section">
   <swim-section section-title="Input States">
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-input label="Normal" placeholder="Normal input"></swim-input>
       <swim-input label="With Value" value="Has a value"></swim-input>
       <swim-input label="Required Field" required placeholder="This is required"></swim-input>
@@ -115,7 +116,7 @@
 <!-- Form Validation Section -->
 <section class="section">
   <swim-section section-title="Form Validation">
-    <form id="demoForm" style="max-width: 500px">
+    <form class="narrow" id="demoForm">
       <swim-input
         id="nameInput"
         name="name"
@@ -146,9 +147,9 @@
         hint="Must be between 18 and 100"
       ></swim-input>
 
-      <div style="margin-top: 1rem">
+      <div class="mt">
         <swim-button type="submit" variant="primary">Submit Form</swim-button>
-        <swim-button type="reset" variant="bordered" style="margin-left: 0.5rem">Reset</swim-button>
+        <swim-button class="ml-sm" type="reset" variant="bordered">Reset</swim-button>
       </div>
     </form>
     <pre class="demo-pre"
@@ -166,7 +167,7 @@
 <!-- Advanced Features Section -->
 <section class="section">
   <swim-section section-title="Advanced Features">
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-input
         type="password"
         label="Password with Toggle"
@@ -184,8 +185,8 @@
       ></swim-input>
 
       <swim-input appearance="fill" label="Fill with Prefix/Suffix" value="example">
-        <span slot="prefix" style="color: var(--grey-300)">https://</span>
-        <span slot="suffix" style="color: var(--grey-300)">.com</span>
+        <span class="color-muted" slot="prefix">https://</span>
+        <span class="color-muted" slot="suffix">.com</span>
       </swim-input>
     </div>
     <pre class="demo-pre"
@@ -205,7 +206,7 @@
 <!-- Input Usage Section -->
 <section class="section">
   <swim-section section-title="Input Usage">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">Import and use the input component in your application:</p>
+    <p class="muted">Import and use the input component in your application:</p>
     <pre class="demo-pre"
     ><code>&lt;script type="module"&gt;
   import '@swimlane/swim-ui/input';
@@ -259,4 +260,5 @@
   </swim-section>
 </section>
 
-<hr style="border: none; border-top: 1px solid var(--grey-700); margin: 4rem 0" />
+<hr class="divider" />
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/list.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/list.css
@@ -1,0 +1,6 @@
+.list-page {
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/list.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/list.html
@@ -1,3 +1,4 @@
+<div class="list-page">
 <hr class="section-divider" />
 <h1 id="list" class="page-title">List</h1>
 <p class="subtitle">
@@ -5,7 +6,7 @@
   <code>swim-list</code> with <code>dataSource</code>, <code>headerLabels</code>, and <code>columns</code> set via JavaScript.
   Supports scroll-based pagination and custom column layout.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/list.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/list.js';</code></p>
 
 <section class="section">
   <swim-section section-title="List">
@@ -173,3 +174,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/navbar.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/navbar.css
@@ -1,0 +1,11 @@
+.navbar-page {
+  .navbar-page--container {
+    display: flex;
+    justify-content: center;
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/navbar.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/navbar.html
@@ -1,15 +1,10 @@
-<style>
-  .navbar-page--container {
-    display: flex;
-    justify-content: center;
-  }
-</style>
+<div class="navbar-page">
 <h1 id="navbar" class="page-title">Navbar</h1>
 <p class="subtitle">
   Navbar with sliding active indicator. Use <code>swim-navbar</code> with <code>swim-navbar-item</code> children.
   Set <code>bar-at-top</code> to show the bar above items; use <code>active</code> and <code>active-change</code> for two-way binding.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/navbar.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/navbar.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Navbar">
@@ -91,3 +86,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/progress-spinner.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/progress-spinner.css
@@ -1,0 +1,84 @@
+.progress-spinner-page {
+  .progress-spinner-configurable-layout {
+    display: grid;
+    grid-template-columns: minmax(200px, 280px) 1fr;
+    gap: var(--spacing-30);
+    align-items: start;
+  }
+  @media (max-width: 720px) {
+    .progress-spinner-configurable-layout {
+      grid-template-columns: 1fr;
+    }
+  }
+  .progress-spinner-configurable-controls {
+    position: sticky;
+    top: var(--spacing-16);
+  }
+  .progress-spinner-configurable-controls .demo-configurable-grid {
+    grid-template-columns: 1fr;
+  }
+  .progress-spinner-configurable-live {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-16);
+    min-width: 0;
+  }
+  .progress-spinner-configurable-preview {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 220px;
+    padding: var(--spacing-24);
+    background: var(--grey-800);
+    border-radius: var(--radius-4);
+    border: 1px solid var(--grey-750);
+  }
+  .progress-spinner-configurable-code {
+    margin: var(--spacing-0);
+  }
+  .progress-spinner-configurable-code code {
+    white-space: pre;
+    font-size: var(--font-size-xs);
+  }
+  .demo-configurable-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: var(--spacing-16);
+    align-items: end;
+  }
+  .demo-configurable-item label {
+    display: block;
+    font-size: var(--font-size-s);
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-4);
+  }
+  .demo-configurable-item input,
+  .demo-configurable-item select {
+    width: 100%;
+    min-width: 0;
+    height: var(--spacing-36);
+    padding: var(--spacing-0) var(--spacing-8);
+    background: var(--grey-800);
+    border: 1px solid var(--grey-700);
+    border-radius: var(--radius-4);
+    color: var(--grey-050);
+    font-size: var(--font-size-s);
+  }
+  .demo-configurable-item input:focus,
+  .demo-configurable-item select:focus {
+    outline: none;
+    border-color: var(--blue-500);
+  }
+  .demo-configurable-item--toggle {
+    display: flex;
+    align-items: center;
+  }
+  .demo-configurable-item--toggle swim-toggle {
+    margin-top: var(--spacing-8);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/progress-spinner.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/progress-spinner.html
@@ -1,89 +1,10 @@
-<style>
-  .progress-spinner-configurable-layout {
-    display: grid;
-    grid-template-columns: minmax(200px, 280px) 1fr;
-    gap: 2rem;
-    align-items: start;
-  }
-  @media (max-width: 720px) {
-    .progress-spinner-configurable-layout {
-      grid-template-columns: 1fr;
-    }
-  }
-  .progress-spinner-configurable-controls {
-    position: sticky;
-    top: 1rem;
-  }
-  .progress-spinner-configurable-controls .demo-configurable-grid {
-    grid-template-columns: 1fr;
-  }
-  .progress-spinner-configurable-live {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    min-width: 0;
-  }
-  .progress-spinner-configurable-preview {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 220px;
-    padding: var(--spacing-24, 24px);
-    background: var(--grey-800);
-    border-radius: var(--radius-4);
-    border: 1px solid var(--grey-750);
-  }
-  .progress-spinner-configurable-code {
-    margin: 0;
-  }
-  .progress-spinner-configurable-code code {
-    white-space: pre;
-    font-size: 0.8rem;
-  }
-  .demo-configurable-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-    gap: 1rem;
-    align-items: end;
-  }
-  .demo-configurable-item label {
-    display: block;
-    font-size: var(--font-size-s, 0.875rem);
-    color: var(--grey-300);
-    margin-bottom: 0.25rem;
-  }
-  .demo-configurable-item input,
-  .demo-configurable-item select {
-    width: 100%;
-    min-width: 0;
-    height: 36px;
-    padding: 0 0.5rem;
-    background: var(--grey-800);
-    border: 1px solid var(--grey-700);
-    border-radius: var(--radius-4);
-    color: var(--grey-050);
-    font-size: 0.9375rem;
-  }
-  .demo-configurable-item input:focus,
-  .demo-configurable-item select:focus {
-    outline: none;
-    border-color: var(--blue-500);
-  }
-  .demo-configurable-item--toggle {
-    display: flex;
-    align-items: center;
-  }
-  .demo-configurable-item--toggle swim-toggle {
-    margin-top: 0.5rem;
-  }
-</style>
-
+<div class="progress-spinner-page">
 <h1 id="progress-spinner" class="page-title">Progress Spinner</h1>
 <p class="subtitle">
   Circular progress indicator matching swim-progress-spinner (swim-ui): determinate or indeterminate mode, optional center icons
   (upload, success, failure), and optional labels.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/progress-spinner.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/progress-spinner.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Configurable (live)">
@@ -428,3 +349,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/radio.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/radio.css
@@ -1,0 +1,10 @@
+.radio-page {
+  .api-tag-gap {
+    margin-top: var(--spacing-20);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/radio.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/radio.html
@@ -1,3 +1,4 @@
+<div class="radio-page">
 <hr class="section-divider" />
 
 <h1 id="radio" class="page-title">Radio Buttons</h1>
@@ -5,7 +6,7 @@
   Radio controls matching swim-radio (swim-ui): use <code>swim-radio</code> alone (controlled by parent) or inside
   <code>swim-radio-group</code>. Arrow keys move focus and selection in a group. Supports form association on the group.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/radio.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/radio.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Single radio buttons">
@@ -130,7 +131,7 @@
           </tbody>
         </table>
       </div>
-      <div style="margin-top:1.25rem"><span class="api-tag-name">&lt;swim-radio&gt;</span></div>
+      <div class="api-tag-gap"><span class="api-tag-name">&lt;swim-radio&gt;</span></div>
       <h4 class="api-heading">Child Properties</h4>
       <div class="api-table-wrap">
         <table class="api-table">
@@ -144,3 +145,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/scrollbars.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/scrollbars.css
@@ -1,0 +1,31 @@
+.scrollbars-page {
+  .scrollbars-demo-box {
+    height: 300px;
+    width: 300px;
+    border: 1px solid var(--grey-600);
+  }
+  .scrollbars-demo-box--default {
+    overflow: auto;
+  }
+  .scrollbars-demo-content {
+    min-height: 520px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-16);
+    padding: var(--spacing-8);
+  }
+  /* icon-class is reflected to the host, so .scrollbars-demo-icon matches and font-size inherits into the icon */
+  .scrollbars-demo-icon {
+    font-size: 300px;
+  }
+
+  .muted-sm {
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-12);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/scrollbars.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/scrollbars.html
@@ -1,30 +1,10 @@
-<style>
-  .scrollbars-demo-box {
-    height: 300px;
-    width: 300px;
-    border: 1px solid var(--grey-600);
-  }
-  .scrollbars-demo-box--default {
-    overflow: auto;
-  }
-  .scrollbars-demo-content {
-    min-height: 520px;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-16);
-    padding: var(--spacing-8);
-  }
-  /* icon-class is reflected to the host, so .scrollbars-demo-icon matches and font-size inherits into the icon */
-  .scrollbars-demo-icon {
-    font-size: 300px;
-  }
-</style>
+<div class="scrollbars-page">
 <h1 id="scrollbars" class="page-title">Scrollbars</h1>
 <p class="subtitle">
   Utility classes for styled scrollbars matching swim-ui. Apply to scrollable elements (with overflow) or to body for
   global scrollbars.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/styles.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/styles.js';</code></p>
 
 <section class="section">
   <swim-section section-title="swim-scroll">
@@ -100,7 +80,7 @@
 <section class="section">
   <swim-section section-title="API Reference" section-collapsed>
     <div class="api-ref">
-      <p style="color: var(--grey-300); margin-bottom: 0.75rem">
+      <p class="muted-sm">
         Scrollbar styling is applied via CSS utility classes. No custom element required — add the class to any scrollable container.
       </p>
       <h4 class="api-heading">CSS Classes</h4>
@@ -117,3 +97,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/section.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/section.css
@@ -1,0 +1,27 @@
+.section-page {
+  .cdn-tight {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-12);
+  }
+
+  .api-tag-gap {
+    margin-top: var(--spacing-20);
+  }
+
+  .host-section-theme {
+    --swim-section-background: var(--grey-850);
+    --swim-section-header-background: var(--grey-800);
+    --swim-section-header-hover-background: var(--blue-500);
+    --swim-section-content-background: var(--grey-825);
+  }
+
+  .desc-readable {
+    margin-top: var(--spacing-0);
+    max-width: 48rem;
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/section.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/section.html
@@ -1,3 +1,4 @@
+<div class="section-page">
 <hr class="section-divider" />
 
 <h1 id="section" class="page-title">Section</h1>
@@ -6,7 +7,7 @@
   <code>section-title</code> or <code>swim-section-header</code> for custom header content. Supports legacy, outline,
   light, and minimal appearances.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/section.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/section.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Title and content">
@@ -141,7 +142,7 @@
 
 <section class="section">
   <swim-section section-title="Theming (CSS custom properties)">
-    <p class="section-desc" style="margin-top: 0; max-width: 48rem">
+    <p class="section-desc desc-readable">
       Set <code>--swim-section-*</code> on <code>&lt;swim-section&gt;</code> (or an ancestor). They override the token
       fallbacks for each <code>appearance</code>. <code>--swim-section-header-hover-background</code> fills the
       <strong>entire header row</strong> on hover when the section can be toggled (<code>header-toggle</code> or the
@@ -150,20 +151,15 @@
     <div class="demo-row demo-row--column">
       <div class="demo-label">Custom surfaces (hover the header)</div>
       <swim-section
+        class="host-section-theme"
         id="section-css-vars-demo"
         section-title="Themed section"
         header-toggle
-        style="
-          --swim-section-background: var(--grey-850);
-          --swim-section-header-background: var(--grey-800);
-          --swim-section-header-hover-background: var(--blue-500);
-          --swim-section-content-background: var(--grey-825);
-        "
       >
-        Host, header, content, and header hover colors are driven by the <code>style</code> attribute on this element.
+        Host, header, content, and header hover colors are driven by CSS custom properties on this element.
       </swim-section>
     </div>
-    <h4 class="api-heading" style="margin-top: 1.25rem">Available overrides</h4>
+    <h4 class="api-heading api-tag-gap">Available overrides</h4>
     <div class="api-table-wrap">
       <table class="api-table">
         <thead>
@@ -259,7 +255,7 @@
         </table>
       </div>
       <h4 class="api-heading">CSS custom properties</h4>
-      <p class="section-desc" style="margin-top: 0; margin-bottom: 0.75rem">
+      <p class="section-desc cdn-tight">
         Optional host overrides (see <strong>Theming (CSS custom properties)</strong> in the demo above).
       </p>
       <div class="api-table-wrap">
@@ -285,3 +281,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/select.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.css
@@ -1,0 +1,97 @@
+.select-page {
+  .select-demo-empty {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-12);
+    color: var(--grey-200);
+  }
+  .select-demo-empty swim-icon {
+    font-size: var(--font-size-xl);
+    color: var(--grey-350);
+    margin-top: var(--spacing-2);
+  }
+
+  .mt-lg {
+    margin-top: var(--spacing-24);
+  }
+
+  .muted {
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-16);
+  }
+
+  .ml-sm {
+    margin-left: var(--spacing-8);
+  }
+
+  .mt {
+    margin-top: var(--spacing-16);
+  }
+
+  .narrow {
+    max-width: 500px;
+  }
+
+  .stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-16);
+    max-width: 500px;
+  }
+
+  .hint-sm {
+    font-size: var(--font-size-s);
+    color: var(--grey-350);
+    margin-top: var(--spacing-4);
+  }
+
+  .value {
+    font-size: var(--font-size-s);
+    color: var(--grey-350);
+    margin: var(--spacing-0);
+  }
+
+  .value code {
+    color: var(--grey-200);
+  }
+
+  .stack-sm {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-12);
+    max-width: 500px;
+  }
+
+  .link-accent {
+    color: var(--blue-400);
+  }
+
+  .narrow-mb {
+    max-width: 500px;
+    margin-bottom: var(--spacing-16);
+  }
+
+  .subhead-spaced {
+    font-size: var(--font-size-m);
+    font-weight: var(--font-weight-semibold);
+    margin: var(--spacing-24) var(--spacing-0) var(--spacing-8);
+    color: var(--grey-300);
+  }
+
+  .subhead {
+    font-size: var(--font-size-m);
+    font-weight: var(--font-weight-semibold);
+    margin-bottom: var(--spacing-8);
+    color: var(--grey-300);
+  }
+
+  .muted-lg {
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-20);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/select.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.html
@@ -2,6 +2,19 @@
 <h1 id="select" class="page-title">Select Component</h1>
 <p class="subtitle">Dropdown select with filtering and multi-select support</p>
 <p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/select.js';</code></p>
+<style>
+  .select-demo-empty {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    color: var(--grey-200);
+  }
+  .select-demo-empty swim-icon {
+    font-size: 1.25rem;
+    color: var(--grey-350);
+    margin-top: 0.1rem;
+  }
+</style>
 
 <!-- Single Select (mirrors ngx-ui selects-page: Basic, Required) -->
 <section class="section">
@@ -24,6 +37,14 @@
         value="breach"
       ></swim-select>
     </div>
+    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Custom hint slot</h4>
+    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+      <swim-select id="customHintSelect" label="Attack Type" placeholder="Select...">
+        <span slot="hint">
+          Prefer <a href="#select" style="color: var(--blue-400)">this guide</a> before choosing.
+        </span>
+      </swim-select>
+    </div>
     <pre class="demo-pre"
     ><code>&lt;!-- Basic --&gt;
 &lt;swim-select label="Attack Type" placeholder="Select..."&gt;&lt;/swim-select&gt;
@@ -33,6 +54,13 @@
 
 &lt;!-- Disabled (with pre-selected value) --&gt;
 &lt;swim-select label="Attack Type" disabled placeholder="Select..." value="breach"&gt;&lt;/swim-select&gt;
+
+&lt;!-- Custom hint (slot) --&gt;
+&lt;swim-select label="Attack Type" placeholder="Select..."&gt;
+  &lt;span slot="hint"&gt;
+    Prefer &lt;a href="#"&gt;this guide&lt;/a&gt; before choosing.
+  &lt;/span&gt;
+&lt;/swim-select&gt;
 
 &lt;script&gt;
   const options = [
@@ -359,6 +387,46 @@
   </swim-section>
 </section>
 
+<!-- Custom empty state -->
+<section class="section">
+  <swim-section section-title="Custom empty state">
+    <p style="color: var(--grey-300); margin-bottom: 1rem">
+      Pass custom markup with <code>slot="empty"</code> to replace the default
+      <code>empty-placeholder</code> / <code>filter-empty-placeholder</code> text when the list has
+      nothing to show. While <code>loading</code>, the string
+      <code>filter-searching-placeholder</code> is still used.
+    </p>
+    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+      <swim-select
+        id="customEmptySelect"
+        label="Search countries"
+        placeholder="Select a country..."
+        filterable
+        filter-placeholder="Try typing zzzz…"
+        hint="Open and filter until nothing matches to see the custom empty template"
+      >
+        <div slot="empty" class="select-demo-empty">
+          <swim-icon font-icon="search"></swim-icon>
+          <div>
+            <strong>No countries match</strong>
+            <div style="font-size: var(--font-size-s); color: var(--grey-350); margin-top: 0.25rem">
+              Clear the filter or try another name.
+            </div>
+          </div>
+        </div>
+      </swim-select>
+    </div>
+    <pre class="demo-pre"
+    ><code>&lt;swim-select label="Search countries" filterable&gt;
+  &lt;div slot="empty"&gt;
+    &lt;swim-icon font-icon="search"&gt;&lt;/swim-icon&gt;
+    &lt;strong&gt;No countries match&lt;/strong&gt;
+    &lt;div&gt;Clear the filter or try another name.&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/swim-select&gt;</code></pre>
+  </swim-section>
+</section>
+
 <!-- Select States Section -->
 <section class="section">
   <swim-section section-title="Select States">
@@ -512,6 +580,17 @@
             <tr><td><code>disabled</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Whether the option is disabled</td></tr>
             <tr><td><code>hidden</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Whether the option is hidden from the list</td></tr>
             <tr><td><code>group</code></td><td><code>string</code></td><td><code>''</code></td><td>Section label (with parent <code>grouped</code> on <code>swim-select</code>)</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <h4 class="api-heading">Slots</h4>
+      <div class="api-table-wrap">
+        <table class="api-table">
+          <thead><tr><th>Name</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><em>(default)</em></td><td><code>swim-option</code> children for declarative options</td></tr>
+            <tr><td><code>hint</code></td><td>Custom hint content below the select</td></tr>
+            <tr><td><code>empty</code></td><td>Custom empty-state when the dropdown has no options to show (overrides string placeholders; not used while <code>loading</code>)</td></tr>
           </tbody>
         </table>
       </div>

--- a/projects/swimlane/swim-ui/demo/public/sections/select.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.html
@@ -326,17 +326,32 @@
         label="Search countries"
         placeholder="Select a country..."
         filterable
-        hint="Type to filter options"
+        hint="Type to filter options (default search icon)"
+      ></swim-select>
+      <swim-select
+        id="filterIconSelect"
+        label="Custom filter icon"
+        placeholder="Select a country..."
+        filterable
+        filter-icon="globe"
+        hint='filter-icon="globe" (any swim-icon name)'
       ></swim-select>
       <swim-select id="noFilterSelect" label="No Filter" placeholder="Select..." filterable="false"></swim-select>
     </div>
     <pre class="demo-pre"
-    ><code>&lt;!-- Filterable (default: true) --&gt;
+    ><code>&lt;!-- Filterable (default: true) — filter shows search icon by default --&gt;
 &lt;swim-select
   label="Search countries"
   placeholder="Select a country..."
   filterable
   hint="Type to filter options"
+&gt;&lt;/swim-select&gt;
+
+&lt;!-- Override filter icon with any swim-icon name --&gt;
+&lt;swim-select
+  label="Custom filter icon"
+  filterable
+  filter-icon="globe"
 &gt;&lt;/swim-select&gt;
 
 &lt;!-- Filtering disabled --&gt;
@@ -475,6 +490,7 @@
             <tr><td><code>.options</code></td><td><code>Array&lt;SelectOption&gt;</code></td><td><code>[]</code></td><td>Options; may include <code>group</code> when <code>grouped</code> is set</td></tr>
             <tr><td><code>multiple</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Enable multi-select mode</td></tr>
             <tr><td><code>filterable</code></td><td><code>boolean</code></td><td><code>true</code></td><td>Enable type-to-filter</td></tr>
+            <tr><td><code>filter-icon</code></td><td><code>string</code></td><td><code>'search'</code></td><td>Filter field icon name (swim-icon <code>font-icon</code>); empty hides icon</td></tr>
             <tr><td><code>dropdown-align</code></td><td><code>'start' | 'center'</code></td><td><code>'start'</code></td><td>With popover layer: <code>center</code> sizes and anchors the panel to the host (centered columns / dialogs)</td></tr>
             <tr><td><code>grouped</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Show section headers from each option’s <code>group</code></td></tr>
             <tr><td><code>allow-clear</code></td><td><code>boolean</code></td><td><code>true</code></td><td>Show clear button when value selected</td></tr>

--- a/projects/swimlane/swim-ui/demo/public/sections/select.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/select.html
@@ -1,34 +1,22 @@
+<div class="select-page">
 <hr class="section-divider" />
 <h1 id="select" class="page-title">Select Component</h1>
 <p class="subtitle">Dropdown select with filtering and multi-select support</p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/select.js';</code></p>
-<style>
-  .select-demo-empty {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.75rem;
-    color: var(--grey-200);
-  }
-  .select-demo-empty swim-icon {
-    font-size: 1.25rem;
-    color: var(--grey-350);
-    margin-top: 0.1rem;
-  }
-</style>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/select.js';</code></p>
 
 <!-- Single Select (mirrors ngx-ui selects-page: Basic, Required) -->
 <section class="section">
   <swim-section section-title="Single Select">
-    <h4 style="font-size: 1rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--grey-300)">Basic</h4>
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <h4 class="subhead">Basic</h4>
+    <div class="stack">
       <swim-select id="basicSelect" label="Attack Type" placeholder="Select..."></swim-select>
     </div>
-    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Required</h4>
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <h4 class="subhead-spaced">Required</h4>
+    <div class="stack">
       <swim-select id="requiredSelect" label="Attack Type" required placeholder="Please select..."></swim-select>
     </div>
-    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Disabled</h4>
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <h4 class="subhead-spaced">Disabled</h4>
+    <div class="stack">
       <swim-select
         id="singleSelectDisabled"
         label="Attack Type"
@@ -37,11 +25,11 @@
         value="breach"
       ></swim-select>
     </div>
-    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Custom hint slot</h4>
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <h4 class="subhead-spaced">Custom hint slot</h4>
+    <div class="stack">
       <swim-select id="customHintSelect" label="Attack Type" placeholder="Select...">
         <span slot="hint">
-          Prefer <a href="#select" style="color: var(--blue-400)">this guide</a> before choosing.
+          Prefer <a class="link-accent" href="#select">this guide</a> before choosing.
         </span>
       </swim-select>
     </div>
@@ -76,10 +64,10 @@
 <!-- Declarative Options (swim-option children) -->
 <section class="section">
   <swim-section section-title="Declarative Options (swim-option)">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Options can be defined inline as <code>&lt;swim-option&gt;</code> children instead of setting the <code>.options</code> property via JavaScript.
     </p>
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-select label="Attack Type" required filterable="false">
         <swim-option name="Breach" value="breach"></swim-option>
         <swim-option name="DDOS" value="ddos"></swim-option>
@@ -112,17 +100,17 @@
 <!-- Grouped options: group -->
 <section class="section">
   <swim-section section-title="Grouped options">
-    <p style="color: var(--grey-300); margin-bottom: 1.25rem">
+    <p class="muted-lg">
       Set <code>grouped</code> on <code>&lt;swim-select&gt;</code> to show section headers from each option’s
       <code>group</code>. Omit <code>grouped</code> and the same data renders as a flat list
       (metadata is still on each option). With <code>grouped</code> and filtering on, typing a section name (e.g.
       “Pantry”) matches options in that section.
     </p>
 
-    <h4 style="font-size: 1rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--grey-300)">
+    <h4 class="subhead">
       Programmatic, with <code>grouped</code>
     </h4>
-    <div style="max-width: 500px; margin-bottom: 1rem">
+    <div class="narrow-mb">
       <swim-select
         id="groupedSelectProgrammatic"
         grouped
@@ -146,10 +134,10 @@
   ];
 &lt;/script&gt;</code></pre>
 
-    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">
+    <h4 class="subhead-spaced">
       Same options without <code>grouped</code> (flat list)
     </h4>
-    <div style="max-width: 500px; margin-bottom: 1rem">
+    <div class="narrow-mb">
       <swim-select
         id="groupedSelectFlat"
         label="Food (flat)"
@@ -173,8 +161,8 @@
   ];
 &lt;/script&gt;</code></pre>
 
-    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Declarative</h4>
-    <div style="max-width: 500px; margin-bottom: 1rem">
+    <h4 class="subhead-spaced">Declarative</h4>
+    <div class="narrow-mb">
       <swim-select grouped label="Drinks (declarative)" placeholder="Select…" filterable="false">
         <swim-option group="Cold" name="Iced tea" value="iced-tea"></swim-option>
         <swim-option group="Cold" name="Soda" value="soda"></swim-option>
@@ -190,8 +178,8 @@
   &lt;swim-option group="Hot" name="Tea" value="hot-tea"&gt;&lt;/swim-option&gt;
 &lt;/swim-select&gt;</code></pre>
 
-    <h4 style="font-size: 1rem; font-weight: 600; margin: 1.5rem 0 0.5rem; color: var(--grey-300)">Multi-select</h4>
-    <div style="max-width: 500px; margin-bottom: 1rem">
+    <h4 class="subhead-spaced">Multi-select</h4>
+    <div class="narrow-mb">
       <swim-select
         id="groupedSelectMulti"
         grouped
@@ -218,7 +206,7 @@
 <!-- Select Appearances Section -->
 <section class="section">
   <swim-section section-title="Select Appearances">
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-select
         id="legacySelect"
         appearance="legacy"
@@ -237,7 +225,7 @@
 <!-- Select Sizes Section -->
 <section class="section">
   <swim-section section-title="Select Sizes">
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-select id="smallSelect" size="sm" label="Small Select" placeholder="Select..."></swim-select>
       <swim-select id="mediumSelect" size="md" label="Medium Select" placeholder="Select..."></swim-select>
       <swim-select id="largeSelect" size="lg" label="Large Select" placeholder="Select..."></swim-select>
@@ -254,7 +242,7 @@
 <!-- Multiple Selection Section -->
 <section class="section">
   <swim-section section-title="Multiple Selection">
-    <div style="max-width: 500px">
+    <div class="narrow">
       <swim-select
         id="multiSelect"
         label="Choose multiple colors"
@@ -286,14 +274,14 @@
 <!-- Remote search: GitHub users -->
 <section class="section">
   <swim-section section-title="Remote search (GitHub users)">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Type at least <strong>2 characters</strong> to search public GitHub users via the
-      <a href="https://docs.github.com/en/rest/search/search#search-users" style="color: var(--blue-400)"
+      <a class="link-accent" href="https://docs.github.com/en/rest/search/search#search-users"
         >Search users</a
       >
       API. Results load after the default <strong>500ms</strong> debounce on <code>filter-change</code>.
     </p>
-    <div style="display: flex; flex-direction: column; gap: 0.75rem; max-width: 500px">
+    <div class="stack-sm">
       <swim-select
         id="githubUserSelect"
         label="GitHub user"
@@ -307,8 +295,8 @@
         dropdown-align="center"
         hint="Uses https://api.github.com/search/users (rate limits apply without auth)."
       ></swim-select>
-      <p style="font-size: var(--font-size-s); color: var(--grey-350); margin: 0">
-        Selected: <code id="githubUserSelectValue" style="color: var(--grey-200)">—</code>
+      <p class="value">
+        Selected: <code id="githubUserSelectValue">—</code>
       </p>
     </div>
     <pre class="demo-pre"
@@ -348,7 +336,7 @@
 <!-- Filtering Section -->
 <section class="section">
   <swim-section section-title="With Filtering">
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-select
         id="filterableSelect"
         label="Search countries"
@@ -390,13 +378,13 @@
 <!-- Custom empty state -->
 <section class="section">
   <swim-section section-title="Custom empty state">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">
+    <p class="muted">
       Pass custom markup with <code>slot="empty"</code> to replace the default
       <code>empty-placeholder</code> / <code>filter-empty-placeholder</code> text when the list has
       nothing to show. While <code>loading</code>, the string
       <code>filter-searching-placeholder</code> is still used.
     </p>
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-select
         id="customEmptySelect"
         label="Search countries"
@@ -409,7 +397,7 @@
           <swim-icon font-icon="search"></swim-icon>
           <div>
             <strong>No countries match</strong>
-            <div style="font-size: var(--font-size-s); color: var(--grey-350); margin-top: 0.25rem">
+            <div class="hint-sm">
               Clear the filter or try another name.
             </div>
           </div>
@@ -430,7 +418,7 @@
 <!-- Select States Section -->
 <section class="section">
   <swim-section section-title="Select States">
-    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 500px">
+    <div class="stack">
       <swim-select id="normalSelect" label="Normal" placeholder="Select..."></swim-select>
       <swim-select id="withValueSelect" label="With Value" placeholder="Select..." value="option2"></swim-select>
       <swim-select id="disabledSelect" label="Disabled" placeholder="Select..." disabled></swim-select>
@@ -454,7 +442,7 @@
 <!-- Form Integration Section -->
 <section class="section">
   <swim-section section-title="Form Integration">
-    <form id="selectForm" style="max-width: 500px">
+    <form class="narrow" id="selectForm">
       <swim-select
         id="formSelect1"
         name="category"
@@ -473,9 +461,9 @@
         hint="Select one or more tags"
       ></swim-select>
 
-      <div style="margin-top: 1rem">
+      <div class="mt">
         <swim-button type="submit" variant="primary">Submit Form</swim-button>
-        <swim-button type="reset" variant="bordered" style="margin-left: 0.5rem">Reset</swim-button>
+        <swim-button class="ml-sm" type="reset" variant="bordered">Reset</swim-button>
       </div>
     </form>
     <pre class="demo-pre"
@@ -515,7 +503,7 @@
 <!-- Select Usage Section -->
 <section class="section">
   <swim-section section-title="Select Usage">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">Import and use the select component in your application:</p>
+    <p class="muted">Import and use the select component in your application:</p>
     <pre class="demo-pre"
     ><code>&lt;script type="module"&gt;
   import '@swimlane/swim-ui/select';
@@ -569,7 +557,7 @@
           </tbody>
         </table>
       </div>
-      <div style="margin-top: 1.5rem"><span class="api-tag-name">&lt;swim-option&gt;</span></div>
+      <div class="mt-lg"><span class="api-tag-name">&lt;swim-option&gt;</span></div>
       <h4 class="api-heading">Properties (swim-option)</h4>
       <div class="api-table-wrap">
         <table class="api-table">
@@ -609,3 +597,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/slider.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/slider.css
@@ -1,0 +1,6 @@
+.slider-page {
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/slider.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/slider.html
@@ -1,3 +1,4 @@
+<div class="slider-page">
 <hr class="section-divider" />
 
 <h1 id="slider" class="page-title">Slider</h1>
@@ -5,7 +6,7 @@
   Range slider matching swim-slider (swim-ui): single or multiple thumbs, optional filled track and tick marks, horizontal or
   vertical. Form-associated; supports min, max, step, and change events.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/slider.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/slider.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Basic">
@@ -157,3 +158,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/split.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/split.css
@@ -1,0 +1,33 @@
+.split-page {
+  .split-example {
+    height: 500px;
+    margin: var(--spacing-20) var(--spacing-0);
+  }
+  .demo-split-panel-left {
+    background: var(--grey-700);
+    padding: var(--spacing-16);
+  }
+  .demo-split-panel-right {
+    background: var(--grey-600);
+    padding: var(--spacing-16);
+  }
+  .demo-split-panel-header {
+    flex: 0 0 50px;
+    background: var(--grey-750);
+    padding: var(--spacing-16);
+  }
+  .demo-split-nested-wrap {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .api-tag-gap {
+    margin-top: var(--spacing-20);
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/split.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/split.html
@@ -1,35 +1,11 @@
-<style>
-  .split-example {
-    height: 500px;
-    margin: 20px 0;
-  }
-  .demo-split-panel-left {
-    background: var(--grey-700);
-    padding: var(--spacing-16);
-  }
-  .demo-split-panel-right {
-    background: var(--grey-600);
-    padding: var(--spacing-16);
-  }
-  .demo-split-panel-header {
-    flex: 0 0 50px;
-    background: var(--grey-750);
-    padding: var(--spacing-16);
-  }
-  .demo-split-nested-wrap {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
-</style>
-
+<div class="split-page">
 <h1 id="split" class="page-title">Split</h1>
 <p class="subtitle">
   Resizable split layout. Use <code>swim-split</code> with <code>swim-split-area</code> and
   <code>swim-split-handle</code> as direct children. Drag the handle to resize; double-click the handle to snap to min
   or max.
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/split.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/split.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Split areas (row)">
@@ -200,7 +176,7 @@
           </tbody>
         </table>
       </div>
-      <div style="margin-top:1.25rem"><span class="api-tag-name">&lt;swim-split-area / swim-split-handle&gt;</span></div>
+      <div class="api-tag-gap"><span class="api-tag-name">&lt;swim-split-area / swim-split-handle&gt;</span></div>
       <h4 class="api-heading">Child Properties</h4>
       <div class="api-table-wrap">
         <table class="api-table">
@@ -213,3 +189,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/tabs.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/tabs.css
@@ -1,0 +1,19 @@
+.tabs-page {
+  .api-tag-gap {
+    margin-top: var(--spacing-20);
+  }
+
+  .muted {
+    color: var(--grey-300);
+    margin-bottom: var(--spacing-16);
+  }
+
+  .medium {
+    max-width: 600px;
+  }
+
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/tabs.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/tabs.html
@@ -1,14 +1,15 @@
+<div class="tabs-page">
 <hr class="section-divider" />
 
 <!-- TABS COMPONENT DEMOS (mirrors ngx-ui components/tabs-page) -->
 <h1 id="tabs" class="page-title">Tabs Component</h1>
 <p class="subtitle">Tabbed content with legacy/light appearance and horizontal/vertical layout</p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/tabs.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/tabs.js';</code></p>
 
 <!-- Basic Tabs (mirrors ngx-ui Basic Tabs) -->
 <section class="section">
   <swim-section section-title="Basic Tabs">
-    <div style="max-width: 600px">
+    <div class="medium">
       <swim-tabs id="basicTabs">
         <swim-tab label="Tab 1" active>Content for tab 1.</swim-tab>
         <swim-tab label="Tab 2">Content for tab 2.</swim-tab>
@@ -27,7 +28,7 @@
 <!-- Light Appearance Section -->
 <section class="section">
   <swim-section section-title="Light Appearance">
-    <div style="max-width: 600px">
+    <div class="medium">
       <swim-tabs appearance="light">
         <swim-tab label="Overview" active>Overview panel content.</swim-tab>
         <swim-tab label="Details">Details panel content.</swim-tab>
@@ -46,7 +47,7 @@
 <!-- Vertical Tabs Section -->
 <section class="section">
   <swim-section section-title="Vertical Tabs">
-    <div style="max-width: 600px">
+    <div class="medium">
       <swim-tabs vertical>
         <swim-tab label="First" active>First tab content.</swim-tab>
         <swim-tab label="Second">Second tab content.</swim-tab>
@@ -65,7 +66,7 @@
 <!-- Vertical + Light Section -->
 <section class="section">
   <swim-section section-title="Vertical + Light">
-    <div style="max-width: 600px">
+    <div class="medium">
       <swim-tabs vertical appearance="light">
         <swim-tab label="Item A" active>Item A content.</swim-tab>
         <swim-tab label="Item B">Item B content.</swim-tab>
@@ -84,7 +85,7 @@
 <!-- Tabs with Disabled Section -->
 <section class="section">
   <swim-section section-title="With Disabled Tab">
-    <div style="max-width: 600px">
+    <div class="medium">
       <swim-tabs>
         <swim-tab label="Active" active>This tab is active.</swim-tab>
         <swim-tab label="Disabled" disabled>This tab is disabled.</swim-tab>
@@ -103,7 +104,7 @@
 <!-- Tabs Usage Section -->
 <section class="section">
   <swim-section section-title="Tabs Usage">
-    <p style="color: var(--grey-300); margin-bottom: 1rem">Import and use the tabs component in your application:</p>
+    <p class="muted">Import and use the tabs component in your application:</p>
     <pre class="demo-pre"
     ><code>&lt;script type="module"&gt;
   import '@swimlane/swim-ui';
@@ -140,7 +141,7 @@
           </tbody>
         </table>
       </div>
-      <div style="margin-top:1.25rem"><span class="api-tag-name">&lt;swim-tab&gt;</span></div>
+      <div class="api-tag-gap"><span class="api-tag-name">&lt;swim-tab&gt;</span></div>
       <h4 class="api-heading">Child Properties</h4>
       <div class="api-table-wrap">
         <table class="api-table">
@@ -155,3 +156,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/toggle.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/toggle.css
@@ -1,0 +1,6 @@
+.toggle-page {
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/toggle.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/toggle.html
@@ -1,3 +1,4 @@
+<div class="toggle-page">
 <hr class="section-divider" />
 
 <h1 id="toggle" class="page-title">Toggle</h1>
@@ -5,7 +6,7 @@
   Toggle (switch) control matching swim-toggle (swim-ui): on/off state, optional check/x icons in the track, label or slot.
   Supports form association and keyboard (Space/Enter to toggle).
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/toggle.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/toggle.js';</code></p>
 
 <section class="section">
   <swim-section section-title="Basic">
@@ -120,3 +121,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/public/sections/tooltip.css
+++ b/projects/swimlane/swim-ui/demo/public/sections/tooltip.css
@@ -1,0 +1,6 @@
+.tooltip-page {
+  .cdn {
+    margin-top: var(--spacing-0);
+    margin-bottom: var(--spacing-24);
+  }
+}

--- a/projects/swimlane/swim-ui/demo/public/sections/tooltip.html
+++ b/projects/swimlane/swim-ui/demo/public/sections/tooltip.html
@@ -1,9 +1,10 @@
+<div class="tooltip-page">
 <hr class="section-divider" />
 <h1 id="tooltip" class="page-title">Tooltip</h1>
 <p class="subtitle">
   Wrap any element to show a compact tooltip on hover or focus. Supports placement (top, right, bottom, left) and type (tooltip or popover).
 </p>
-<p class="section-desc" style="margin-top: 0; margin-bottom: 1.5rem;"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/tooltip.js';</code></p>
+<p class="section-desc cdn"><strong>CDN:</strong> <code>import 'https://widgets.swimlane.app/swim-ui/tooltip.js';</code></p>
 <section class="section">
   <swim-section section-title="Tooltip">
     <p class="section-desc">Compact tooltips by placement. Hover or focus to show.</p>
@@ -193,3 +194,4 @@
     </div>
   </swim-section>
 </section>
+</div>

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -425,6 +425,9 @@ function setupSelectDemos(): void {
   const basicSelect = document.getElementById('basicSelect') as any;
   if (basicSelect) basicSelect.options = attackTypeOptions;
 
+  const customHintSelect = document.getElementById('customHintSelect') as any;
+  if (customHintSelect) customHintSelect.options = attackTypeOptions;
+
   const groupedOptionsDemo = [
     { name: 'Apples', value: 'apples', group: 'Produce' },
     { name: 'Carrots', value: 'carrots', group: 'Produce' },
@@ -517,6 +520,9 @@ function setupSelectDemos(): void {
 
   const filterIconSelect = document.getElementById('filterIconSelect') as any;
   if (filterIconSelect) filterIconSelect.options = countries;
+
+  const customEmptySelect = document.getElementById('customEmptySelect') as any;
+  if (customEmptySelect) customEmptySelect.options = countries;
 
   setupGithubUserAsyncSelect('githubUserSelect', 'githubUserSelectValue');
   setupGithubUserAsyncSelect('dialogMediumGithubUserSelect', 'dialogMediumGithubUserSelectValue');

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -515,6 +515,9 @@ function setupSelectDemos(): void {
   const filterableSelect = document.getElementById('filterableSelect') as any;
   if (filterableSelect) filterableSelect.options = countries;
 
+  const filterIconSelect = document.getElementById('filterIconSelect') as any;
+  if (filterIconSelect) filterIconSelect.options = countries;
+
   setupGithubUserAsyncSelect('githubUserSelect', 'githubUserSelectValue');
   setupGithubUserAsyncSelect('dialogMediumGithubUserSelect', 'dialogMediumGithubUserSelectValue');
 

--- a/projects/swimlane/swim-ui/demo/src/demo-init.ts
+++ b/projects/swimlane/swim-ui/demo/src/demo-init.ts
@@ -109,12 +109,9 @@ function setupEventBubblingMatrixDemo(): void {
   if (mount && !mount.querySelector('[data-matrix-shadow-demo]')) {
     const host = document.createElement('div');
     host.dataset.matrixShadowDemo = '';
-    host.setAttribute(
-      'style',
-      'padding:1rem;background:var(--grey-800);border-radius:4px;border:1px solid var(--grey-600)'
-    );
+    host.className = 'matrix-shadow-host';
     const title = document.createElement('div');
-    title.style.cssText = 'font-size:0.875rem;color:var(--grey-300);margin-bottom:0.5rem';
+    title.className = 'matrix-shadow-title';
     title.textContent = 'Shadow host (open shadow contains swim-checkbox below)';
     host.appendChild(title);
     const shadow = host.attachShadow({ mode: 'open' });
@@ -188,6 +185,22 @@ async function loadSection(sectionId: string): Promise<string> {
   return html;
 }
 
+function loadSectionCss(sectionId: string): Promise<void> {
+  const linkId = `section-css-${sectionId}`;
+  if (document.getElementById(linkId)) {
+    return Promise.resolve();
+  }
+  return new Promise(resolve => {
+    const link = document.createElement('link');
+    link.id = linkId;
+    link.rel = 'stylesheet';
+    link.href = `${getDemoBasePath()}sections/${sectionId}.css`;
+    link.onload = () => resolve();
+    link.onerror = () => resolve();
+    document.head.appendChild(link);
+  });
+}
+
 function getSectionIdFromHash(): string {
   const hash = window.location.hash.slice(1).toLowerCase();
   return SECTION_SET.has(hash) ? hash : DEFAULT_SECTION;
@@ -201,7 +214,7 @@ async function showSection(sectionId: string): Promise<void> {
     cyclingStateIntervalId = null;
   }
   try {
-    const html = await loadSection(sectionId);
+    const [html] = await Promise.all([loadSection(sectionId), loadSectionCss(sectionId)]);
     container.innerHTML = html;
     setupDemos();
   } catch (err) {

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -27,6 +27,7 @@ import './select-option.component';
  *
  * @slot - swim-option children for declarative options
  * @slot hint - Custom hint content
+ * @slot empty - Custom empty-state content when the dropdown has no options to show
  *
  * @fires change - Fired when selection changes (does not bubble; listen on this element).
  * @fires dropdown-open - Options panel opened (does not bubble).
@@ -35,6 +36,7 @@ import './select-option.component';
  *
  * @csspart select - The select input element
  * @csspart dropdown - The dropdown container
+ * @csspart empty - The empty-state container (string placeholder or slotted content)
  */
 const SELECT_TAG = 'swim-select';
 
@@ -296,6 +298,10 @@ export class SwimSelect extends LitElement {
   @state()
   private _hasSlottedHint = false;
 
+  /** Direct child assigned to `slot="empty"` (kept in sync via `_setupChildObserver`). */
+  @state()
+  private _hasSlottedEmpty = false;
+
   @state()
   private _open = false;
 
@@ -340,6 +346,7 @@ export class SwimSelect extends LitElement {
     super.connectedCallback();
     this._collectSlottedOptions();
     this._syncSlottedHintPresence();
+    this._syncSlottedEmptyPresence();
     this._setupChildObserver();
     this._updateActiveState();
   }
@@ -386,10 +393,18 @@ export class SwimSelect extends LitElement {
     }
   }
 
+  private _syncSlottedEmptyPresence() {
+    const next = Array.from(this.children).some(el => el.slot === 'empty');
+    if (next !== this._hasSlottedEmpty) {
+      this._hasSlottedEmpty = next;
+    }
+  }
+
   private _setupChildObserver() {
     this._childObserver = new MutationObserver(() => {
       this._collectSlottedOptions();
       this._syncSlottedHintPresence();
+      this._syncSlottedEmptyPresence();
     });
     this._childObserver.observe(this, {
       childList: true,
@@ -616,7 +631,7 @@ export class SwimSelect extends LitElement {
                             }
                           </ul>
                         `
-                      : html`<div class="select-empty">${this._emptyDropdownMessage()}</div>`
+                      : this._renderEmptyState()
                   }
                 </div>
               `
@@ -699,6 +714,16 @@ export class SwimSelect extends LitElement {
         : this.emptyPlaceholder;
     }
     return this.filterEmptyPlaceholder;
+  }
+
+  // Renders empty dropdown content or custom empty slot
+  private _renderEmptyState() {
+    const useEmptySlot = this._hasSlottedEmpty && !this.loading;
+    return html`
+      <div class="select-empty ${useEmptySlot ? 'select-empty--custom' : ''}" part="empty">
+        ${useEmptySlot ? html`<slot name="empty"></slot>` : this._emptyDropdownMessage()}
+      </div>
+    `;
   }
 
   private _renderChip(option: SelectOption) {

--- a/projects/swimlane/swim-ui/src/components/select/select.component.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.component.ts
@@ -85,6 +85,12 @@ export class SwimSelect extends LitElement {
   filterPlaceholder = 'Filter options...';
 
   /**
+   * Icon name for the filter field; '' hides it. Default: 'search'.
+   */
+  @property({ type: String, attribute: 'filter-icon' })
+  filterIcon = 'search';
+
+  /**
    * When the filter matches nothing (sync) or async search returned no users
    */
   @property({ type: String, attribute: 'filter-empty-placeholder' })
@@ -540,19 +546,51 @@ export class SwimSelect extends LitElement {
                     this.filterable
                       ? html`
                           <div
-                            class="select-filter ${this.loading ? 'select-filter--loading' : ''}"
+                            class="select-filter ${this.loading ? 'select-filter--loading' : ''} ${
+                              this.filterIcon ? 'select-filter--has-icon' : ''
+                            }"
                             aria-busy="${this.loading}"
                           >
+                            ${
+                              this.filterIcon
+                                ? html`
+                                    <swim-icon
+                                      class="select-filter-icon"
+                                      font-icon="${this.filterIcon}"
+                                      aria-hidden="true"
+                                    ></swim-icon>
+                                  `
+                                : nothing
+                            }
                             <input
-                              type="text"
+                              type="search"
                               class="select-filter-input"
                               placeholder="${this.filterPlaceholder}"
+                              autocomplete="off"
+                              autocorrect="off"
+                              spellcheck="false"
                               ?disabled="${this.disabled}"
                               ?readonly="${this.loading}"
                               .value="${this._filterQuery}"
                               @input="${this._handleFilterInput}"
                               @keydown="${this._handleFilterKeyDown}"
+                              @change="${(e: Event) => e.stopPropagation()}"
                             />
+                            ${
+                              this._filterQuery
+                                ? html`
+                                    <button
+                                      type="button"
+                                      class="select-filter-clear"
+                                      aria-label="Clear filter"
+                                      ?disabled="${this.disabled || this.loading}"
+                                      @click="${this._clearFilter}"
+                                    >
+                                      <swim-icon font-icon="x"></swim-icon>
+                                    </button>
+                                  `
+                                : nothing
+                            }
                           </div>
                         `
                       : nothing
@@ -812,6 +850,27 @@ export class SwimSelect extends LitElement {
         this._emitFilterChange(q);
       }, this.filterDebounceMs);
     }
+  }
+
+  private _clearFilter(e: Event) {
+    e.stopPropagation();
+    if (this.disabled || this.loading) {
+      return;
+    }
+    this._filterQuery = '';
+    this._focusedIndex = 0;
+    if (this.filterInput) {
+      this.filterInput.value = '';
+      this.filterInput.focus({ preventScroll: true });
+    }
+    if (this.asyncFilter) {
+      if (this._filterDebounceTimer !== undefined) {
+        clearTimeout(this._filterDebounceTimer);
+        this._filterDebounceTimer = undefined;
+      }
+      this._emitFilterChange('');
+    }
+    this.requestUpdate();
   }
 
   private _handleFilterKeyDown(e: KeyboardEvent) {

--- a/projects/swimlane/swim-ui/src/components/select/select.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.styles.ts
@@ -429,6 +429,10 @@ export const selectStyles = css`
     font-style: italic;
   }
 
+  .select-empty--custom {
+    font-style: normal;
+  }
+
   /* Multiple selection */
   :host([multiple]) .select-value {
     display: flex;

--- a/projects/swimlane/swim-ui/src/components/select/select.styles.ts
+++ b/projects/swimlane/swim-ui/src/components/select/select.styles.ts
@@ -274,6 +274,50 @@ export const selectStyles = css`
     border-top-right-radius: var(--radius-4);
   }
 
+  .select-filter-icon,
+  .select-filter-clear {
+    position: absolute;
+    top: 50%;
+    color: var(--grey-350);
+  }
+
+  .select-filter-icon {
+    left: var(--spacing-10);
+    font-size: var(--font-size-s);
+    margin-top: -6px;
+    pointer-events: none;
+    line-height: 1;
+  }
+
+  .select-filter-clear {
+    right: var(--spacing-10);
+    margin-top: -4.5px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: var(--font-size-xxs);
+    line-height: 1;
+    color: var(--grey-350);
+  }
+
+  .select-filter-clear:hover:not(:disabled) {
+    color: var(--grey-300);
+  }
+
+  .select-filter-clear:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .select-filter-clear swim-icon {
+    display: block;
+    font-size: inherit;
+  }
+
   .select-filter-input {
     width: 100%;
     background: transparent;
@@ -283,6 +327,22 @@ export const selectStyles = css`
     font-size: var(--font-size-m);
     font-family: inherit;
     padding: var(--spacing-4);
+    display: block;
+  }
+
+  .select-filter--has-icon .select-filter-input {
+    padding-left: var(--spacing-20);
+  }
+
+  .select-filter:has(.select-filter-clear) .select-filter-input {
+    padding-right: var(--spacing-20);
+  }
+
+  .select-filter-input::-webkit-search-decoration,
+  .select-filter-input::-webkit-search-cancel-button,
+  .select-filter-input::-webkit-search-results-button,
+  .select-filter-input::-webkit-search-results-decoration {
+    -webkit-appearance: none;
   }
 
   .select-filter-input::placeholder {
@@ -297,10 +357,6 @@ export const selectStyles = css`
   .select-filter--loading .select-filter-input {
     opacity: 0.85;
     cursor: wait;
-  }
-
-  .select-filter--loading {
-    position: relative;
   }
 
   .select-options {


### PR DESCRIPTION
## Summary

Updates `swim-select` by following points

- **Filter icon:** default `search` icon on the filter input; override with `filter-icon` (any `swim-icon` name). Pass `filter-icon=""` to hide it.
- **Filter clear:** an `x` button appears when the filter has text and clears the query (parity with ngx-ui).
- **Custom empty state:** `slot="empty"` replaces `empty-placeholder` / `filter-empty-placeholder` when the list has nothing to show. While `loading`, `filter-searching-placeholder` is still used.
- **Demo:** filter icon, custom empty state, and custom `slot="hint"` examples on the select page.

```html
<swim-select label="Country" filterable filter-icon="globe">
  <div slot="empty">
    <strong>No countries match</strong>
  </div>
</swim-select>
```

## Checklist

- [x] *Added unit tests
- [ ] *Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_*required_

## Test plan

- [ ] Open the swim-ui demo (`yarn dev` in `projects/swimlane/swim-ui`) at `/#select`
- [ ] Filterable select shows a search icon; custom example uses `filter-icon="globe"`
- [ ] Typing in the filter shows the clear (`x`) button; clicking it clears the query
- [ ] Custom empty state: filter until no matches and confirm slotted markup is shown
- [ ] Async/loading select still shows `filter-searching-placeholder` instead of the empty slot

[SPT-68046]: https://swimlane.atlassian.net/browse/SPT-68046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ