### PR TITLE
feat(ngx-select): inline tagging chip UX (commit, paste, keyboard, validator)

### DIFF
--- a/cypress/e2e/forms/selects.cy.ts
+++ b/cypress/e2e/forms/selects.cy.ts
@@ -202,18 +202,8 @@ describe('Selects', () => {
       cy.get('@CUT').find('.ngx-select-clear').first().click();
     });
 
-    it('supports free tagging entry and chip editing', () => {
-      cy.get('@SUT').find('ngx-select').eq(1).as('freeTagging');
-
-      cy.get('@freeTagging').find('textarea').type('one,two{enter}');
-      cy.get('@freeTagging').find('.ngx-select-input-option').should('contain.text', 'one');
-      cy.get('@freeTagging').find('.ngx-select-input-option').should('contain.text', 'two');
-
-      cy.get('@freeTagging').find('.ngx-select-input-option').contains('alpha').dblclick();
-      cy.get('@freeTagging').find('textarea').should('have.value', 'alpha');
-    });
-
     it('is keyboard accessible', () => {
+      cy.get('@CUT').clear();
       cy.get('@SUT').find('h4').contains('Basic').realClick();
 
       cy.get('@CUT').within(() => {
@@ -254,6 +244,17 @@ describe('Selects', () => {
 
       // Clears with backspace
       cy.focused().type('{backspace}{backspace}{backspace}'); // For some reason needs three backspaces in testing
+    });
+
+    it('supports free tagging entry and chip editing', () => {
+      cy.get('@SUT').find('ngx-select').eq(1).as('freeTagging');
+
+      cy.get('@freeTagging').find('textarea').type('one,two{enter}');
+      cy.get('@freeTagging').find('.ngx-select-input-option').should('contain.text', 'one');
+      cy.get('@freeTagging').find('.ngx-select-input-option').should('contain.text', 'two');
+
+      cy.get('@freeTagging').find('.ngx-select-input-option').contains('alpha').dblclick();
+      cy.get('@freeTagging').find('textarea').should('have.value', 'alpha');
     });
   });
 

--- a/cypress/e2e/forms/selects.cy.ts
+++ b/cypress/e2e/forms/selects.cy.ts
@@ -184,6 +184,7 @@ describe('Selects', () => {
       const text = 'Other';
 
       // TODO(ngx-ui-testing): support ngxFill for tagging
+      // Basic tagging (with options) still uses <input>; free tagging uses <textarea>.
       cy.get('@CUT').find('input').click().type(text).type('{enter}');
       cy.get('@CUT').ngxGetValue().should('equal', text);
 
@@ -199,6 +200,17 @@ describe('Selects', () => {
 
       cy.get('@CUT').find('.ngx-select-clear').first().click();
       cy.get('@CUT').find('.ngx-select-clear').first().click();
+    });
+
+    it('supports free tagging entry and chip editing', () => {
+      cy.get('@SUT').find('ngx-select').eq(1).as('freeTagging');
+
+      cy.get('@freeTagging').find('textarea').type('one,two{enter}');
+      cy.get('@freeTagging').find('.ngx-select-input-option').should('contain.text', 'one');
+      cy.get('@freeTagging').find('.ngx-select-input-option').should('contain.text', 'two');
+
+      cy.get('@freeTagging').find('.ngx-select-input-option').contains('alpha').dblclick();
+      cy.get('@freeTagging').find('textarea').should('have.value', 'alpha');
     });
 
     it('is keyboard accessible', () => {

--- a/cypress/e2e/forms/selects.cy.ts
+++ b/cypress/e2e/forms/selects.cy.ts
@@ -184,7 +184,6 @@ describe('Selects', () => {
       const text = 'Other';
 
       // TODO(ngx-ui-testing): support ngxFill for tagging
-      // Basic tagging (with options) still uses <input>; free tagging uses <textarea>.
       cy.get('@CUT').find('input').click().type(text).type('{enter}');
       cy.get('@CUT').ngxGetValue().should('equal', text);
 
@@ -246,15 +245,25 @@ describe('Selects', () => {
       cy.focused().type('{backspace}{backspace}{backspace}'); // For some reason needs three backspaces in testing
     });
 
-    it('supports free tagging entry and chip editing', () => {
-      cy.get('@SUT').find('ngx-select').eq(1).as('freeTagging');
+    it('supports inline tagging entry and chip editing', () => {
+      cy.get('@SUT').find('[data-cy=inline-tagging]').as('inlineTagging');
 
-      cy.get('@freeTagging').find('textarea').type('one,two{enter}');
-      cy.get('@freeTagging').find('.ngx-select-input-option').should('contain.text', 'one');
-      cy.get('@freeTagging').find('.ngx-select-input-option').should('contain.text', 'two');
+      cy.get('@inlineTagging').should('have.class', 'fill');
+      cy.get('@inlineTagging').find('textarea').type('one,two{enter}');
+      cy.get('@inlineTagging').find('.ngx-select-input-option').should('contain.text', 'one');
+      cy.get('@inlineTagging').find('.ngx-select-input-option').should('contain.text', 'two');
 
-      cy.get('@freeTagging').find('.ngx-select-input-option').contains('alpha').dblclick();
-      cy.get('@freeTagging').find('textarea').should('have.value', 'alpha');
+      cy.get('@inlineTagging').find('.ngx-select-input-option').contains('alpha').dblclick();
+      cy.get('@inlineTagging').find('textarea').should('have.value', 'alpha');
+    });
+
+    it('supports inline tagging in fill appearance with textarea and chips', () => {
+      cy.get('[data-cy=inline-tagging-fill-autosize]').as('inlineFill');
+
+      cy.get('@inlineFill').should('have.class', 'fill');
+      cy.get('@inlineFill').find('textarea.ngx-select-text-box').should('exist').type('gamma{enter}');
+      cy.get('@inlineFill').find('.ngx-select-input-option').should('contain.text', 'gamma');
+      cy.get('@inlineFill').find('textarea.ngx-select-text-box').should('exist');
     });
   });
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Enhancement (`ngx-select`): Free / no-option tagging now commits with Enter/Tab/comma, cleans bulk paste, commits on blur, supports chip keyboard nav/edit, shows long chip text via tooltip, and accepts an optional `taggingValidator`. Tagging-with-options and other select modes are unchanged.
+
 ## 53.2.2 (2026-09-01)
 
 - Fix (`ngx-list`): Nested flatten/sort no longer assume every dataSource slot is a row object. Virtual/paged lists keep unloaded indexes as `undefined` (length matches totalCount), so search results spanning more than one page no longer throw.

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Enhancement (`ngx-select`): Free / no-option tagging now commits with Enter/Tab/comma, cleans bulk paste, commits on blur, supports chip keyboard nav/edit, shows long chip text via tooltip, and accepts an optional `taggingValidator`. Chip presentation (tooltip/invalid) is precomputed; free tags render as plain text. Tagging-with-options and other select modes are unchanged.
+- Enhancement (`ngx-select`): Inline / no-option tagging now commits with Enter/Tab/comma, cleans bulk paste, commits on blur, supports chip keyboard nav/edit, shows long chip text via tooltip, and accepts an optional `taggingValidator` (inline tagging only). Chip presentation (tooltip/invalid) is precomputed; tags render as plain text. Tagging-with-options and other select modes are unchanged.
 
 ## 53.2.2 (2026-09-01)
 

--- a/projects/swimlane/ngx-ui/CHANGELOG.md
+++ b/projects/swimlane/ngx-ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (unreleased)
 
-- Enhancement (`ngx-select`): Free / no-option tagging now commits with Enter/Tab/comma, cleans bulk paste, commits on blur, supports chip keyboard nav/edit, shows long chip text via tooltip, and accepts an optional `taggingValidator`. Tagging-with-options and other select modes are unchanged.
+- Enhancement (`ngx-select`): Free / no-option tagging now commits with Enter/Tab/comma, cleans bulk paste, commits on blur, supports chip keyboard nav/edit, shows long chip text via tooltip, and accepts an optional `taggingValidator`. Chip presentation (tooltip/invalid) is precomputed; free tags render as plain text. Tagging-with-options and other select modes are unchanged.
 
 ## 53.2.2 (2026-09-01)
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -5,7 +5,7 @@
     (keyup)="onGlobalKeyUp($event)"
     class="ngx-select-input-box"
     (click)="onClick($event)"
-    (focus)="onFocus()"
+    (focusin)="onFocus($event)"
     #inputContainer
   >
     @if (label) {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -4,10 +4,10 @@
     (keydown)="onKeyDown($event)"
     (keyup)="onGlobalKeyUp($event)"
     class="ngx-select-input-box"
-    (click)="onClick()"
+    (click)="onClick($event)"
     (focus)="onFocus()"
     #inputContainer
-    >
+  >
     @if (label) {
       <label class="ngx-select-label" [attr.for]="selectId">
         <span>{{ label }}</span>
@@ -16,7 +16,7 @@
     }
     @if (!selected?.length) {
       @if (placeholder) {
-      <span class="ngx-select-placeholder" [innerHTML]="placeholder"> </span>
+        <span class="ngx-select-placeholder" [innerHTML]="placeholder"> </span>
       } @else if (placeholderTemplate) {
         <div class="ngx-select-placeholder template">
           <ng-container [ngTemplateOutlet]="placeholderTemplate"></ng-container>
@@ -24,25 +24,35 @@
       }
     }
     @if (tagging || selectedOptions?.length) {
-      <ul
-        class="horizontal-list ngx-select-input-list"
-        [class.no-selections]="!selected?.length"
-        >
-        @for (option of selectedOptions; track option) {
+      <ul class="horizontal-list ngx-select-input-list" [class.no-selections]="!selected?.length">
+        @for (option of selectedOptions; track trackChip(option); let index = $index) {
           <li
             class="ngx-select-input-option"
             [class.disabled]="multiple && selectedOptions.length > 1 && option.disabled"
-            >
+            [class.ngx-select-input-option--invalid]="isFreeTagging && !!taggingValidator && isOptionInvalid(option)"
+            [class.ngx-select-input-option--active]="isFreeTagging && selectedChipIndex === index"
+            (click)="onChipClick($event, index)"
+            (dblclick)="onChipDoubleClick($event, index)"
+          >
             @if (option.inputTemplate) {
-              <ng-template
-                [ngTemplateOutlet]="option.inputTemplate"
-                [ngTemplateOutletContext]="{ option: option }"
-                >
+              <ng-template [ngTemplateOutlet]="option.inputTemplate" [ngTemplateOutletContext]="{ option: option }">
               </ng-template>
             }
             @if (!option.inputTemplate) {
-              <span class="ngx-select-input-name" [innerHTML]="option.name || option.value">
-              </span>
+              @if (isFreeTagging) {
+                @let tip = chipTooltip(option);
+                <span
+                  class="ngx-select-input-name"
+                  ngx-tooltip
+                  [tooltipTitle]="tip"
+                  [tooltipDisabled]="!tip"
+                  [tooltipType]="'tooltip'"
+                  [tooltipPlacement]="'top'"
+                  [innerHTML]="option.name || option.value"
+                ></span>
+              } @else {
+                <span class="ngx-select-input-name" [innerHTML]="option.name || option.value"></span>
+              }
             }
             @if (allowClear && (multiple || tagging) && !option.disabled) {
               <button
@@ -50,7 +60,7 @@
                 title="Remove Selection"
                 class="ngx-select-clear"
                 (click)="onOptionRemove($event, option)"
-                >
+              >
                 <i class="ngx-icon ngx-x-small"></i>
               </button>
             }
@@ -58,27 +68,45 @@
         }
         @if (tagging) {
           <li class="ngx-select-input-box-wrapper">
-            <input
-              #tagInput
-              type="search"
-              class="ngx-select-text-box"
-              autocomplete="off"
-              autocorrect="off"
-              spellcheck="off"
-              (keydown)="onInputKeyDown($event)"
-              (keyup)="onInputKeyUp($event)"
-              (change)="$event.stopPropagation()"
-              (blur)="clearInput()"
+            @if (isFreeTagging) {
+              <textarea
+                #tagInput
+                class="ngx-select-text-box"
+                rows="1"
+                [disabled]="disabled"
+                autocomplete="off"
+                autocorrect="off"
+                spellcheck="false"
+                (keydown)="onInputKeyDown($event)"
+                (keyup)="onInputKeyUp($event)"
+                (input)="onInputValueChange()"
+                (paste)="onInputPaste($event)"
+                (change)="$event.stopPropagation()"
+                (blur)="onInputBlur($event)"
+              ></textarea>
+            } @else {
+              <input
+                #tagInput
+                type="search"
+                class="ngx-select-text-box"
+                autocomplete="off"
+                autocorrect="off"
+                spellcheck="off"
+                (keydown)="onInputKeyDown($event)"
+                (keyup)="onInputKeyUp($event)"
+                (change)="$event.stopPropagation()"
+                (blur)="clearInput()"
               />
-            @if (tagInput.value) {
-              <button
-                type="button"
-                aria-label="Clear"
-                class="ngx-select-clear-tagging-input"
-                (click)="onClearTaggingInput($event)"
+              @if (tagInput.value) {
+                <button
+                  type="button"
+                  aria-label="Clear"
+                  class="ngx-select-clear-tagging-input"
+                  (click)="onClearTaggingInput($event)"
                 >
-                <i class="ngx-icon ngx-x-small"></i>
-              </button>
+                  <i class="ngx-icon ngx-x-small"></i>
+                </button>
+              }
             }
           </li>
         }
@@ -94,17 +122,12 @@
           aria-label="Clear Selections"
           class="ngx-select-clear"
           (click)="onClear($event)"
-          >
+        >
           <i class="ngx-icon ngx-x-small"></i>
         </button>
       }
       @if (caretVisible) {
-        <button
-          type="button"
-          aria-label="Toggle Dropdown"
-          class="ngx-select-caret"
-          (click)="onToggle($event)"
-          >
+        <button type="button" aria-label="Toggle Dropdown" class="ngx-select-caret" (click)="onToggle($event)">
           @if (!selectCaret) {
             <i class="ngx-icon ngx-chevron-bold-down"></i>
           }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.html
@@ -23,43 +23,48 @@
         </div>
       }
     }
-    @if (tagging || selectedOptions?.length) {
+    @if (tagging || selectedChips?.length) {
       <ul class="horizontal-list ngx-select-input-list" [class.no-selections]="!selected?.length">
-        @for (option of selectedOptions; track trackChip(option); let index = $index) {
+        @for (chip of selectedChips; track chip.trackBy; let index = $index) {
           <li
             class="ngx-select-input-option"
-            [class.disabled]="multiple && selectedOptions.length > 1 && option.disabled"
-            [class.ngx-select-input-option--invalid]="isFreeTagging && !!taggingValidator && isOptionInvalid(option)"
+            [class.disabled]="multiple && selectedChips.length > 1 && chip.option.disabled"
+            [class.ngx-select-input-option--invalid]="chip.invalid"
             [class.ngx-select-input-option--active]="isFreeTagging && selectedChipIndex === index"
+            [attr.aria-invalid]="chip.invalid ? true : null"
             (click)="onChipClick($event, index)"
             (dblclick)="onChipDoubleClick($event, index)"
           >
-            @if (option.inputTemplate) {
-              <ng-template [ngTemplateOutlet]="option.inputTemplate" [ngTemplateOutletContext]="{ option: option }">
+            @if (chip.option.inputTemplate) {
+              <ng-template
+                [ngTemplateOutlet]="chip.option.inputTemplate"
+                [ngTemplateOutletContext]="{ option: chip.option }"
+              >
               </ng-template>
             }
-            @if (!option.inputTemplate) {
+            @if (!chip.option.inputTemplate) {
               @if (isFreeTagging) {
-                @let tip = chipTooltip(option);
                 <span
                   class="ngx-select-input-name"
                   ngx-tooltip
-                  [tooltipTitle]="tip"
-                  [tooltipDisabled]="!tip"
-                  [tooltipType]="'tooltip'"
-                  [tooltipPlacement]="'top'"
-                  [innerHTML]="option.name || option.value"
-                ></span>
+                  [tooltipTitle]="chip.tooltipTitle"
+                  [tooltipDisabled]="!chip.tooltipTitle"
+                  tooltipType="tooltip"
+                  tooltipPlacement="top"
+                >
+                  {{ chip.labelText }}
+                </span>
               } @else {
-                <span class="ngx-select-input-name" [innerHTML]="option.name || option.value"></span>
+                <span class="ngx-select-input-name" [innerHTML]="chip.option.name || chip.option.value"></span>
               }
             }
-            @if (allowClear && (multiple || tagging) && !option.disabled) {
+            @if (allowClear && (multiple || tagging) && !chip.option.disabled) {
               <button
                 type="button"
                 title="Remove Selection"
+                aria-label="Remove Selection"
                 class="ngx-select-clear"
-                (click)="onOptionRemove($event, option)"
+                (click)="onOptionRemove($event, chip.option)"
               >
                 <i class="ngx-icon ngx-x-small"></i>
               </button>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.spec.ts
@@ -70,7 +70,8 @@ describe('SelectInputComponent', () => {
         preventDefault: () => undefined,
         stopPropagation: () => undefined,
         key: '',
-        target: { value: '' }
+        code: '',
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
       };
     });
 
@@ -82,13 +83,14 @@ describe('SelectInputComponent', () => {
 
     describe('enter', () => {
       beforeEach(() => {
+        component.tagging = true;
         event.key = event.code = KeyboardKeys.ENTER;
       });
 
       it('should select value when not selected', () => {
         const spy = vi.spyOn(component.selection, 'emit');
         event.target.value = 'test';
-        component.onInputKeyUp(event);
+        component.onInputKeyDown(event);
         expect(spy).toHaveBeenCalled();
       });
 
@@ -96,13 +98,13 @@ describe('SelectInputComponent', () => {
         component.selected = ['test'];
         const spy = vi.spyOn(component.selection, 'emit');
         event.target.value = 'test';
-        component.onInputKeyUp(event);
+        component.onInputKeyDown(event);
         expect(spy).not.toHaveBeenCalled();
       });
 
       it('should do nothing if !value', () => {
         const spy = vi.spyOn(component.selection, 'emit');
-        component.onInputKeyUp(event);
+        component.onInputKeyDown(event);
         expect(spy).not.toHaveBeenCalled();
       });
     });
@@ -149,6 +151,158 @@ describe('SelectInputComponent', () => {
       component.tagging = false;
       component.onKeyDown(event);
       expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('tagging', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('tagging', true);
+      // No-option / free tagging path under test.
+      component.disableDropdown = true;
+      component.options = [];
+      component.selected = [];
+      fixture.detectChanges();
+    });
+
+    it('splits and normalizes pasted values', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        clipboardData: { getData: () => ' <b>one</b>, two\u200B;three\nfour' },
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any;
+
+      component.onInputPaste(event);
+
+      expect(spy).toHaveBeenCalledWith(['one', 'two', 'three', 'four']);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('commits values with Tab', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      const event = {
+        key: KeyboardKeys.TAB,
+        code: KeyboardKeys.TAB,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: '42', selectionStart: 2, selectionEnd: 2 }
+      } as any;
+
+      component.onInputKeyDown(event);
+
+      expect(spy).toHaveBeenCalledWith(['42']);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('rejects invalid values and surfaces the error', () => {
+      const selectionSpy = vi.spyOn(component.selection, 'emit');
+      const errorSpy = vi.spyOn(component.taggingError, 'emit');
+      component.taggingValidator = value => (value.length > 3 ? 'Too long' : null);
+      const event = {
+        key: KeyboardKeys.ENTER,
+        code: KeyboardKeys.ENTER,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: 'lengthy', selectionStart: 7, selectionEnd: 7 }
+      } as any;
+
+      component.onInputKeyDown(event);
+
+      expect(selectionSpy).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith('Too long');
+    });
+
+    it('commits pending input on blur', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.inputElement.nativeElement.value = 'pending';
+
+      component.onInputBlur({ relatedTarget: null } as FocusEvent);
+
+      expect(spy).toHaveBeenCalledWith(['pending']);
+    });
+
+    it('does not commit filter text on blur when tagging has options', () => {
+      component.disableDropdown = false;
+      component.options = [{ name: 'DDOS', value: 'ddos' }];
+      fixture.detectChanges();
+
+      const spy = vi.spyOn(component.selection, 'emit');
+      const clearSpy = vi.spyOn(component, 'clearInput');
+      component.inputElement.nativeElement.value = 'dd';
+
+      // Classic path uses clearInput on blur, not commit.
+      component.clearInput();
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(component.isFreeTagging).toBe(false);
+      expect(clearSpy).toHaveBeenCalled();
+    });
+
+    it('selects and removes chips with the keyboard', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.selected = ['one', 'two'];
+      const event = {
+        key: KeyboardKeys.ARROW_LEFT,
+        code: KeyboardKeys.ARROW_LEFT,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any;
+
+      component.onInputKeyDown(event);
+      expect(component.selectedChipIndex).toBe(1);
+
+      event.key = event.code = KeyboardKeys.ARROW_LEFT;
+      component.onInputKeyDown(event);
+      expect(component.selectedChipIndex).toBe(0);
+
+      event.key = event.code = KeyboardKeys.DELETE;
+      component.onInputKeyDown(event);
+      expect(spy).toHaveBeenCalledWith(['two']);
+    });
+
+    it('highlights the last chip on first Backspace before removing', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.selected = ['one', 'two'];
+      const event = {
+        key: KeyboardKeys.BACKSPACE,
+        code: KeyboardKeys.BACKSPACE,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any;
+
+      component.onInputKeyDown(event);
+      expect(component.selectedChipIndex).toBe(1);
+      expect(spy).not.toHaveBeenCalled();
+
+      component.onInputKeyDown(event);
+      expect(spy).toHaveBeenCalledWith(['one']);
+    });
+
+    it('moves a double-clicked chip into the editor', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.selected = ['one', 'two'];
+
+      component.onChipDoubleClick({ preventDefault: vi.fn(), stopPropagation: vi.fn() } as any, 0);
+
+      expect(spy).toHaveBeenCalledWith(['two']);
+      expect(component.inputElement.nativeElement.value).toBe('one');
+    });
+
+    it('leaves an empty Tab available for native navigation', () => {
+      const event = {
+        key: KeyboardKeys.TAB,
+        code: KeyboardKeys.TAB,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any;
+
+      component.onInputKeyDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
     });
   });
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.spec.ts
@@ -81,29 +81,38 @@ describe('SelectInputComponent', () => {
       expect(spy).toHaveBeenCalledWith({ event, value: '' });
     });
 
-    describe('enter', () => {
+    describe('classic tagging enter', () => {
       beforeEach(() => {
         component.tagging = true;
+        component.disableDropdown = false;
+        component.options = [{ name: 'Test', value: 'test-option' }];
         event.key = event.code = KeyboardKeys.ENTER;
       });
 
-      it('should select value when not selected', () => {
+      it('should select value on keyup when not selected', () => {
         const spy = vi.spyOn(component.selection, 'emit');
         event.target.value = 'test';
-        component.onInputKeyDown(event);
-        expect(spy).toHaveBeenCalled();
+        component.onInputKeyUp(event);
+        expect(spy).toHaveBeenCalledWith(['test']);
       });
 
       it('should not select value when already selected', () => {
         component.selected = ['test'];
         const spy = vi.spyOn(component.selection, 'emit');
         event.target.value = 'test';
-        component.onInputKeyDown(event);
+        component.onInputKeyUp(event);
         expect(spy).not.toHaveBeenCalled();
       });
 
       it('should do nothing if !value', () => {
         const spy = vi.spyOn(component.selection, 'emit');
+        component.onInputKeyUp(event);
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('should not select value on keydown (commit stays on keyup)', () => {
+        const spy = vi.spyOn(component.selection, 'emit');
+        event.target.value = 'test';
         component.onInputKeyDown(event);
         expect(spy).not.toHaveBeenCalled();
       });
@@ -157,7 +166,6 @@ describe('SelectInputComponent', () => {
   describe('tagging', () => {
     beforeEach(() => {
       fixture.componentRef.setInput('tagging', true);
-      // No-option / free tagging path under test.
       component.disableDropdown = true;
       component.options = [];
       component.selected = [];
@@ -177,6 +185,56 @@ describe('SelectInputComponent', () => {
 
       expect(spy).toHaveBeenCalledWith(['one', 'two', 'three', 'four']);
       expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('splits tab-separated paste into chips', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.onInputPaste({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        clipboardData: { getData: (type: string) => (type === 'text/plain' ? 'one\ttwo' : '') },
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any);
+
+      expect(spy).toHaveBeenCalledWith(['one', 'two']);
+    });
+
+    it('splits semicolon and newline paste into chips', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.onInputPaste({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        clipboardData: { getData: (type: string) => (type === 'text/plain' ? 'a;b\nc' : '') },
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any);
+
+      expect(spy).toHaveBeenCalledWith(['a', 'b', 'c']);
+    });
+
+    it('splits pasted text that contains \\n escape sequences into chips', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.onInputPaste({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        clipboardData: { getData: (type: string) => (type === 'text/plain' ? 'a;b\\nc' : '') },
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any);
+
+      expect(spy).toHaveBeenCalledWith(['a', 'b', 'c']);
+    });
+
+    it('inserts a single pasted value without committing', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      const target = { value: '', selectionStart: 0, selectionEnd: 0, setSelectionRange: vi.fn() };
+      component.onInputPaste({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        clipboardData: { getData: () => 'hello <b>world</b>' },
+        target
+      } as any);
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(target.value).toBe('hello world');
     });
 
     it('commits values with Tab', () => {
@@ -316,6 +374,22 @@ describe('SelectInputComponent', () => {
       expect(component.selectedChips[0].invalid).toBe(false);
     });
 
+    it('revalidates chips with peers only so uniqueness validators stay valid', () => {
+      component.taggingValidator = (value, selected) => (selected.includes(value) ? 'Already selected' : null);
+      component.selected = ['one', 'two'];
+
+      expect(component.selectedChips.every(chip => !chip.invalid)).toBe(true);
+    });
+
+    it('marks chips invalid when a peer-based constraint fails', () => {
+      component.taggingValidator = (value, selected) =>
+        value === 'b' && selected.includes('a') ? 'Conflicts with a' : null;
+      component.selected = ['a', 'b'];
+
+      expect(component.selectedChips[0].invalid).toBe(false);
+      expect(component.selectedChips[1].invalid).toBe(true);
+    });
+
     it('commits pending input on blur', () => {
       const spy = vi.spyOn(component.selection, 'emit');
       component.inputElement.nativeElement.value = 'pending';
@@ -334,7 +408,6 @@ describe('SelectInputComponent', () => {
       const clearSpy = vi.spyOn(component, 'clearInput');
       component.inputElement.nativeElement.value = 'dd';
 
-      // Classic path uses clearInput on blur, not commit.
       component.clearInput();
 
       expect(spy).not.toHaveBeenCalled();
@@ -406,6 +479,60 @@ describe('SelectInputComponent', () => {
       component.onInputKeyDown(event);
 
       expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('ignores auto-repeat Backspace after a chip is highlighted', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.selected = ['one', 'two'];
+      const event = {
+        key: KeyboardKeys.BACKSPACE,
+        code: KeyboardKeys.BACKSPACE,
+        repeat: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any;
+
+      component.onInputKeyDown(event);
+      expect(component.selectedChipIndex).toBe(1);
+      expect(spy).not.toHaveBeenCalled();
+
+      event.repeat = true;
+      component.onInputKeyDown(event);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('ignores auto-repeat Enter when committing', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      const event = {
+        key: KeyboardKeys.ENTER,
+        code: KeyboardKeys.ENTER,
+        repeat: true,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: 'tag', selectionStart: 3, selectionEnd: 3 }
+      } as any;
+
+      component.onInputKeyDown(event);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('rejects commits that would exceed maxSelections', () => {
+      const selectionSpy = vi.spyOn(component.selection, 'emit');
+      const errorSpy = vi.spyOn(component.taggingError, 'emit');
+      component.maxSelections = 1;
+      component.selected = ['one'];
+
+      component.onInputKeyDown({
+        key: KeyboardKeys.ENTER,
+        code: KeyboardKeys.ENTER,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: 'two', selectionStart: 3, selectionEnd: 3 }
+      } as any);
+
+      expect(selectionSpy).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith('A maximum of 1 selections is allowed.');
     });
   });
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.spec.ts
@@ -198,7 +198,8 @@ describe('SelectInputComponent', () => {
     it('rejects invalid values and surfaces the error', () => {
       const selectionSpy = vi.spyOn(component.selection, 'emit');
       const errorSpy = vi.spyOn(component.taggingError, 'emit');
-      component.taggingValidator = value => (value.length > 3 ? 'Too long' : null);
+      component.taggingValidator = (value: unknown) =>
+        typeof value === 'string' && value.length > 3 ? 'Too long' : null;
       const event = {
         key: KeyboardKeys.ENTER,
         code: KeyboardKeys.ENTER,
@@ -211,6 +212,108 @@ describe('SelectInputComponent', () => {
 
       expect(selectionSpy).not.toHaveBeenCalled();
       expect(errorSpy).toHaveBeenCalledWith('Too long');
+    });
+
+    it('passes domain values to the validator, not chip view models', () => {
+      const seen: { value: unknown; selected: readonly unknown[] }[] = [];
+      component.selected = ['alpha'];
+      component.taggingValidator = (value, selected) => {
+        seen.push({ value, selected: [...selected] });
+        return null;
+      };
+
+      component.onInputKeyDown({
+        key: KeyboardKeys.ENTER,
+        code: KeyboardKeys.ENTER,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: 'beta', selectionStart: 4, selectionEnd: 4 }
+      } as any);
+
+      expect(seen).toEqual([{ value: 'beta', selected: ['alpha'] }]);
+    });
+
+    it('decodes entities and strips tags when committing paste batches', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.onInputPaste({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        clipboardData: { getData: () => 'AT&amp;T, hello <b>world</b>' },
+        target: { value: '', selectionStart: 0, selectionEnd: 0 }
+      } as any);
+
+      expect(spy).toHaveBeenCalledWith(['AT&T', 'hello world']);
+    });
+
+    it('ignores whitespace-only commits', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.onInputKeyDown({
+        key: KeyboardKeys.ENTER,
+        code: KeyboardKeys.ENTER,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: '   ', selectionStart: 3, selectionEnd: 3 }
+      } as any);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('skips duplicate free tags', () => {
+      const spy = vi.spyOn(component.selection, 'emit');
+      component.selected = ['one'];
+
+      component.onInputKeyDown({
+        key: KeyboardKeys.ENTER,
+        code: KeyboardKeys.ENTER,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { value: 'one', selectionStart: 3, selectionEnd: 3 }
+      } as any);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('precomputes plain label, tooltip, and invalid chip state', () => {
+      const long = 'x'.repeat(40);
+      component.taggingValidator = (value: unknown) => (value === 'bad' ? 'Nope' : null);
+      component.selected = ['ok', 'bad', long];
+
+      expect(component.selectedChips).toHaveLength(3);
+      expect(component.selectedChips[0]).toMatchObject({
+        labelText: 'ok',
+        tooltipTitle: '',
+        invalid: false
+      });
+      expect(component.selectedChips[1]).toMatchObject({
+        labelText: 'bad',
+        tooltipTitle: '',
+        invalid: true
+      });
+      expect(component.selectedChips[2]).toMatchObject({
+        labelText: long,
+        tooltipTitle: long,
+        invalid: false
+      });
+      expect(component.selectedChips[2].option).not.toHaveProperty('tooltipTitle');
+    });
+
+    it('keeps free-tag labels as plain text without mutating option objects', () => {
+      const option = { name: 'Shared', value: 'shared' };
+      component.options = [option];
+      component.selected = ['shared'];
+
+      expect(component.selectedChips[0].labelText).toBe('Shared');
+      expect(option).toEqual({ name: 'Shared', value: 'shared' });
+    });
+
+    it('updates chip invalid state when selections are removed', () => {
+      component.taggingValidator = (value: unknown) => (value === 'bad' ? 'Nope' : null);
+      component.selected = ['bad', 'ok'];
+      expect(component.selectedChips[0].invalid).toBe(true);
+
+      component.selected = ['ok'];
+      expect(component.selectedChips).toHaveLength(1);
+      expect(component.selectedChips[0].invalid).toBe(false);
     });
 
     it('commits pending input on blur', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
@@ -338,10 +338,11 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     if (this.tagging) this.focusInput();
   }
 
-  onFocus() {
-    if (!this.disabled && this.tagging) {
-      this.onClick();
-    }
+  onFocus(event?: FocusEvent) {
+    if (this.disabled || !this.tagging) return;
+    // focusin bubbles from buttons (clear/caret); don't treat those as field activation.
+    if ((event?.target as HTMLElement | null)?.closest?.('button')) return;
+    this.onClick();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -369,11 +370,10 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   }
 
   focus() {
-    if (this.tagging) {
-      this.focusInput();
-    } else {
-      this.inputContainer.nativeElement.focus();
-    }
+    // Prefer the container so classic tagging still runs onFocus → open dropdown.
+    // Free tagging then moves focus into the textarea via onFocus/onClick.
+    this.inputContainer?.nativeElement.focus();
+    if (this.isFreeTagging) this.focusInput();
   }
 
   isOptionInvalid(option: SelectDropdownOption): boolean {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
@@ -15,6 +16,33 @@ import {
 import { KeyboardKeys } from '../../enums/keyboard-keys.enum';
 import { SelectDropdownOption } from './select-dropdown-option.interface';
 import { CoerceBooleanProperty } from '../../utils/coerce/coerce-boolean';
+import { SelectTaggingValidator } from './select-tagging.interface';
+
+const TAG_SEPARATOR_PATTERN = /[,;\n\r\t]+/;
+/** Approx. truncated chip width (~18rem); shorter labels need no tooltip. */
+const CHIP_TOOLTIP_MIN_LENGTH = 32;
+
+function cleanTag(value: string): string {
+  return (
+    value
+      .replace(/<[^>]*>/g, '')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&amp;/gi, '&')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&quot;/gi, '"')
+      .replace(/&#39;/g, "'")
+      // eslint-disable-next-line no-control-regex -- strip control chars from pasted text
+      .replace(/[\u0000-\u001f\u007f]/g, '')
+      .replace(/[\u200b-\u200d\ufeff]/g, '')
+      .replace(/\u00a0/g, ' ')
+      .trim()
+  );
+}
+
+function plainChipLabel(option: SelectDropdownOption): string {
+  return `${option?.name ?? option?.value ?? ''}`.replace(/<[^>]*>/g, '').trim();
+}
 
 @Component({
   exportAs: 'ngxSelectInput',
@@ -39,6 +67,8 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   @Input() requiredIndicator: string | boolean;
   @Input() tabindex = 0;
   @Input() withHint = true;
+  @Input() maxSelections?: number;
+  @Input() taggingValidator?: SelectTaggingValidator;
 
   @Input()
   @CoerceBooleanProperty()
@@ -75,6 +105,9 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   set selected(val: any[]) {
     this._selected = val;
     this.selectedOptions = this.calcSelectedOptions(val);
+    if (this.selectedChipIndex != null && this.selectedChipIndex >= (val?.length || 0)) {
+      this.setSelectedChipIndex(val?.length ? val.length - 1 : null);
+    }
   }
 
   @Output() toggle = new EventEmitter<void>();
@@ -83,12 +116,27 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   @Output() activate = new EventEmitter<void>();
   @Output() activateLast = new EventEmitter<void>();
   @Output() keyup = new EventEmitter<{ event: KeyboardEvent; value?: string }>();
+  @Output() taggingError = new EventEmitter<string>();
 
   @ViewChild('inputContainer')
   readonly inputContainer?: ElementRef<HTMLElement>;
 
   @ViewChild('tagInput')
-  readonly inputElement?: ElementRef<HTMLInputElement>;
+  readonly inputElement?: ElementRef<HTMLInputElement | HTMLTextAreaElement>;
+
+  selectedOptions: SelectDropdownOption[] = [];
+  selectedChipIndex: number | null = null;
+
+  private _selected: any[];
+  private _lastTaggingError = '';
+  private suppressEscapeToggle = false;
+
+  constructor(private readonly _cdr: ChangeDetectorRef) {}
+
+  /** Enhanced chip UX only when tagging has no usable options dropdown. */
+  get isFreeTagging(): boolean {
+    return !!this.tagging && (this.disableDropdown || !this.options?.length);
+  }
 
   get caretVisible(): boolean {
     if (this.disableDropdown) return false;
@@ -107,34 +155,35 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     return !(typeof this.selectCaret === 'object' && this.selectCaret instanceof TemplateRef);
   }
 
-  selectedOptions: SelectDropdownOption[] = [];
-
-  private _selected: any[];
-
   ngOnChanges(changes: SimpleChanges) {
-    if ('options' in changes && !changes.options.firstChange) {
+    if ('options' in changes || 'taggingValidator' in changes) {
       this.selectedOptions = this.calcSelectedOptions(this.selected);
     }
   }
 
   ngAfterViewInit(): void {
     if (this.tagging && this.autofocus) {
-      setTimeout(() => {
-        this.inputElement.nativeElement.focus();
-      }, 5);
+      setTimeout(() => this.inputElement?.nativeElement.focus(), 5);
     }
+    if (this.isFreeTagging) this.syncInputHeight();
   }
 
-  // Events in the input box
   onInputKeyDown(event: KeyboardEvent): void {
     event.stopPropagation();
+    if (!this.tagging) return;
 
+    if (this.isFreeTagging) {
+      this.onFreeTaggingKeyDown(event);
+      return;
+    }
+
+    // Classic tagging-with-options: preserve prior Enter/Escape behavior only.
     switch (event.code) {
       case KeyboardKeys.ENTER:
         event.preventDefault();
         break;
       case KeyboardKeys.ESCAPE: {
-        const value = (event.target as any).value;
+        const value = (event.target as HTMLInputElement).value;
         if (value === '') {
           const newSelections = this.selected.slice(0, this.selected.length - 1);
           this.selection.emit(newSelections);
@@ -144,23 +193,23 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     }
   }
 
-  // Events in the input box
   onInputKeyUp(event: KeyboardEvent): void {
     event.stopPropagation();
+    const value = (event.target as HTMLInputElement | HTMLTextAreaElement).value;
 
-    const value = (event.target as any).value;
+    if (this.isFreeTagging) {
+      this.onFreeTaggingKeyUp(event, value);
+      return;
+    }
 
+    // Classic tagging-with-options keyup (unchanged contract).
     switch (event.code) {
       case KeyboardKeys.ENTER:
         event.preventDefault();
         if (value !== '') {
-          const hasSelection = this.selected.find(selection => {
-            return value === selection;
-          });
-
+          const hasSelection = this.selected?.find(selection => value === selection);
           if (!hasSelection) {
-            const newSelections = [...this.selected, value];
-            this.selection.emit(newSelections);
+            this.selection.emit([...(this.selected || []), value]);
             this.clearInput();
           }
         }
@@ -174,14 +223,80 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     this.keyup.emit({ event, value });
   }
 
-  clearInput() {
-    if (this.inputElement && this.inputElement.nativeElement) {
-      this.inputElement.nativeElement.value = '';
+  onInputPaste(event: ClipboardEvent): void {
+    if (!this.isFreeTagging) return;
+
+    const pasted = event.clipboardData?.getData('text') || '';
+    if (!TAG_SEPARATOR_PATTERN.test(pasted)) {
+      setTimeout(() => this.syncInputHeight());
+      return;
     }
-    this.keyup.emit({ event: undefined, value: '' });
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const input = event.target as HTMLTextAreaElement;
+    const value = input.value || '';
+    const start = input.selectionStart ?? value.length;
+    const end = input.selectionEnd ?? value.length;
+    this.commitInput(`${value.slice(0, start)}${pasted}${value.slice(end)}`);
   }
 
-  // Events on ngx-select-input-box element
+  onInputValueChange(): void {
+    if (this.isFreeTagging) this.syncInputHeight();
+  }
+
+  onInputBlur(event: FocusEvent): void {
+    if (!this.isFreeTagging) return;
+    const next = event.relatedTarget as Node | null;
+    if (next && this.inputContainer?.nativeElement.contains(next)) return;
+    this.commitInput(this.inputElement?.nativeElement.value || '');
+  }
+
+  onChipClick(event: MouseEvent, index: number): void {
+    if (!this.isFreeTagging) return;
+    event.stopPropagation();
+    this.commitInput(this.inputElement?.nativeElement.value || '');
+    this.setSelectedChipIndex(index);
+    this.focusInput();
+  }
+
+  onChipDoubleClick(event: MouseEvent, index: number): void {
+    if (!this.isFreeTagging) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const option = this.selectedOptions[index];
+    if (!option || option.disabled) return;
+
+    const selections = [...(this.selected || [])];
+    selections.splice(index, 1);
+    this.selection.emit(selections);
+    this.setSelectedChipIndex(null);
+    if (this.inputElement?.nativeElement) {
+      this.inputElement.nativeElement.value = `${option.name ?? option.value ?? ''}`;
+      this.syncInputHeight();
+    }
+    this.emitTaggingError('');
+    this.focusInput();
+  }
+
+  clearInput() {
+    if (this.inputElement?.nativeElement) {
+      this.inputElement.nativeElement.value = '';
+      if (this.isFreeTagging) this.syncInputHeight();
+    }
+    this.keyup.emit({ event: undefined, value: '' });
+    this._cdr.markForCheck();
+  }
+
+  onClearTaggingInput(ev?: PointerEvent): void {
+    ev?.stopPropagation();
+    if (this.inputElement?.nativeElement) {
+      this.inputElement.nativeElement.value = '';
+    }
+  }
+
   onGlobalKeyUp(event: KeyboardEvent) {
     event.stopPropagation();
 
@@ -199,13 +314,11 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
         event.preventDefault();
         this.close.emit();
         break;
-      // TODO: Printable characters: select any matching options without expanding the options menu
     }
   }
 
   onKeyDown(event: KeyboardEvent): void {
-    if (event.code === KeyboardKeys.TAB) return; // don't trap tabs
-
+    if (event.code === KeyboardKeys.TAB) return;
     if (this.disableDropdown) return;
     event.stopPropagation();
 
@@ -215,28 +328,24 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     }
   }
 
-  onClick(): void {
-    if (this.disableDropdown) return;
-    this.activate.emit();
+  onClick(event?: MouseEvent): void {
+    if (this.disabled || (event?.target as HTMLElement | null)?.closest?.('button')) return;
 
-    if (this.tagging) {
-      setTimeout(() => {
-        this.inputElement.nativeElement.focus();
-      }, 30);
+    if (!this.disableDropdown) {
+      this.activate.emit();
     }
+
+    if (this.tagging) this.focusInput();
   }
 
   onFocus() {
     if (!this.disabled && this.tagging) {
-      // Open dropdown and focus on input
       this.onClick();
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onToggle(_ev?: PointerEvent): void {
-    // Future: this should stopPropagation
-    // not happening now to ensure closeOnBodyClick is triggered
     this.toggle.emit();
   }
 
@@ -250,32 +359,207 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   onOptionRemove(event: Event, option: SelectDropdownOption): void {
     event.stopPropagation();
 
-    const newSelections = this.selected.filter(selection => {
-      if (this.identifier !== undefined) {
-        return option.value[this.identifier] !== selection[this.identifier];
+    const index = (this.selected || []).findIndex(selection => {
+      if (this.identifier !== undefined && selection != null && option.value != null) {
+        return selection[this.identifier] === option.value[this.identifier];
       }
-
-      return option.value !== selection;
+      return selection === option.value;
     });
-
-    this.selection.emit(newSelections);
-  }
-
-  onClearTaggingInput(ev?: PointerEvent): void {
-    ev?.stopPropagation();
-    if (this.inputElement && this.inputElement.nativeElement) {
-      this.inputElement.nativeElement.value = '';
-    }
+    this.removeOptionAt(index);
   }
 
   focus() {
-    this.inputContainer.nativeElement.focus();
+    if (this.tagging) {
+      this.focusInput();
+    } else {
+      this.inputContainer.nativeElement.focus();
+    }
+  }
+
+  isOptionInvalid(option: SelectDropdownOption): boolean {
+    return !!this.taggingValidator?.(option.value, this.selected || []);
+  }
+
+  /** Full label for tooltip, or empty when short enough that truncation is unlikely. */
+  chipTooltip(option: SelectDropdownOption): string {
+    const text = plainChipLabel(option);
+    return text.length >= CHIP_TOOLTIP_MIN_LENGTH ? text : '';
+  }
+
+  trackChip(option: SelectDropdownOption): unknown {
+    if (this.identifier && option?.value != null) {
+      return option.value[this.identifier];
+    }
+    return option?.value ?? option;
+  }
+
+  private onFreeTaggingKeyDown(event: KeyboardEvent): void {
+    const input = event.target as HTMLTextAreaElement;
+    const value = input.value || '';
+    const empty = !value;
+    const caret = input.selectionStart ?? 0;
+    const atStart = caret === 0 && (input.selectionEnd ?? 0) === 0;
+    const key = event.key;
+
+    if (key === KeyboardKeys.ARROW_LEFT && (empty || atStart) && this.selected?.length) {
+      event.preventDefault();
+      this.setSelectedChipIndex(
+        this.selectedChipIndex == null ? this.selected.length - 1 : Math.max(0, this.selectedChipIndex - 1)
+      );
+      return;
+    }
+
+    if (key === KeyboardKeys.ARROW_RIGHT && this.selectedChipIndex != null) {
+      event.preventDefault();
+      this.setSelectedChipIndex(this.selectedChipIndex < this.selected.length - 1 ? this.selectedChipIndex + 1 : null);
+      return;
+    }
+
+    if ((key === KeyboardKeys.BACKSPACE || key === KeyboardKeys.DELETE) && this.selectedChipIndex != null) {
+      event.preventDefault();
+      this.removeOptionAt(this.selectedChipIndex);
+      return;
+    }
+
+    if (key === KeyboardKeys.BACKSPACE && empty && atStart && this.selected?.length) {
+      event.preventDefault();
+      this.setSelectedChipIndex(this.selected.length - 1);
+      return;
+    }
+
+    if (key === KeyboardKeys.ESCAPE) {
+      if (this.selectedChipIndex != null) {
+        event.preventDefault();
+        this.setSelectedChipIndex(null);
+        this.suppressEscapeToggle = true;
+        return;
+      }
+      if (empty && this.selected?.length) {
+        event.preventDefault();
+        this.removeOptionAt(this.selected.length - 1);
+        this.suppressEscapeToggle = true;
+        return;
+      }
+    }
+
+    if (key.length === 1 && this.selectedChipIndex != null) {
+      this.setSelectedChipIndex(null);
+    }
+
+    if (key.length === 1 && this._lastTaggingError) {
+      this.emitTaggingError('');
+    }
+
+    if (key === KeyboardKeys.ENTER || key === KeyboardKeys.TAB || key === ',') {
+      if (!value) {
+        if (key !== KeyboardKeys.TAB) event.preventDefault();
+        return;
+      }
+      event.preventDefault();
+      this.commitInput(value);
+    }
+  }
+
+  private onFreeTaggingKeyUp(event: KeyboardEvent, value: string): void {
+    if (event.code === KeyboardKeys.ESCAPE) {
+      event.preventDefault();
+      if (this.suppressEscapeToggle) {
+        this.suppressEscapeToggle = false;
+        return;
+      }
+      this.toggle.emit();
+      return;
+    }
+
+    if (
+      event.key === KeyboardKeys.ENTER ||
+      event.key === KeyboardKeys.TAB ||
+      event.key === KeyboardKeys.ARROW_LEFT ||
+      event.key === KeyboardKeys.ARROW_RIGHT ||
+      event.key === ','
+    ) {
+      return;
+    }
+
+    this.keyup.emit({ event, value });
+  }
+
+  private commitInput(raw: string): void {
+    if (!raw) return;
+
+    const values = raw.split(TAG_SEPARATOR_PATTERN).map(cleanTag).filter(Boolean);
+
+    if (!values.length) {
+      this.clearInput();
+      return;
+    }
+
+    const next = [...(this.selected || [])];
+    let lastError = '';
+
+    for (const value of values) {
+      if (next.includes(value)) continue;
+
+      const reason =
+        this.maxSelections !== undefined && next.length >= this.maxSelections
+          ? `A maximum of ${this.maxSelections} selections is allowed.`
+          : this.taggingValidator?.(value, next) || '';
+
+      if (reason) {
+        lastError = reason;
+        continue;
+      }
+
+      next.push(value);
+    }
+
+    if (next.length !== (this.selected || []).length) {
+      this.selection.emit(next);
+    }
+
+    this.emitTaggingError(lastError);
+    this.clearInput();
+  }
+
+  private removeOptionAt(index: number): void {
+    if (index < 0 || index >= (this.selected || []).length) return;
+
+    const selections = [...this.selected];
+    selections.splice(index, 1);
+    this.selection.emit(selections);
+    this.setSelectedChipIndex(selections.length ? Math.min(index, selections.length - 1) : null);
+    this.emitTaggingError('');
+  }
+
+  private setSelectedChipIndex(index: number | null): void {
+    if (this.selectedChipIndex === index) return;
+    this.selectedChipIndex = index;
+    this._cdr.markForCheck();
+  }
+
+  private emitTaggingError(error: string): void {
+    if (error === this._lastTaggingError) return;
+    this._lastTaggingError = error;
+    this.taggingError.emit(error);
+    this._cdr.markForCheck();
+  }
+
+  private focusInput(): void {
+    setTimeout(() => {
+      this.inputElement?.nativeElement.focus();
+      this.syncInputHeight();
+    }, 30);
+  }
+
+  private syncInputHeight(): void {
+    const el = this.inputElement?.nativeElement;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
   }
 
   private calcSelectedOptions(selected: any[]) {
     const results: SelectDropdownOption[] = [];
-
-    // result out if nothing here
     if (!selected) return results;
 
     for (const selection of selected) {
@@ -286,7 +570,6 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
           if (this.identifier) {
             return selection[this.identifier] === option.value[this.identifier];
           }
-
           return selection === option.value;
         });
       }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
@@ -17,15 +17,13 @@ import { KeyboardKeys } from '../../enums/keyboard-keys.enum';
 import { SelectDropdownOption } from './select-dropdown-option.interface';
 import { CoerceBooleanProperty } from '../../utils/coerce/coerce-boolean';
 import { SelectTaggingValidator } from './select-tagging.interface';
-import { freeTagPlainLabel, splitFreeTagBatch } from './select-tagging.util';
+import { freeTagPlainLabel, freeTagBatchHasSeparator, splitFreeTagBatch } from './select-tagging.util';
 
 const CHIP_TOOLTIP_MIN_LENGTH = 32;
 
-/** Derived chip presentation — never mutates consumer option objects. */
 interface SelectedChipView {
   readonly option: SelectDropdownOption;
   readonly trackBy: unknown;
-  /** Plain text label for free-tagging display and chip edit. */
   readonly labelText: string;
   readonly tooltipTitle: string;
   readonly invalid: boolean;
@@ -111,9 +109,7 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   @ViewChild('tagInput')
   readonly inputElement?: ElementRef<HTMLInputElement | HTMLTextAreaElement>;
 
-  /** Derived chip view models (tooltip / invalid / plain label). */
   selectedChips: SelectedChipView[] = [];
-  /** Option list mirrored from selectedChips for existing callers/tests. */
   selectedOptions: SelectDropdownOption[] = [];
   selectedChipIndex: number | null = null;
 
@@ -123,7 +119,6 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
 
   constructor(private readonly _cdr: ChangeDetectorRef) {}
 
-  /** Enhanced chip UX only when tagging has no usable options dropdown. */
   get isFreeTagging(): boolean {
     return !!this.tagging && (this.disableDropdown || !this.options?.length);
   }
@@ -174,7 +169,6 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
       return;
     }
 
-    // Classic tagging-with-options: preserve prior Enter/Escape behavior only.
     switch (event.code) {
       case KeyboardKeys.ENTER:
         event.preventDefault();
@@ -199,7 +193,6 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
       return;
     }
 
-    // Classic tagging-with-options keyup (unchanged contract).
     switch (event.code) {
       case KeyboardKeys.ENTER:
         event.preventDefault();
@@ -223,21 +216,27 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   onInputPaste(event: ClipboardEvent): void {
     if (!this.isFreeTagging) return;
 
-    const pasted = event.clipboardData?.getData('text') || '';
-    // Decide multi-value after sanitization so `&amp;` is not treated as a `;` separator.
-    if (splitFreeTagBatch(pasted).length <= 1) {
-      setTimeout(() => this.syncInputHeight());
-      return;
-    }
-
     event.preventDefault();
     event.stopPropagation();
 
+    const pasted = event.clipboardData?.getData('text/plain') || event.clipboardData?.getData('text') || '';
     const input = event.target as HTMLTextAreaElement;
     const value = input.value || '';
     const start = input.selectionStart ?? value.length;
     const end = input.selectionEnd ?? value.length;
-    this.commitInput(`${value.slice(0, start)}${pasted}${value.slice(end)}`);
+    const merged = `${value.slice(0, start)}${pasted}${value.slice(end)}`;
+
+    if (freeTagBatchHasSeparator(pasted) || splitFreeTagBatch(merged).length > 1) {
+      this.commitInput(merged);
+      return;
+    }
+
+    const inserted = splitFreeTagBatch(pasted)[0] ?? '';
+    input.value = `${value.slice(0, start)}${inserted}${value.slice(end)}`;
+    const caret = start + inserted.length;
+    input.setSelectionRange(caret, caret);
+    this.syncInputHeight();
+    this._cdr.markForCheck();
   }
 
   onInputValueChange(): void {
@@ -338,7 +337,6 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
 
   onFocus(event?: FocusEvent) {
     if (this.disabled || !this.tagging) return;
-    // focusin bubbles from buttons (clear/caret); don't treat those as field activation.
     if ((event?.target as HTMLElement | null)?.closest?.('button')) return;
     this.onClick();
   }
@@ -368,8 +366,6 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   }
 
   focus() {
-    // Prefer the container so classic tagging still runs onFocus → open dropdown.
-    // Free tagging then moves focus into the textarea via onFocus/onClick.
     this.inputContainer?.nativeElement.focus();
     if (this.isFreeTagging) this.focusInput();
   }
@@ -381,6 +377,13 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     const caret = input.selectionStart ?? 0;
     const atStart = caret === 0 && (input.selectionEnd ?? 0) === 0;
     const key = event.key;
+
+    if (
+      event.repeat &&
+      (key === KeyboardKeys.BACKSPACE || key === KeyboardKeys.DELETE || key === KeyboardKeys.ENTER || key === ',')
+    ) {
+      return;
+    }
 
     if (key === KeyboardKeys.ARROW_LEFT && (empty || atStart) && this.selected?.length) {
       event.preventDefault();
@@ -551,7 +554,7 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     const free = this.isFreeTagging;
     const validator = free ? this.taggingValidator : undefined;
 
-    for (const selection of selected) {
+    selected.forEach((selection, index) => {
       let match: SelectDropdownOption | undefined;
 
       if (this.options) {
@@ -568,11 +571,12 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
         match = { value: selection, name: label };
       }
 
-      if (!match) continue;
+      if (!match) return;
 
       const labelText = free ? freeTagPlainLabel(match.value, match.name) : '';
       const tooltipTitle = free && labelText.length >= CHIP_TOOLTIP_MIN_LENGTH ? labelText : '';
-      const invalid = validator ? !!validator(match.value, selected) : false;
+      const peers = selected.filter((_, i) => i !== index);
+      const invalid = validator ? !!validator(match.value, peers) : false;
 
       results.push({
         option: match,
@@ -581,7 +585,7 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
         tooltipTitle,
         invalid
       });
-    }
+    });
 
     return results;
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-input.component.ts
@@ -17,31 +17,18 @@ import { KeyboardKeys } from '../../enums/keyboard-keys.enum';
 import { SelectDropdownOption } from './select-dropdown-option.interface';
 import { CoerceBooleanProperty } from '../../utils/coerce/coerce-boolean';
 import { SelectTaggingValidator } from './select-tagging.interface';
+import { freeTagPlainLabel, splitFreeTagBatch } from './select-tagging.util';
 
-const TAG_SEPARATOR_PATTERN = /[,;\n\r\t]+/;
-/** Approx. truncated chip width (~18rem); shorter labels need no tooltip. */
 const CHIP_TOOLTIP_MIN_LENGTH = 32;
 
-function cleanTag(value: string): string {
-  return (
-    value
-      .replace(/<[^>]*>/g, '')
-      .replace(/&nbsp;/gi, ' ')
-      .replace(/&amp;/gi, '&')
-      .replace(/&lt;/gi, '<')
-      .replace(/&gt;/gi, '>')
-      .replace(/&quot;/gi, '"')
-      .replace(/&#39;/g, "'")
-      // eslint-disable-next-line no-control-regex -- strip control chars from pasted text
-      .replace(/[\u0000-\u001f\u007f]/g, '')
-      .replace(/[\u200b-\u200d\ufeff]/g, '')
-      .replace(/\u00a0/g, ' ')
-      .trim()
-  );
-}
-
-function plainChipLabel(option: SelectDropdownOption): string {
-  return `${option?.name ?? option?.value ?? ''}`.replace(/<[^>]*>/g, '').trim();
+/** Derived chip presentation — never mutates consumer option objects. */
+interface SelectedChipView {
+  readonly option: SelectDropdownOption;
+  readonly trackBy: unknown;
+  /** Plain text label for free-tagging display and chip edit. */
+  readonly labelText: string;
+  readonly tooltipTitle: string;
+  readonly invalid: boolean;
 }
 
 @Component({
@@ -104,7 +91,7 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   }
   set selected(val: any[]) {
     this._selected = val;
-    this.selectedOptions = this.calcSelectedOptions(val);
+    this.rebuildSelectedChips(val);
     if (this.selectedChipIndex != null && this.selectedChipIndex >= (val?.length || 0)) {
       this.setSelectedChipIndex(val?.length ? val.length - 1 : null);
     }
@@ -124,6 +111,9 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   @ViewChild('tagInput')
   readonly inputElement?: ElementRef<HTMLInputElement | HTMLTextAreaElement>;
 
+  /** Derived chip view models (tooltip / invalid / plain label). */
+  selectedChips: SelectedChipView[] = [];
+  /** Option list mirrored from selectedChips for existing callers/tests. */
   selectedOptions: SelectDropdownOption[] = [];
   selectedChipIndex: number | null = null;
 
@@ -144,7 +134,7 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   }
 
   get clearVisible() {
-    return this.allowClear && !this.multiple && !this.tagging && this.selectedOptions?.length > 0;
+    return this.allowClear && !this.multiple && !this.tagging && this.selectedChips?.length > 0;
   }
 
   get hasControls(): boolean {
@@ -156,8 +146,15 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if ('options' in changes || 'taggingValidator' in changes) {
-      this.selectedOptions = this.calcSelectedOptions(this.selected);
+    if (
+      'options' in changes ||
+      'taggingValidator' in changes ||
+      'tagging' in changes ||
+      'disableDropdown' in changes ||
+      'identifier' in changes ||
+      'allowAdditions' in changes
+    ) {
+      this.rebuildSelectedChips(this.selected);
     }
   }
 
@@ -227,7 +224,8 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     if (!this.isFreeTagging) return;
 
     const pasted = event.clipboardData?.getData('text') || '';
-    if (!TAG_SEPARATOR_PATTERN.test(pasted)) {
+    // Decide multi-value after sanitization so `&amp;` is not treated as a `;` separator.
+    if (splitFreeTagBatch(pasted).length <= 1) {
       setTimeout(() => this.syncInputHeight());
       return;
     }
@@ -266,15 +264,15 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     event.preventDefault();
     event.stopPropagation();
 
-    const option = this.selectedOptions[index];
-    if (!option || option.disabled) return;
+    const chip = this.selectedChips[index];
+    if (!chip || chip.option.disabled) return;
 
     const selections = [...(this.selected || [])];
     selections.splice(index, 1);
     this.selection.emit(selections);
     this.setSelectedChipIndex(null);
     if (this.inputElement?.nativeElement) {
-      this.inputElement.nativeElement.value = `${option.name ?? option.value ?? ''}`;
+      this.inputElement.nativeElement.value = chip.labelText;
       this.syncInputHeight();
     }
     this.emitTaggingError('');
@@ -376,23 +374,6 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     if (this.isFreeTagging) this.focusInput();
   }
 
-  isOptionInvalid(option: SelectDropdownOption): boolean {
-    return !!this.taggingValidator?.(option.value, this.selected || []);
-  }
-
-  /** Full label for tooltip, or empty when short enough that truncation is unlikely. */
-  chipTooltip(option: SelectDropdownOption): string {
-    const text = plainChipLabel(option);
-    return text.length >= CHIP_TOOLTIP_MIN_LENGTH ? text : '';
-  }
-
-  trackChip(option: SelectDropdownOption): unknown {
-    if (this.identifier && option?.value != null) {
-      return option.value[this.identifier];
-    }
-    return option?.value ?? option;
-  }
-
   private onFreeTaggingKeyDown(event: KeyboardEvent): void {
     const input = event.target as HTMLTextAreaElement;
     const value = input.value || '';
@@ -487,7 +468,7 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
   private commitInput(raw: string): void {
     if (!raw) return;
 
-    const values = raw.split(TAG_SEPARATOR_PATTERN).map(cleanTag).filter(Boolean);
+    const values = splitFreeTagBatch(raw);
 
     if (!values.length) {
       this.clearInput();
@@ -558,12 +539,20 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
     el.style.height = `${el.scrollHeight}px`;
   }
 
-  private calcSelectedOptions(selected: any[]) {
-    const results: SelectDropdownOption[] = [];
+  private rebuildSelectedChips(selected: any[] | null | undefined): void {
+    this.selectedChips = this.buildSelectedChips(selected);
+    this.selectedOptions = this.selectedChips.map(chip => chip.option);
+  }
+
+  private buildSelectedChips(selected: any[] | null | undefined): SelectedChipView[] {
+    const results: SelectedChipView[] = [];
     if (!selected) return results;
 
+    const free = this.isFreeTagging;
+    const validator = free ? this.taggingValidator : undefined;
+
     for (const selection of selected) {
-      let match: SelectDropdownOption;
+      let match: SelectDropdownOption | undefined;
 
       if (this.options) {
         match = this.options.find(option => {
@@ -575,12 +564,32 @@ export class SelectInputComponent implements AfterViewInit, OnChanges {
       }
 
       if ((this.tagging || this.allowAdditions) && !match) {
-        match = { value: selection, name: selection };
+        const label = freeTagPlainLabel(selection);
+        match = { value: selection, name: label };
       }
 
-      if (match) results.push(match);
+      if (!match) continue;
+
+      const labelText = free ? freeTagPlainLabel(match.value, match.name) : '';
+      const tooltipTitle = free && labelText.length >= CHIP_TOOLTIP_MIN_LENGTH ? labelText : '';
+      const invalid = validator ? !!validator(match.value, selected) : false;
+
+      results.push({
+        option: match,
+        trackBy: this.resolveTrackBy(match),
+        labelText,
+        tooltipTitle,
+        invalid
+      });
     }
 
     return results;
+  }
+
+  private resolveTrackBy(option: SelectDropdownOption): unknown {
+    if (this.identifier && option?.value != null) {
+      return option.value[this.identifier];
+    }
+    return option?.value ?? option;
   }
 }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.interface.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.interface.ts
@@ -1,0 +1,2 @@
+/** Optional per-tag validator. Return an error message to reject the tag, or null to accept. */
+export type SelectTaggingValidator = (value: any, selected: readonly any[]) => string | null;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.interface.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.interface.ts
@@ -1,6 +1,1 @@
-/**
- * Optional per-tag validator for free tagging.
- * Receives the domain tag value (free tags are strings) and the current selection.
- * Return an error message to reject the tag, or null to accept.
- */
 export type SelectTaggingValidator<T = unknown> = (value: T, selected: readonly T[]) => string | null;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.interface.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.interface.ts
@@ -1,2 +1,6 @@
-/** Optional per-tag validator. Return an error message to reject the tag, or null to accept. */
-export type SelectTaggingValidator = (value: any, selected: readonly any[]) => string | null;
+/**
+ * Optional per-tag validator for free tagging.
+ * Receives the domain tag value (free tags are strings) and the current selection.
+ * Return an error message to reject the tag, or null to accept.
+ */
+export type SelectTaggingValidator<T = unknown> = (value: T, selected: readonly T[]) => string | null;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.util.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.util.spec.ts
@@ -1,0 +1,88 @@
+import { freeTagPlainLabel, normalizeFreeTagInput, splitFreeTagBatch } from './select-tagging.util';
+
+describe('normalizeFreeTagInput', () => {
+  it('strips complete HTML tags from pasted text', () => {
+    expect(normalizeFreeTagInput('hello <b>world</b>')).toBe('hello world');
+  });
+
+  it('decodes common HTML entities in a single pass', () => {
+    expect(normalizeFreeTagInput('AT&amp;T')).toBe('AT&T');
+    expect(normalizeFreeTagInput('&lt;div&gt;')).toBe('<div>');
+    expect(normalizeFreeTagInput('a &gt; b')).toBe('a > b');
+    expect(normalizeFreeTagInput('a &lt; b')).toBe('a < b');
+    expect(normalizeFreeTagInput('&quot;quoted&quot;')).toBe('"quoted"');
+    expect(normalizeFreeTagInput('&#39;x&#39;')).toBe("'x'");
+  });
+
+  it('only unescapes entities once (&amp;amp; → &amp;)', () => {
+    expect(normalizeFreeTagInput('&amp;amp;')).toBe('&amp;');
+  });
+
+  it('rejects whitespace-only fragments', () => {
+    expect(normalizeFreeTagInput('   ')).toBe('');
+    expect(normalizeFreeTagInput('\n\t')).toBe('');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(normalizeFreeTagInput('  hello  ')).toBe('hello');
+  });
+
+  it('strips control characters and zero-width spaces', () => {
+    expect(normalizeFreeTagInput('one\u200Btwo')).toBe('onetwo');
+    expect(normalizeFreeTagInput('a\u0000b')).toBe('ab');
+  });
+
+  it('preserves emoji and unicode letters', () => {
+    expect(normalizeFreeTagInput('café 🎉')).toBe('café 🎉');
+  });
+
+  it('leaves incomplete tag-like text alone', () => {
+    expect(normalizeFreeTagInput('<script')).toBe('<script');
+    expect(normalizeFreeTagInput('<')).toBe('<');
+    expect(normalizeFreeTagInput('>')).toBe('>');
+    expect(normalizeFreeTagInput('&')).toBe('&');
+  });
+
+  it('strips a complete script element but does not claim XSS safety', () => {
+    expect(normalizeFreeTagInput('<script>alert(1)</script>')).toBe('alert(1)');
+  });
+});
+
+describe('splitFreeTagBatch', () => {
+  it('sanitizes before splitting so entity semicolons are preserved', () => {
+    expect(splitFreeTagBatch('AT&amp;T, hello <b>world</b>')).toEqual(['AT&T', 'hello world']);
+  });
+
+  it('splits on commas, semicolons, and newlines after markup decode', () => {
+    expect(splitFreeTagBatch(' <b>one</b>, two\u200B;three\nfour')).toEqual(['one', 'two', 'three', 'four']);
+  });
+
+  it('returns a single tag when there are no separators', () => {
+    expect(splitFreeTagBatch('AT&amp;T')).toEqual(['AT&T']);
+  });
+
+  it('drops empty and whitespace-only fragments', () => {
+    expect(splitFreeTagBatch('a,  ,b')).toEqual(['a', 'b']);
+  });
+});
+
+describe('freeTagPlainLabel', () => {
+  it('prefers a string name', () => {
+    expect(freeTagPlainLabel('value', 'Name')).toBe('Name');
+  });
+
+  it('falls back to string values', () => {
+    expect(freeTagPlainLabel('alpha')).toBe('alpha');
+  });
+
+  it('stringifies numbers and booleans', () => {
+    expect(freeTagPlainLabel(42)).toBe('42');
+    expect(freeTagPlainLabel(true)).toBe('true');
+  });
+
+  it('does not stringify arbitrary objects', () => {
+    expect(freeTagPlainLabel({ foo: 1 })).toBe('');
+    expect(freeTagPlainLabel(null)).toBe('');
+    expect(freeTagPlainLabel(undefined)).toBe('');
+  });
+});

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.util.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.util.spec.ts
@@ -7,9 +7,8 @@ describe('normalizeFreeTagInput', () => {
 
   it('decodes common HTML entities in a single pass', () => {
     expect(normalizeFreeTagInput('AT&amp;T')).toBe('AT&T');
-    expect(normalizeFreeTagInput('&lt;div&gt;')).toBe('<div>');
-    expect(normalizeFreeTagInput('a &gt; b')).toBe('a > b');
-    expect(normalizeFreeTagInput('a &lt; b')).toBe('a < b');
+    expect(normalizeFreeTagInput('a &gt; b')).toBe('a  b');
+    expect(normalizeFreeTagInput('a &lt; b')).toBe('a  b');
     expect(normalizeFreeTagInput('&quot;quoted&quot;')).toBe('"quoted"');
     expect(normalizeFreeTagInput('&#39;x&#39;')).toBe("'x'");
   });
@@ -36,15 +35,20 @@ describe('normalizeFreeTagInput', () => {
     expect(normalizeFreeTagInput('café 🎉')).toBe('café 🎉');
   });
 
-  it('leaves incomplete tag-like text alone', () => {
-    expect(normalizeFreeTagInput('<script')).toBe('<script');
-    expect(normalizeFreeTagInput('<')).toBe('<');
-    expect(normalizeFreeTagInput('>')).toBe('>');
+  it('removes incomplete tag-like markup and leftover angle brackets', () => {
+    expect(normalizeFreeTagInput('<script')).toBe('script');
+    expect(normalizeFreeTagInput('<')).toBe('');
+    expect(normalizeFreeTagInput('>')).toBe('');
     expect(normalizeFreeTagInput('&')).toBe('&');
   });
 
-  it('strips a complete script element but does not claim XSS safety', () => {
+  it('strips a complete script element to its text content', () => {
     expect(normalizeFreeTagInput('<script>alert(1)</script>')).toBe('alert(1)');
+  });
+
+  it('strips entity-encoded tags after a single decode pass', () => {
+    expect(normalizeFreeTagInput('&lt;div&gt;')).toBe('');
+    expect(normalizeFreeTagInput('hello &lt;b&gt;world&lt;/b&gt;')).toBe('hello world');
   });
 });
 
@@ -53,8 +57,16 @@ describe('splitFreeTagBatch', () => {
     expect(splitFreeTagBatch('AT&amp;T, hello <b>world</b>')).toEqual(['AT&T', 'hello world']);
   });
 
-  it('splits on commas, semicolons, and newlines after markup decode', () => {
+  it('splits on commas, semicolons, tabs, and newlines after markup decode', () => {
     expect(splitFreeTagBatch(' <b>one</b>, two\u200B;three\nfour')).toEqual(['one', 'two', 'three', 'four']);
+    expect(splitFreeTagBatch('one\ttwo')).toEqual(['one', 'two']);
+    expect(splitFreeTagBatch('a;b\nc')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('splits on typed/pasted \\n \\t \\r escape sequences', () => {
+    expect(splitFreeTagBatch('a;b\\nc')).toEqual(['a', 'b', 'c']);
+    expect(splitFreeTagBatch('one\\ttwo')).toEqual(['one', 'two']);
+    expect(splitFreeTagBatch('x\\r\\ny')).toEqual(['x', 'y']);
   });
 
   it('returns a single tag when there are no separators', () => {
@@ -63,6 +75,10 @@ describe('splitFreeTagBatch', () => {
 
   it('drops empty and whitespace-only fragments', () => {
     expect(splitFreeTagBatch('a,  ,b')).toEqual(['a', 'b']);
+  });
+
+  it('normalizes malformed HTML-like fragments before split', () => {
+    expect(splitFreeTagBatch('<script,safe')).toEqual(['script', 'safe']);
   });
 });
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.util.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.util.ts
@@ -1,29 +1,74 @@
-/**
- * Decode common entities and strip complete HTML tags from free-tag text.
- * Does not remove control characters or trim — callers do that per fragment
- * after splitting so `\n` / `\t` remain available as separators.
- *
- * This is paste/cleanup normalization — not an HTML security boundary.
- * Safety for free tags comes from rendering them as text, not as HTML.
- *
- * Entity decoding is a single pass (e.g. `&amp;amp;` → `&amp;`).
- * Must run on the full batch *before* splitting on `;`, otherwise `&amp;T` breaks apart.
- */
-export function decodeFreeTagMarkup(value: string): string {
+const NAMED_ENTITIES: Readonly<Record<string, string>> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' '
+};
+
+const TAG_SEPARATOR_PATTERN = /[,;\n\r\t\v\f\u2028\u2029]+/;
+
+function expandWhitespaceEscapes(value: string): string {
   return value
-    .replace(/<[^>]*>/g, '')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/g, "'");
+    .replace(/\\r\\n/gi, '\n')
+    .replace(/\\n/gi, '\n')
+    .replace(/\\r/gi, '\n')
+    .replace(/\\t/gi, '\t');
 }
 
-/** Clean a single free-tag fragment (control chars, zero-width spaces, trim). */
+function prepareFreeTagBatch(raw: string): string {
+  return expandWhitespaceEscapes(decodeFreeTagMarkup(raw));
+}
+
+function decodeEntityReference(
+  match: string,
+  named: string | undefined,
+  dec: string | undefined,
+  hex: string | undefined
+): string {
+  if (named) {
+    const decoded = NAMED_ENTITIES[named.toLowerCase()];
+    return decoded !== undefined ? decoded : match;
+  }
+
+  const codePoint = hex ? parseInt(hex, 16) : parseInt(dec!, 10);
+  if (!Number.isFinite(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return match;
+  }
+
+  try {
+    return String.fromCodePoint(codePoint);
+  } catch {
+    return match;
+  }
+}
+
+function decodeEntitiesOnce(value: string): string {
+  return value.replace(/&(?:([a-z]+)|#(\d+)|#x([0-9a-f]+));/gi, decodeEntityReference);
+}
+
+function stripMarkup(value: string): string {
+  let previous = '';
+  let next = value;
+  while (next !== previous) {
+    previous = next;
+    next = next.replace(/<[^>]*>/g, '');
+  }
+  return next.replace(/[<>]/g, '');
+}
+
+export function decodeFreeTagMarkup(value: string): string {
+  return stripMarkup(decodeEntitiesOnce(value));
+}
+
+export function freeTagBatchHasSeparator(raw: string): boolean {
+  return TAG_SEPARATOR_PATTERN.test(prepareFreeTagBatch(raw));
+}
+
 export function normalizeFreeTagInput(value: string): string {
   return (
-    decodeFreeTagMarkup(value)
+    prepareFreeTagBatch(value)
       // eslint-disable-next-line no-control-regex -- strip control chars from pasted text
       .replace(/[\u0000-\u001f\u007f]/g, '')
       .replace(/[\u200b-\u200d\ufeff]/g, '')
@@ -32,13 +77,9 @@ export function normalizeFreeTagInput(value: string): string {
   );
 }
 
-/**
- * Split a typed/pasted free-tag batch into normalized plain tags.
- * Decodes markup on the whole payload before separator split so entity `;` is preserved.
- */
 export function splitFreeTagBatch(raw: string): string[] {
-  return decodeFreeTagMarkup(raw)
-    .split(/[,;\n\r\t]+/)
+  return prepareFreeTagBatch(raw)
+    .split(TAG_SEPARATOR_PATTERN)
     .map(part =>
       part
         // eslint-disable-next-line no-control-regex -- strip residual control chars per fragment
@@ -50,7 +91,6 @@ export function splitFreeTagBatch(raw: string): string[] {
     .filter(Boolean);
 }
 
-/** Plain display/edit label for a free-tag domain value. Avoids `[object Object]`. */
 export function freeTagPlainLabel(value: unknown, name?: unknown): string {
   if (typeof name === 'string') return name;
   if (typeof value === 'string') return value;

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.util.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select-tagging.util.ts
@@ -1,0 +1,59 @@
+/**
+ * Decode common entities and strip complete HTML tags from free-tag text.
+ * Does not remove control characters or trim — callers do that per fragment
+ * after splitting so `\n` / `\t` remain available as separators.
+ *
+ * This is paste/cleanup normalization — not an HTML security boundary.
+ * Safety for free tags comes from rendering them as text, not as HTML.
+ *
+ * Entity decoding is a single pass (e.g. `&amp;amp;` → `&amp;`).
+ * Must run on the full batch *before* splitting on `;`, otherwise `&amp;T` breaks apart.
+ */
+export function decodeFreeTagMarkup(value: string): string {
+  return value
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/** Clean a single free-tag fragment (control chars, zero-width spaces, trim). */
+export function normalizeFreeTagInput(value: string): string {
+  return (
+    decodeFreeTagMarkup(value)
+      // eslint-disable-next-line no-control-regex -- strip control chars from pasted text
+      .replace(/[\u0000-\u001f\u007f]/g, '')
+      .replace(/[\u200b-\u200d\ufeff]/g, '')
+      .replace(/\u00a0/g, ' ')
+      .trim()
+  );
+}
+
+/**
+ * Split a typed/pasted free-tag batch into normalized plain tags.
+ * Decodes markup on the whole payload before separator split so entity `;` is preserved.
+ */
+export function splitFreeTagBatch(raw: string): string[] {
+  return decodeFreeTagMarkup(raw)
+    .split(/[,;\n\r\t]+/)
+    .map(part =>
+      part
+        // eslint-disable-next-line no-control-regex -- strip residual control chars per fragment
+        .replace(/[\u0000-\u001f\u007f]/g, '')
+        .replace(/[\u200b-\u200d\ufeff]/g, '')
+        .replace(/\u00a0/g, ' ')
+        .trim()
+    )
+    .filter(Boolean);
+}
+
+/** Plain display/edit label for a free-tag domain value. Avoids `[object Object]`. */
+export function freeTagPlainLabel(value: unknown, name?: unknown): string {
+  if (typeof name === 'string') return name;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return '';
+}

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.html
@@ -14,9 +14,11 @@
         [identifier]="identifier"
         [tagging]="tagging"
         [allowAdditions]="allowAdditions"
+        [maxSelections]="maxSelections"
+        [taggingValidator]="taggingValidator"
         [selectCaret]="selectCaret"
         [selected]="value"
-        [hint]="hint"
+        [hint]="inputHint"
         [withHint]="withHint"
         [disableDropdown]="disableDropdown"
         [disabled]="disabled"
@@ -26,7 +28,8 @@
         (activate)="onFocus()"
         (activateLast)="onFocusLast()"
         (selection)="onInputSelection($event)"
-        >
+        (taggingError)="onTaggingError($event)"
+      >
       </ngx-select-input>
     </div>
   </div>
@@ -55,7 +58,7 @@
       (deselection)="onDropdownDeselection($event)"
       (keyboardSelection)="onDropdownSelection($event, false)"
       (keyboardDeselection)="onDropdownDeselection($event, false)"
-      >
+    >
     </ngx-select-dropdown>
   }
 </div>

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -280,6 +280,66 @@ $color-chip-text: #ffffff;
     }
   }
 
+  // Free / no-option tagging only — do not affect tagging-with-dropdown or multi-select.
+  &.free-tagging-selection {
+    .ngx-select-input {
+      .ngx-select-input-list.horizontal-list {
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        max-height: 12rem;
+        overflow-x: hidden;
+        overflow-y: auto;
+        width: 100%;
+      }
+
+      .ngx-select-input-option {
+        max-width: min(100%, 18rem);
+        overflow: hidden;
+        align-items: center;
+
+        .ngx-select-input-name {
+          flex: 1 1 auto;
+          min-width: 0;
+        }
+
+        &.ngx-select-input-option--invalid {
+          box-shadow: inset 0 0 0 1px var(--red-500);
+        }
+
+        &.ngx-select-input-option--active {
+          box-shadow: inset 0 0 0 2px var(--blue-400);
+          background: var(--grey-700);
+        }
+      }
+
+      .ngx-select-input-box-wrapper {
+        flex: 1 1 8rem;
+        min-width: 4rem;
+        max-width: 100%;
+        box-sizing: border-box;
+        padding: var(--spacing-4);
+
+        textarea.ngx-select-text-box {
+          display: block;
+          font-family: inherit;
+          margin: var(--spacing-0);
+          min-height: 1.4em;
+          min-width: 0;
+          width: 100%;
+          max-width: 100%;
+          resize: none;
+          overflow: hidden;
+          overflow-wrap: anywhere;
+          word-break: break-word;
+          white-space: pre-wrap;
+          box-sizing: border-box;
+          vertical-align: unset;
+        }
+      }
+    }
+  }
+
   // single-select
   &.single-selection {
     .ngx-select-input {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.scss
@@ -280,13 +280,18 @@ $color-chip-text: #ffffff;
     }
   }
 
-  // Free / no-option tagging only — do not affect tagging-with-dropdown or multi-select.
   &.free-tagging-selection {
+    &.tagging-selection .ngx-select-input-option {
+      align-items: center;
+      margin: 0;
+    }
+
     .ngx-select-input {
       .ngx-select-input-list.horizontal-list {
         align-items: center;
         display: flex;
         flex-wrap: wrap;
+        gap: var(--spacing-4);
         max-height: 12rem;
         overflow-x: hidden;
         overflow-y: auto;
@@ -318,12 +323,17 @@ $color-chip-text: #ffffff;
         min-width: 4rem;
         max-width: 100%;
         box-sizing: border-box;
-        padding: var(--spacing-4);
+        padding: var(--spacing-0);
+        margin: var(--spacing-0);
+        align-self: center;
 
         textarea.ngx-select-text-box {
           display: block;
           font-family: inherit;
+          font-size: var(--font-size-m);
           margin: var(--spacing-0);
+          padding: var(--spacing-0);
+          line-height: 1.4em;
           min-height: 1.4em;
           min-width: 0;
           width: 100%;
@@ -334,7 +344,20 @@ $color-chip-text: #ffffff;
           word-break: break-word;
           white-space: pre-wrap;
           box-sizing: border-box;
-          vertical-align: unset;
+          vertical-align: middle;
+        }
+      }
+    }
+
+    &.fill {
+      .ngx-select-input {
+        .ngx-select-input-list.horizontal-list {
+          padding-left: var(--spacing-10);
+          padding-right: var(--spacing-4);
+        }
+
+        .ngx-select-input-box {
+          min-height: var(--input-height);
         }
       }
     }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
@@ -327,6 +327,28 @@ describe('SelectComponent', () => {
       component.select.value = ['test', 'test1'];
       expect(component.select.invalid).toBeTruthy();
     });
+
+    it('should be true when a tagging entry was rejected', () => {
+      component.select.onTaggingError('Invalid tag');
+      expect(component.select.invalid).toBeTruthy();
+      expect(component.select.inputHint).toBe('Invalid tag');
+    });
+
+    it('should validate existing tagging values', () => {
+      component.select.tagging = true;
+      component.select.disableDropdown = true;
+      component.select.taggingValidator = value => (value === 'invalid' ? 'Invalid tag' : null);
+      component.select.value = ['invalid'];
+      expect(component.select.invalid).toBeTruthy();
+    });
+
+    it('should clear taggingError after dropdown selection path', () => {
+      component.select.onTaggingError('Invalid tag');
+      expect(component.select.invalid).toBeTruthy();
+      component.select.onClear();
+      expect(component.select.taggingError).toBe('');
+      expect(component.select.invalid).toBeFalsy();
+    });
   });
 
   describe('requiredIndicatorView', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
@@ -352,6 +352,25 @@ describe('SelectComponent', () => {
       expect(component.select.invalid).toBeFalsy();
     });
 
+    it('should stay valid for uniqueness validators that check selected peers', () => {
+      component.select.tagging = true;
+      component.select.disableDropdown = true;
+      component.select.taggingValidator = (value, selected) =>
+        selected.includes(value) ? 'Already selected' : null;
+      component.select.value = ['one', 'two'];
+      expect(component.select.invalid).toBeFalsy();
+    });
+
+    it('should not apply taggingValidator when tagging has options (not inline)', () => {
+      component.select.tagging = true;
+      component.select.disableDropdown = false;
+      component.select.options = [{ name: 'DDOS', value: 'ddos' }];
+      component.select.taggingValidator = () => 'always invalid';
+      component.select.value = ['ddos'];
+      expect(component.select.isFreeTagging).toBeFalsy();
+      expect(component.select.invalid).toBeFalsy();
+    });
+
     it('should clear taggingError after dropdown selection path', () => {
       component.select.onTaggingError('Invalid tag');
       expect(component.select.invalid).toBeTruthy();

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
@@ -337,9 +337,19 @@ describe('SelectComponent', () => {
     it('should validate existing tagging values', () => {
       component.select.tagging = true;
       component.select.disableDropdown = true;
-      component.select.taggingValidator = value => (value === 'invalid' ? 'Invalid tag' : null);
+      component.select.taggingValidator = (value: unknown) => (value === 'invalid' ? 'Invalid tag' : null);
       component.select.value = ['invalid'];
       expect(component.select.invalid).toBeTruthy();
+    });
+
+    it('should clear free-tag invalid state after removing bad values', () => {
+      component.select.tagging = true;
+      component.select.disableDropdown = true;
+      component.select.taggingValidator = (value: unknown) => (value === 'invalid' ? 'Invalid tag' : null);
+      component.select.value = ['invalid'];
+      expect(component.select.invalid).toBeTruthy();
+      component.select.value = ['ok'];
+      expect(component.select.invalid).toBeFalsy();
     });
 
     it('should clear taggingError after dropdown selection path', () => {

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.spec.ts
@@ -355,8 +355,7 @@ describe('SelectComponent', () => {
     it('should stay valid for uniqueness validators that check selected peers', () => {
       component.select.tagging = true;
       component.select.disableDropdown = true;
-      component.select.taggingValidator = (value, selected) =>
-        selected.includes(value) ? 'Already selected' : null;
+      component.select.taggingValidator = (value, selected) => (selected.includes(value) ? 'Already selected' : null);
       component.select.value = ['one', 'two'];
       expect(component.select.invalid).toBeFalsy();
     });

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -30,6 +30,7 @@ import { SelectInputComponent } from './select-input.component';
 import { SelectOptionDirective } from './select-option.directive';
 import { CoerceBooleanProperty } from '../../utils/coerce/coerce-boolean';
 import { CoerceNumberProperty } from '../../utils/coerce/coerce-number';
+import { SelectTaggingValidator } from './select-tagging.interface';
 
 let nextId = 0;
 
@@ -63,6 +64,7 @@ function arrayEquals(a, b) {
     '[class.lg]': 'size === "lg"',
     '[class.invalid]': 'invalid && touched',
     '[class.tagging-selection]': 'tagging',
+    '[class.free-tagging-selection]': 'isFreeTagging',
     '[class.multi-selection]': 'multiple',
     '[class.single-selection]': 'isSingleSelect',
     '[class.disabled]': 'disabled',
@@ -171,6 +173,8 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   @CoerceBooleanProperty()
   tagging = false;
 
+  @Input() taggingValidator?: SelectTaggingValidator;
+
   @Input()
   @CoerceBooleanProperty()
   multiple = false;
@@ -228,11 +232,27 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     this._cdr.markForCheck();
   }
 
+  get isFreeTagging(): boolean {
+    return this.tagging && (this.disableDropdown || !this.options?.length);
+  }
+
   get invalid() {
+    if (this.taggingError) return true;
     if (this.required && this.checkInvalidValue(this.value)) return true;
     if (this.maxSelections !== undefined && this.value && this.value.length > this.maxSelections) return true;
     if (this.minSelections !== undefined && (!this.value || this.value.length < this.minSelections)) return true;
+    if (
+      this.isFreeTagging &&
+      this.taggingValidator &&
+      this.value?.some(value => !!this.taggingValidator(value, this.value))
+    ) {
+      return true;
+    }
     return false;
+  }
+
+  get inputHint(): string {
+    return this.taggingError || this.hint;
   }
 
   get requiredIndicatorView() {
@@ -280,6 +300,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   focusIndex = -1;
   dropdownActive = false;
   touched = false;
+  taggingError = '';
 
   private _optionTemplates: QueryList<SelectOptionDirective>;
   private _value: any[] = [];
@@ -328,12 +349,24 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     if (this.tagging) {
       this.inputComponent.clearInput();
     }
+    this.clearTaggingError();
 
     if (shouldClose) this.onClose(true);
   }
 
   onInputSelection(selections: any[]): void {
     this.value = selections;
+  }
+
+  onTaggingError(error: string): void {
+    this.taggingError = error;
+    this._cdr.markForCheck();
+  }
+
+  private clearTaggingError(): void {
+    if (!this.taggingError) return;
+    this.taggingError = '';
+    this._cdr.markForCheck();
   }
 
   onFocus(): void {
@@ -359,6 +392,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
 
   onClear(): void {
     this.value = [];
+    this.clearTaggingError();
   }
 
   onBodyClick(event: Event): void {
@@ -418,7 +452,8 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   onKeyUp({ event, value }: { event: KeyboardEvent; value?: string }): void {
     if (event && event.key === (KeyboardKeys.ARROW_DOWN as any) && this.focusIndex < this.options.length) {
       ++this.focusIndex;
-    } else {
+    } else if (this.filterQuery !== value) {
+      // Skip no-op writes so typing the same filtered value does not dirty CD.
       this.filterQuery = value;
     }
 
@@ -429,6 +464,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     /* istanbul ignore else */
     if (val !== this._value) {
       this._value = val;
+      this.clearTaggingError();
       this._cdr.markForCheck();
     }
   }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -338,7 +338,13 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     this._hasInvalidFreeTags = !!(
       this.isFreeTagging &&
       this.taggingValidator &&
-      values?.some((value, index) => !!this.taggingValidator!(value, values.filter((_, i) => i !== index)))
+      values?.some(
+        (value, index) =>
+          !!this.taggingValidator!(
+            value,
+            values.filter((_, i) => i !== index)
+          )
+      )
     );
   }
 

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -7,9 +7,11 @@ import {
   EventEmitter,
   forwardRef,
   Input,
+  OnChanges,
   OnDestroy,
   Output,
   Renderer2,
+  SimpleChanges,
   TemplateRef,
   ViewChild,
   ViewEncapsulation
@@ -82,7 +84,7 @@ function arrayEquals(a, b) {
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false
 })
-export class SelectComponent extends _InputMixinBase implements ControlValueAccessor, OnDestroy {
+export class SelectComponent extends _InputMixinBase implements ControlValueAccessor, OnChanges, OnDestroy {
   @Input() id = `select-${++nextId}`;
   @Input() name: string;
   @Input() label: string;
@@ -173,7 +175,14 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   @CoerceBooleanProperty()
   tagging = false;
 
-  @Input() taggingValidator?: SelectTaggingValidator;
+  @Input()
+  get taggingValidator(): SelectTaggingValidator | undefined {
+    return this._taggingValidator;
+  }
+  set taggingValidator(value: SelectTaggingValidator | undefined) {
+    this._taggingValidator = value;
+    this.refreshInvalidFreeTags();
+  }
 
   @Input()
   @CoerceBooleanProperty()
@@ -229,6 +238,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
       }
     }
 
+    this.refreshInvalidFreeTags();
     this._cdr.markForCheck();
   }
 
@@ -241,13 +251,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     if (this.required && this.checkInvalidValue(this.value)) return true;
     if (this.maxSelections !== undefined && this.value && this.value.length > this.maxSelections) return true;
     if (this.minSelections !== undefined && (!this.value || this.value.length < this.minSelections)) return true;
-    if (
-      this.isFreeTagging &&
-      this.taggingValidator &&
-      this.value?.some(value => !!this.taggingValidator(value, this.value))
-    ) {
-      return true;
-    }
+    if (this._hasInvalidFreeTags) return true;
     return false;
   }
 
@@ -283,6 +287,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   set value(val: any[]) {
     if (val !== this._value) {
       this._value = val;
+      this.refreshInvalidFreeTags();
       this.onChangeCallback(this._value);
       this.change.emit(this._value);
       this._cdr.markForCheck();
@@ -307,6 +312,9 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   private _autosizeMinWidth = '60px';
   private _options: SelectDropdownOption[] = [];
   private _boundByOptionsInput = false;
+  /** Cached free-tag validator result; refreshed when value/options/validator change. */
+  private _hasInvalidFreeTags = false;
+  private _taggingValidator?: SelectTaggingValidator;
 
   constructor(
     private readonly _element: ElementRef,
@@ -316,8 +324,22 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     super();
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('taggingValidator' in changes || 'tagging' in changes || 'disableDropdown' in changes || 'options' in changes) {
+      this.refreshInvalidFreeTags();
+    }
+  }
+
   ngOnDestroy(): void {
     this.toggleDropdown(false);
+  }
+
+  private refreshInvalidFreeTags(): void {
+    this._hasInvalidFreeTags = !!(
+      this.isFreeTagging &&
+      this.taggingValidator &&
+      this.value?.some(value => !!this.taggingValidator!(value, this.value))
+    );
   }
 
   onDropdownSelection(selection: SelectDropdownOption, shouldClose = this.closeOnSelect || !this.multiple): void {
@@ -464,6 +486,7 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
     /* istanbul ignore else */
     if (val !== this._value) {
       this._value = val;
+      this.refreshInvalidFreeTags();
       this.clearTaggingError();
       this._cdr.markForCheck();
     }

--- a/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
+++ b/projects/swimlane/ngx-ui/src/lib/components/select/select.component.ts
@@ -312,7 +312,6 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   private _autosizeMinWidth = '60px';
   private _options: SelectDropdownOption[] = [];
   private _boundByOptionsInput = false;
-  /** Cached free-tag validator result; refreshed when value/options/validator change. */
   private _hasInvalidFreeTags = false;
   private _taggingValidator?: SelectTaggingValidator;
 
@@ -335,10 +334,11 @@ export class SelectComponent extends _InputMixinBase implements ControlValueAcce
   }
 
   private refreshInvalidFreeTags(): void {
+    const values = this.value;
     this._hasInvalidFreeTags = !!(
       this.isFreeTagging &&
       this.taggingValidator &&
-      this.value?.some(value => !!this.taggingValidator!(value, this.value))
+      values?.some((value, index) => !!this.taggingValidator!(value, values.filter((_, i) => i !== index)))
     );
   }
 

--- a/projects/swimlane/ngx-ui/src/public_api.ts
+++ b/projects/swimlane/ngx-ui/src/public_api.ts
@@ -248,6 +248,7 @@ export * from './lib/components/select/select-option-input-template.directive';
 export * from './lib/components/select/select-input.component';
 export * from './lib/components/select/select-dropdown.component';
 export * from './lib/components/select/select-dropdown-option.interface';
+export * from './lib/components/select/select-tagging.interface';
 
 export * from './lib/components/slider/slider.module';
 export * from './lib/components/slider/slider.component';

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -702,13 +702,23 @@
 <br />
 
 <h4>No Options</h4>
-<ngx-select [filterable]="false" [tagging]="true">
+<p>Free tagging with no dropdown. Paste comma/semicolon values. Double-click a chip to edit. Hover a long chip for a tooltip.</p>
+<ngx-select
+  label="Free Tagging"
+  [tagging]="true"
+  [filterable]="false"
+  [disableDropdown]="true"
+  [(ngModel)]="taggingDemoValues">
+  @for (tag of taggingDemoValues; track tag) {
+    <ngx-select-option [name]="tag" [value]="tag"></ngx-select-option>
+  }
 </ngx-select>
 
 <app-prism>
   <![CDATA[<ngx-select
   [filterable]="false"
-  [tagging]="true">
+  [tagging]="true"
+  [disableDropdown]="true">
 </ngx-select>
 ]]>
 </app-prism>

--- a/src/app/forms/selects-page/selects-page.component.html
+++ b/src/app/forms/selects-page/selects-page.component.html
@@ -701,10 +701,12 @@
 <br />
 <br />
 
-<h4>No Options</h4>
-<p>Free tagging with no dropdown. Paste comma/semicolon values. Double-click a chip to edit. Hover a long chip for a tooltip.</p>
+<h4>Inline Tagging</h4>
+<p>Inline tagging with no dropdown. Paste comma/semicolon values. Double-click a chip to edit. Hover a long chip for a tooltip.</p>
 <ngx-select
-  label="Free Tagging"
+  data-cy="inline-tagging"
+  appearance="fill"
+  label="Inline Tagging"
   [tagging]="true"
   [filterable]="false"
   [disableDropdown]="true"
@@ -716,6 +718,7 @@
 
 <app-prism>
   <![CDATA[<ngx-select
+  appearance="fill"
   [filterable]="false"
   [tagging]="true"
   [disableDropdown]="true">
@@ -824,8 +827,8 @@
 
   <br />
 
-  <ngx-select [filterable]="false" [tagging]="true" appearance="fill" label="Fill Tagging With No Options"
-    autosize="true">
+  <ngx-select data-cy="inline-tagging-fill-autosize" [filterable]="false" [tagging]="true" appearance="fill"
+    label="Inline Tagging" autosize="true">
   </ngx-select>
 
   <br />
@@ -1249,7 +1252,8 @@
             <code class="component-type">&#64;Input()</code>
             <code>maxSelections: number</code>
           </th>
-          <td class="component-description">The maximum number of selections to display.</td>
+          <td class="component-description">Maximum selections (multi-select and tagging). For inline tagging,
+            enforced when committing a new tag.</td>
         </tr>
         <tr>
           <th>
@@ -1307,6 +1311,15 @@
             <code>tagging: boolean</code>
           </th>
           <td class="component-description">Whether selected options are displayed as tags.</td>
+        </tr>
+        <tr>
+          <th>
+            <code class="component-type">&#64;Input()</code>
+            <code>taggingValidator: SelectTaggingValidator</code>
+          </th>
+          <td class="component-description">Per-tag validator for inline tagging only
+            (<code>tagging &amp;&amp; (disableDropdown || !options?.length)</code>).
+            Return an error message to reject, or null to accept.</td>
         </tr>
         <tr>
           <th>

--- a/src/app/forms/selects-page/selects-page.component.ts
+++ b/src/app/forms/selects-page/selects-page.component.ts
@@ -23,6 +23,7 @@ export class SelectsPageComponent implements OnInit {
   selects = this._results;
   selectsModel = [this.selects[0]];
   singleSelectModel = this.selects[0];
+  taggingDemoValues = ['alpha', 'a long tag that truncates — hover to see the full value in a tooltip'];
   asyncOptions$: Observable<any>;
   form = new UntypedFormGroup({
     formCtrl1: new UntypedFormControl([]),


### PR DESCRIPTION
https://github.com/user-attachments/assets/d225eeb1-c27a-4b4b-a556-2c027944389f
## Summary

Adds **inline tagging** for `ngx-select` when there is no dropdown of options (`tagging && (disableDropdown || !options?.length)`).

Tagging-with-options, multi-select, and single-select behave as before.

### Behavior

- Commit tags with **Enter**, **Tab**, or **comma**
- Paste splits on comma / semicolon / tab / newline (also `\n` / `\t` escape text)
- Strips accidental HTML/entities from paste
- Commits unfinished text on blur or chip click
- Arrow keys select chips; Backspace/Delete remove (first Backspace highlights)
- Double-click a chip to edit it
- Long labels show a tooltip; optional `[taggingValidator]` for reject + invalid chip styling
- Fill appearance is the primary demo (`appearance="fill"`)

### API

- `taggingValidator?: SelectTaggingValidator` — **inline tagging only**
- `maxSelections` — unchanged shared input; also enforced on inline commit

## Checklist

- [x] Added unit tests
- [x] Added a code reviewer
- [x] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

## Test plan

- [ ] Demo → Tagging → **Basic**: still `<input>`, Enter adds tags, dropdown works
- [ ] Demo → Tagging → **Inline Tagging** (fill): Enter/Tab/comma, multi-value paste, blur commit, chip nav/edit, tooltip
- [ ] Demo → Autosize → **Inline Tagging** fill: textarea + chips align
- [ ] `[taggingValidator]` rejects bad tags (hint + no chip); existing bad values show invalid styling
- [ ] `yarn test:unit`
- [ ] `yarn test:prettier && yarn test:lint`